### PR TITLE
Add custom diffusion model support

### DIFF
--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -1,0 +1,119 @@
+"""FastAPI routes for managing diffusion models."""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Callable, Coroutine
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from pydantic import BaseModel
+
+from backend.shared.logging import configure_logging
+from backend.shared.tracing import configure_tracing
+from backend.shared.profiling import add_profiling
+from backend.shared import add_error_handlers, configure_sentry
+
+from .model_repository import list_models, register_model, set_default
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "mockup-generation")
+app = FastAPI(title="Mockup Generation Service")
+configure_tracing(app, SERVICE_NAME)
+configure_sentry(app, SERVICE_NAME)
+add_profiling(app)
+add_error_handlers(app)
+
+
+class ModelCreate(BaseModel):  # type: ignore[misc]
+    """Schema for registering a new model."""
+
+    name: str
+    version: str
+    model_id: str
+    details: dict[str, object] | None = None
+    is_default: bool = False
+
+
+def _identify_user(request: Request) -> str:
+    """Return identifier for logging, header ``X-User`` or client IP."""
+
+    return str(request.headers.get("X-User", request.client.host))
+
+
+@app.middleware("http")
+async def add_correlation_id(
+    request: Request,
+    call_next: Callable[[Request], Coroutine[None, None, Response]],
+) -> Response:
+    """Ensure each request includes a correlation ID."""
+
+    correlation_id = request.headers.get("X-Correlation-ID", str(uuid.uuid4()))
+    request.state.correlation_id = correlation_id
+    try:
+        import sentry_sdk
+
+        sentry_sdk.set_tag("correlation_id", correlation_id)
+    except Exception:  # pragma: no cover - sentry optional
+        pass
+    logger.info(
+        "request received",
+        extra={
+            "correlation_id": correlation_id,
+            "user": _identify_user(request),
+            "path": request.url.path,
+            "method": request.method,
+        },
+    )
+    response = await call_next(request)
+    response.headers["X-Correlation-ID"] = correlation_id
+    return response
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Return service liveness."""
+
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready() -> dict[str, str]:
+    """Return service readiness."""
+
+    return {"status": "ready"}
+
+
+@app.get("/models")
+async def get_models() -> list[dict[str, object]]:
+    """Return all registered models."""
+
+    return [m.__dict__ for m in list_models()]
+
+
+@app.post("/models")
+async def create_model(payload: ModelCreate) -> dict[str, int]:
+    """Register a new diffusion model."""
+
+    model_id = register_model(
+        payload.name,
+        payload.version,
+        payload.model_id,
+        details=payload.details,
+        is_default=payload.is_default,
+    )
+    return {"id": model_id}
+
+
+@app.post("/models/{model_id}/default")
+async def switch_default(model_id: int) -> dict[str, str]:
+    """Switch the default diffusion model."""
+
+    try:
+        set_default(model_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {"status": "ok"}

--- a/backend/mockup-generation/tests/test_api_models.py
+++ b/backend/mockup-generation/tests/test_api_models.py
@@ -1,0 +1,139 @@
+"""Tests for model management API in the mockup generation service."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import types
+from fastapi.testclient import TestClient
+
+root = Path(__file__).resolve().parents[3]
+sys.path.append(str(root))  # noqa: E402
+sys.path.append(str(root / "backend" / "mockup-generation"))  # noqa: E402
+
+fastapi_mod = types.ModuleType("fastapi")
+fastapi_mod.FastAPI = object
+fastapi_mod.Request = object
+fastapi_mod.Response = object
+fastapi_mod.HTTPException = Exception
+responses_mod = types.ModuleType("fastapi.responses")
+responses_mod.JSONResponse = object
+sys.modules.setdefault("fastapi.responses", responses_mod)
+fastapi_mod.responses = responses_mod
+sys.modules.setdefault("fastapi", fastapi_mod)
+
+trace_root = types.ModuleType("opentelemetry.trace")
+trace_root.set_tracer_provider = lambda *a, **k: None
+sys.modules.setdefault("opentelemetry.trace", trace_root)
+fastapi_instr = types.ModuleType("opentelemetry.instrumentation.fastapi")
+fastapi_instr.FastAPIInstrumentor = type(
+    "FastAPIInstrumentor",
+    (),
+    {"instrument_app": lambda *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.instrumentation.fastapi", fastapi_instr)
+flask_instr = types.ModuleType("opentelemetry.instrumentation.flask")
+flask_instr.FlaskInstrumentor = object
+sys.modules.setdefault("opentelemetry.instrumentation.flask", flask_instr)
+res_mod = types.ModuleType("opentelemetry.sdk.resources")
+res_mod.Resource = type(
+    "Resource", (), {"create": staticmethod(lambda *a, **k: object())}
+)
+sys.modules.setdefault("opentelemetry.sdk.resources", res_mod)
+trace_mod = types.ModuleType("opentelemetry.sdk.trace")
+trace_mod.TracerProvider = type(
+    "TracerProvider",
+    (),
+    {
+        "__init__": lambda self, *a, **k: None,
+        "add_span_processor": lambda self, *a, **k: None,
+    },
+)
+sys.modules.setdefault("opentelemetry.sdk.trace", trace_mod)
+export_mod = types.ModuleType("opentelemetry.sdk.trace.export")
+export_mod.BatchSpanProcessor = type(
+    "BatchSpanProcessor",
+    (),
+    {"__init__": lambda self, *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.sdk.trace.export", export_mod)
+exp_http_mod = types.ModuleType("opentelemetry.exporter.otlp.proto.http.trace_exporter")
+exp_http_mod.OTLPSpanExporter = type(
+    "OTLPSpanExporter",
+    (),
+    {"__init__": lambda self, *a, **k: None},
+)
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    exp_http_mod,
+)
+
+for name in [
+    "opentelemetry",
+    "opentelemetry.trace",
+    "opentelemetry.instrumentation.fastapi",
+    "opentelemetry.instrumentation.flask",
+    "opentelemetry.sdk.resources",
+    "opentelemetry.sdk.trace",
+    "opentelemetry.sdk.trace.export",
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    "sentry_sdk",
+    "sentry_sdk.integrations.asgi",
+    "sentry_sdk.integrations.logging",
+]:
+    sys.modules.setdefault(name, types.ModuleType(name))
+
+sentry_mod = sys.modules.setdefault("sentry_sdk", types.ModuleType("sentry_sdk"))
+sentry_mod.init = lambda *args, **kwargs: None
+sentry_asgi = sys.modules.setdefault(
+    "sentry_sdk.integrations.asgi", types.ModuleType("sentry_sdk.integrations.asgi")
+)
+sentry_asgi.SentryAsgiMiddleware = object
+logging_mod = sys.modules.setdefault(
+    "sentry_sdk.integrations.logging",
+    types.ModuleType("sentry_sdk.integrations.logging"),
+)
+logging_mod.LoggingIntegration = object
+
+from mockup_generation.api import app  # noqa: E402
+from mockup_generation.model_repository import list_models
+
+client = TestClient(app)
+
+
+def test_register_and_list_models() -> None:
+    """Register a model and verify it appears in listings."""
+
+    resp = client.post(
+        "/models",
+        json={
+            "name": "base",
+            "version": "1",
+            "model_id": "model/a",
+            "details": {},
+            "is_default": True,
+        },
+    )
+    assert resp.status_code == 200
+    model_id = resp.json()["id"]
+    models = [m for m in list_models() if m.id == model_id]
+    assert models
+
+
+def test_switch_default_model() -> None:
+    """Switch model via the service API."""
+
+    resp = client.post(
+        "/models",
+        json={
+            "name": "alt",
+            "version": "2",
+            "model_id": "model/b",
+        },
+    )
+    model_id = resp.json()["id"]
+    resp = client.post(f"/models/{model_id}/default")
+    assert resp.status_code == 200
+    models = list_models()
+    assert any(m.id == model_id and m.is_default for m in models)

--- a/backend/shared/db/migrations/api_gateway/versions/0006_add_ai_models_table.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0006_add_ai_models_table.py
@@ -1,0 +1,35 @@
+"""Add ai_models table for tracking model versions."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create ai_models table."""
+    op.create_table(
+        "ai_models",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("version", sa.String(length=50), nullable=False),
+        sa.Column("model_id", sa.String(), nullable=False, unique=True),
+        sa.Column("details", sa.JSON(), nullable=True),
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Drop ai_models table."""
+    op.drop_table("ai_models")


### PR DESCRIPTION
## Summary
- allow registering custom diffusion models in the database
- expose model management endpoints in a new API module
- create API gateway migration for the ai_models table
- add unit tests for the mockup generation service API

## Testing
- `pytest backend/mockup-generation/tests/test_api_models.py -q` *(fails: ModuleNotFoundError etc.)*

------
https://chatgpt.com/codex/tasks/task_b_687a352a9424833194e62d769add522e