### PR TITLE
Implement GPU locking with per-queue workers

### DIFF
--- a/backend/mockup-generation/Dockerfile
+++ b/backend/mockup-generation/Dockerfile
@@ -9,4 +9,8 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["celery", "-A", "mockup_generation.celery_app", "worker", "--loglevel=info"]
+ARG GPU_INDEX=0
+ENV GPU_WORKER_INDEX=${GPU_INDEX}
+ENV CUDA_VISIBLE_DEVICES=${GPU_INDEX}
+
+CMD ["celery", "-A", "mockup_generation.celery_app", "worker", "--loglevel=info", "-Q", "gpu-${GPU_WORKER_INDEX}", "--concurrency=1"]

--- a/backend/mockup-generation/tests/test_gpu_lock.py
+++ b/backend/mockup-generation/tests/test_gpu_lock.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+import contextlib
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
@@ -12,8 +13,112 @@ import types  # noqa: E402
 diffusers_mod = types.ModuleType("diffusers")
 diffusers_mod.StableDiffusionXLPipeline = object  # type: ignore[attr-defined]
 sys.modules.setdefault("diffusers", diffusers_mod)
-sys.modules.setdefault("torch", types.ModuleType("torch"))
+torch_mod = types.ModuleType("torch")
+torch_mod.nn = types.ModuleType("nn")
+torch_mod.nn.Module = object
+torch_mod.cuda = types.ModuleType("cuda")
+torch_mod.cuda.is_available = lambda: False
+sys.modules.setdefault("torch", torch_mod)
+sys.modules.setdefault("torch.nn", torch_mod.nn)
+fastapi_mod = types.ModuleType("fastapi")
+fastapi_mod.FastAPI = object
+fastapi_mod.Request = object
+fastapi_mod.Response = object
+fastapi_mod.HTTPException = Exception
+responses_mod = types.ModuleType("fastapi.responses")
+responses_mod.JSONResponse = object
+sys.modules.setdefault("fastapi.responses", responses_mod)
+fastapi_mod.responses = responses_mod
+sys.modules.setdefault("fastapi", fastapi_mod)
+model_repo_mod = types.ModuleType("mockup_generation.model_repository")
+model_repo_mod.get_default_model_id = lambda: "model"
+sys.modules.setdefault("mockup_generation.model_repository", model_repo_mod)
+for name in [
+    "opentelemetry",
+    "opentelemetry.instrumentation.fastapi",
+    "opentelemetry.instrumentation.flask",
+    "opentelemetry.sdk.resources",
+    "opentelemetry.sdk.trace",
+    "opentelemetry.sdk.trace.export",
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    "sentry_sdk",
+    "sentry_sdk.integrations.asgi",
+    "backend.shared.db",
+    "backend.shared.tracing",
+    "backend.shared.logging",
+    "backend.shared.sentry",
+    "backend.shared.feature_flags",
+    "backend.shared.errors",
+]:
+    sys.modules.setdefault(name, types.ModuleType(name))
+db_mod = sys.modules.setdefault(
+    "backend.shared.db", types.ModuleType("backend.shared.db")
+)
+db_mod.engine = object()
 
+
+class _DummySession:
+    def scalar(self, *args, **kwargs):
+        return None
+
+
+@contextlib.contextmanager
+def _scope():
+    yield _DummySession()
+
+
+db_mod.session_scope = _scope
+sys.modules.setdefault(
+    "backend.shared.db.base", types.ModuleType("backend.shared.db.base")
+)
+sys.modules.setdefault(
+    "backend.shared.db.models", types.ModuleType("backend.shared.db.models")
+)
+base_mod = sys.modules.setdefault(
+    "backend.shared.db.base", types.ModuleType("backend.shared.db.base")
+)
+
+
+class _Base:
+    metadata = type("metadata", (), {"create_all": lambda *args, **kwargs: None})
+
+
+base_mod.Base = _Base
+models_mod = sys.modules["backend.shared.db.models"]
+
+
+class _AIModel:
+    model_id = "id"
+    is_default = True
+
+
+class _GeneratedMockup:
+    id = 1
+    prompt = ""
+    num_inference_steps = 1
+    seed = 0
+
+
+models_mod.AIModel = _AIModel
+models_mod.GeneratedMockup = _GeneratedMockup
+open_clip_mod = types.ModuleType("open_clip")
+open_clip_mod.tokenize = lambda *args, **kwargs: type(
+    "T", (), {"to": lambda self, *a, **k: self}
+)()
+sys.modules.setdefault("open_clip", open_clip_mod)
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+flask_mod = types.ModuleType("flask")
+flask_mod.Flask = object
+flask_mod.request = object()
+flask_mod.jsonify = lambda *args, **kwargs: ""
+sys.modules.setdefault("flask", flask_mod)
+sys.modules.setdefault("fastapi", types.ModuleType("fastapi"))
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    types.ModuleType("opentelemetry.exporter.otlp.proto.http.trace_exporter"),
+)
+
+import threading  # noqa: E402
 import fakeredis  # noqa: E402
 import pytest  # noqa: E402
 
