### PR TITLE
Implement per-source centroids

### DIFF
--- a/backend/scoring-engine/scoring_engine/centroid_job.py
+++ b/backend/scoring-engine/scoring_engine/centroid_job.py
@@ -6,6 +6,7 @@ import logging
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from sqlalchemy import select
+import numpy as np
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding, Weights
@@ -25,10 +26,8 @@ def compute_and_store_centroids() -> None:
             ).all()
             if not vectors:
                 continue
-            dim = len(vectors[0])
-            centroid = [
-                float(sum(vec[i] for vec in vectors) / len(vectors)) for i in range(dim)
-            ]
+            arr = np.array(vectors, dtype=float)
+            centroid = arr.mean(axis=0).tolist()
             weights = session.scalar(select(Weights).where(Weights.source == src))
             if weights is None:
                 weights = Weights(source=src)

--- a/backend/scoring-engine/tests/__init__.py
+++ b/backend/scoring-engine/tests/__init__.py
@@ -2,30 +2,51 @@
 
 import os
 import sys
+import warnings
 
 os.environ["OTEL_SDK_DISABLED"] = "true"
 os.environ["SENTRY_DSN"] = ""
-import backend.shared.errors as errors
+warnings.filterwarnings(
+    "ignore",
+    message='directory "/run/secrets" does not exist',
+)
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")),
+)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-errors.sentry_sdk = None
+try:  # pragma: no cover - optional dependency
+    import backend.shared.errors as errors  # noqa: E402
+
+    errors.sentry_sdk = None
+except Exception:  # pragma: no cover - ignore if import fails
+    pass
 
 
 class DummyRedis:
+    """Simple asynchronous wrapper around :class:`fakeredis.FakeRedis`."""
+
     def __init__(self) -> None:
+        """Initialize fake Redis client."""
         import fakeredis
 
         self._client = fakeredis.FakeRedis()
 
     async def get(self, key: str) -> bytes | None:
+        """Return value for ``key`` if present."""
         return self._client.get(key)
 
     async def setex(self, key: str, ttl: int, value: float) -> None:
+        """Set ``key`` with ``ttl`` and ``value``."""
         self._client.setex(key, ttl, value)
 
     async def incr(self, key: str) -> None:
+        """Increment ``key`` counter."""
         self._client.incr(key)
+
 
 sys.path.insert(
     0,
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")),
 )

--- a/backend/scoring-engine/tests/test_cache.py
+++ b/backend/scoring-engine/tests/test_cache.py
@@ -34,7 +34,7 @@ def test_score_endpoint_caches() -> None:
         "engagement_rate": 1.0,
         "embedding": [1.0, 0.0],
         "metadata": {"a": 1.0},
-        "centroid": [0.0, 1.0],
+        "source": "global",
         "median_engagement": 1.0,
         "topics": ["t"],
     }

--- a/backend/scoring-engine/tests/test_scoring.py
+++ b/backend/scoring-engine/tests/test_scoring.py
@@ -6,8 +6,11 @@ from datetime import datetime, timezone
 
 import numpy as np
 
-from scoring_engine.scoring import Signal, calculate_score
+from scoring_engine.scoring import Signal, calculate_score, compute_novelty
 from scoring_engine.weight_repository import update_weights
+from scoring_engine.centroid_job import compute_and_store_centroids
+from backend.shared.db import session_scope
+from backend.shared.db.models import Embedding
 
 
 def test_calculate_score_simple(tmp_path, monkeypatch):
@@ -20,16 +23,49 @@ def test_calculate_score_simple(tmp_path, monkeypatch):
         seasonality=1.0,
     )
     signal = Signal(
+        source="src",
         timestamp=datetime.now(timezone.utc),
         engagement_rate=1.0,
         embedding=[1.0, 0.0],
         metadata={"a": 1.0, "b": 0.0},
     )
-    centroid = np.array([0.0, 1.0])
     score = calculate_score(
         signal,
-        centroid,
         median_engagement=1.0,
         topics=["t"],
     )
     assert isinstance(score, float)
+
+
+def test_scoring_uses_db_centroid(tmp_path) -> None:
+    """Novelty uses centroid stored in the database."""
+    update_weights(
+        freshness=0.0,
+        engagement=0.0,
+        novelty=1.0,
+        community_fit=0.0,
+        seasonality=0.0,
+    )
+    with session_scope() as session:
+        dim_vec1 = [1.0] + [0.0] * 767
+        dim_vec2 = [0.0] * 767 + [1.0]
+        session.add_all(
+            [
+                Embedding(source="src", embedding=dim_vec1),
+                Embedding(source="src", embedding=dim_vec2),
+            ]
+        )
+        session.flush()
+    compute_and_store_centroids()
+    signal = Signal(
+        source="src",
+        timestamp=datetime.now(timezone.utc),
+        engagement_rate=0.0,
+        embedding=dim_vec1,
+        metadata={},
+    )
+    score = calculate_score(signal, median_engagement=0.0, topics=[])
+    expected = compute_novelty(
+        np.array(dim_vec1), np.array([0.5] + [0.0] * 766 + [0.5])
+    )
+    assert score == expected

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -7,8 +7,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
-
-import numpy as np
 import pytest
 import vcr
 from PIL import Image
@@ -89,12 +87,13 @@ async def test_end_to_end(monkeypatch, tmp_path) -> None:
         seasonality=1.0,
     )
     sig = scoring.Signal(
+        source="global",
         timestamp=datetime.now(timezone.utc),
         engagement_rate=1.0,
         embedding=[0.1, 0.2],
         metadata={},
     )
-    score = scoring.calculate_score(sig, np.array([0.0, 0.0]), 0.5, [])
+    score = scoring.calculate_score(sig, 0.5, [])
     assert isinstance(score, float)
 
     gen = MockupGenerator()


### PR DESCRIPTION
## Summary
- aggregate embeddings by source in the centroid job
- launch centroid update scheduler on app startup
- look up centroids automatically when scoring
- wire through source value in the API request
- update tests for new centroid behaviour

## Testing
- `flake8 backend/scoring-engine/scoring_engine backend/scoring-engine/tests tests/integration/test_workflow.py`
- `pydocstyle backend/scoring-engine/scoring_engine backend/scoring-engine/tests`
- `black backend/scoring-engine/scoring_engine backend/scoring-engine/tests tests/integration/test_workflow.py --check`
- `mypy backend/scoring-engine/scoring_engine backend/scoring-engine/tests/test_scoring.py tests/integration/test_workflow.py` *(failed: Module "backend.shared.errors" does not explicitly export attribute)*
- `pytest backend/scoring-engine/tests/test_centroid.py backend/scoring-engine/tests/test_cache.py backend/scoring-engine/tests/test_scoring.py -q` *(failed: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_b_6879cece10d4833198c720371cbf3eec