### PR TITLE
Implement endpoints for A/B feedback loop

### DIFF
--- a/backend/feedback-loop/feedback_loop/__init__.py
+++ b/backend/feedback-loop/feedback_loop/__init__.py
@@ -1,16 +1,58 @@
 """Feedback loop service components."""
 
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
 from .ab_testing import ABTestManager, BudgetAllocation
-from .scheduler import setup_scheduler
-from .weight_updater import update_weights
-from .ingestion import (
-    ingest_metrics,
-    fetch_marketplace_metrics,
-    store_marketplace_metrics,
-    schedule_marketplace_ingestion,
-    aggregate_marketplace_metrics,
-    update_weights_from_db,
-)
+
+
+def _load(module: str) -> ModuleType:
+    """Import a module lazily."""
+    return import_module(f"feedback_loop.{module}")
+
+
+def setup_scheduler(*args: Any, **kwargs: Any) -> Any:
+    """Return the configured scheduler."""
+    return _load("scheduler").setup_scheduler(*args, **kwargs)
+
+
+def update_weights(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to :func:`weight_updater.update_weights`."""
+    return _load("weight_updater").update_weights(*args, **kwargs)
+
+
+def ingest_metrics(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to :func:`ingestion.ingest_metrics`."""
+    return _load("ingestion").ingest_metrics(*args, **kwargs)
+
+
+def fetch_marketplace_metrics(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to :func:`ingestion.fetch_marketplace_metrics`."""
+    return _load("ingestion").fetch_marketplace_metrics(*args, **kwargs)
+
+
+def store_marketplace_metrics(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to :func:`ingestion.store_marketplace_metrics`."""
+    return _load("ingestion").store_marketplace_metrics(*args, **kwargs)
+
+
+def schedule_marketplace_ingestion(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to :func:`ingestion.schedule_marketplace_ingestion`."""
+    return _load("ingestion").schedule_marketplace_ingestion(*args, **kwargs)
+
+
+def aggregate_marketplace_metrics(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to :func:`ingestion.aggregate_marketplace_metrics`."""
+    return _load("ingestion").aggregate_marketplace_metrics(*args, **kwargs)
+
+
+def update_weights_from_db(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to :func:`ingestion.update_weights_from_db`."""
+    return _load("ingestion").update_weights_from_db(*args, **kwargs)
+
 
 __all__ = [
     "ABTestManager",

--- a/backend/feedback-loop/tests/test_main.py
+++ b/backend/feedback-loop/tests/test_main.py
@@ -1,0 +1,27 @@
+"""Tests for feedback loop main endpoints."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from feedback_loop import ABTestManager  # noqa: E402
+import feedback_loop.main as main  # noqa: E402
+
+
+def test_impression_conversion_allocation(tmp_path) -> None:
+    """Recorded events should influence allocation."""
+    main.manager = ABTestManager(database_url="sqlite:///:memory:")
+    client = TestClient(main.app)
+
+    resp = client.post("/impression", params={"variant": "A"})
+    assert resp.status_code == 200
+
+    resp = client.post("/conversion", params={"variant": "B"})
+    assert resp.status_code == 200
+
+    resp = client.get("/allocation", params={"total_budget": 100})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) == {"variant_a", "variant_b"}


### PR DESCRIPTION
## Summary
- expose impression, conversion and allocation endpoints
- lazily load heavy feedback_loop modules
- support in-memory SQLite for AB tests
- test new REST endpoints

## Testing
- `flake8 backend/feedback-loop/feedback_loop/main.py backend/feedback-loop/feedback_loop/__init__.py backend/feedback-loop/tests/test_main.py`
- `pytest backend/feedback-loop/tests/test_main.py backend/feedback-loop/tests/test_health.py backend/feedback-loop/tests/test_ab_testing.py backend/feedback-loop/tests/test_weight_updater.py --cov=backend/feedback-loop/feedback_loop --cov-report=term --cov-fail-under=80 -q` *(fails: Coverage failure: total of 15 is less than fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_b_687a454a240c8331a2fd09fb86e30088