@@ -29,3 +134,25 @@ def test_gpu_slot(monkeypatch: pytest.MonkeyPatch) -> None:
     with tasks.gpu_slot():
         assert fake.lock("gpu_slot:0").locked()
     assert not fake.lock("gpu_slot:0").locked()
+
+
+def test_gpu_slot_contention(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Multiple workers should acquire the lock sequentially."""
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(tasks, "redis_client", fake)
+    monkeypatch.setattr(tasks, "GPU_SLOTS", 1)
+
+    order: list[str] = []
+
+    def worker(label: str) -> None:
+        with tasks.gpu_slot():
+            order.append(label)
+
+    t1 = threading.Thread(target=worker, args=("a",))
+    t2 = threading.Thread(target=worker, args=("b",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert order == ["a", "b"] or order == ["b", "a"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,13 +7,14 @@ The `blueprints` folder contains the full system blueprint.
 - [Configuration](configuration.md)
 - [Metrics Storage](metrics_storage.md)
 - [Log Aggregation](logs_with_loki.md)
+- [GPU Mockup Generation](mockup_generation.md)
 - Kafka schemas under `schemas/` are loaded into the registry configured by `SCHEMA_REGISTRY_URL`.
 
 The `scripts` directory provides helper scripts for setting up storage and CDN resources:
 
-- `setup_storage.sh` – create the S3/MinIO bucket structure
-- `configure_cdn.sh` – create a CloudFront distribution
-- `invalidate_cache.sh` – invalidate CDN caches when mockups change
+- `setup_storage.sh` - create the S3/MinIO bucket structure
+- `configure_cdn.sh` - create a CloudFront distribution
+- `invalidate_cache.sh` - invalidate CDN caches when mockups change
 - Base Kubernetes manifests can be found in `infrastructure/k8s` with instructions for
   customizing them for local Minikube testing.
   This document merges the original project summary, system architecture, deployment guide, implementation plan and all earlier blueprint versions into one reference.

--- a/docs/mockup_generation.md
+++ b/docs/mockup_generation.md
@@ -1,0 +1,15 @@
+# GPU Mockup Generation
+
+The mockup generation service runs inside CUDA-enabled containers. Each
+Celery worker is pinned to a specific GPU using the `GPU_WORKER_INDEX`
+environment variable. Workers listen on dedicated queues
+`gpu-<index>` so Kubernetes can scale them independently.
+
+```bash
+# build image and target the first GPU
+docker build -f backend/mockup-generation/Dockerfile \
+  --build-arg GPU_INDEX=0 -t mockupgen:latest .
+```
+
+The provided HorizontalPodAutoscaler manifests scale the deployment
+based on CPU, memory and the `celery_queue_length` metric.

--- a/infrastructure/k8s/overlays/production/hpa.yaml
+++ b/infrastructure/k8s/overlays/production/hpa.yaml
@@ -22,6 +22,39 @@ spec:
         target:
           type: Utilization
           averageUtilization: 70
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ai-mockup-generation
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ai-mockup-generation
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: External
+      external:
+        metric:
+          name: celery_queue_length
+        target:
+          type: AverageValue
+          averageValue: "30"
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
## Summary
- add GPU queue locking in mockup_generation tasks
- document CUDA workers and update README
- support autoscaling with new HPA manifest
- update Dockerfile for GPU worker index
- add fakeredis contention test

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_gpu_lock.py`
- `mypy backend/mockup-generation/mockup_generation/tasks.py --ignore-missing-imports --follow-imports=skip`
- `python -m pytest backend/mockup-generation/tests/test_gpu_lock.py -W error` *(fails: ModuleNotFoundError: open_clip)*

------
https://chatgpt.com/codex/tasks/task_b_6879d39355888331866a5af15dc87bc4