### PR TITLE
Add cronjobs and sensor for Dagster orchestration

### DIFF
--- a/backend/orchestrator/orchestrator/__init__.py
+++ b/backend/orchestrator/orchestrator/__init__.py
@@ -2,6 +2,7 @@
 
 from .jobs import cleanup_job, idea_job, backup_job
 from .schedules import daily_backup_schedule, hourly_cleanup_schedule
+from .sensors import idea_sensor
 
 __all__ = [
     "idea_job",
@@ -9,4 +10,5 @@ __all__ = [
     "cleanup_job",
     "daily_backup_schedule",
     "hourly_cleanup_schedule",
+    "idea_sensor",
 ]

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -4,9 +4,11 @@ from dagster import Definitions
 
 from .jobs import backup_job, cleanup_job, idea_job
 from .schedules import daily_backup_schedule, hourly_cleanup_schedule
+from .sensors import idea_sensor
 
 
 defs = Definitions(
     jobs=[idea_job, backup_job, cleanup_job],
     schedules=[daily_backup_schedule, hourly_cleanup_schedule],
+    sensors=[idea_sensor],
 )

--- a/backend/orchestrator/orchestrator/sensors.py
+++ b/backend/orchestrator/orchestrator/sensors.py
@@ -1,0 +1,24 @@
+"""Dagster sensors for conditional job triggers."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, Union
+
+from dagster import RunRequest, SensorEvaluationContext, SkipReason, sensor
+
+from .jobs import idea_job
+
+
+@sensor(job=idea_job, minimum_interval_seconds=3600)  # type: ignore[misc]
+def idea_sensor(
+    context: SensorEvaluationContext,
+) -> Iterator[Union[RunRequest, SkipReason]]:
+    """Trigger ``idea_job`` when ``AUTO_RUN_IDEA`` is enabled."""
+    if os.environ.get("AUTO_RUN_IDEA") == "true":
+        yield RunRequest(
+            run_key=context.cursor,
+            tags={"trigger": "sensor"},
+        )
+    else:
+        yield SkipReason("AUTO_RUN_IDEA not enabled")

--- a/backend/orchestrator/tests/test_jobs.py
+++ b/backend/orchestrator/tests/test_jobs.py
@@ -1,11 +1,26 @@
-"""Tests for the Dagster orchestrator."""
+"""Tests for the Dagster orchestrator."""  # noqa: E402
 
-from orchestrator.jobs import (
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))  # noqa: E402
+
+from orchestrator.jobs import (  # noqa: E402
     backup_job,
     cleanup_job,
     idea_job,
 )
-from orchestrator.schedules import daily_backup_schedule, hourly_cleanup_schedule
+import pytest  # noqa: E402
+from dagster import DagsterInstance, RunRequest, build_sensor_context  # noqa: E402
+
+from orchestrator.schedules import (  # noqa: E402
+    daily_backup_schedule,  # noqa: E402
+    hourly_cleanup_schedule,  # noqa: E402
+)
+from orchestrator.sensors import idea_sensor  # noqa: E402
 
 
 def test_job_structure() -> None:
@@ -30,3 +45,47 @@ def test_cleanup_schedule_definition() -> None:
     """Hourly cleanup schedule is correctly configured."""
     assert hourly_cleanup_schedule.job == cleanup_job
     assert hourly_cleanup_schedule.cron_schedule == "0 * * * *"
+
+
+def test_idea_job_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run ``idea_job`` with a Dagster instance and verify op order."""
+    calls: list[str] = []
+
+    def fake_post(url: str, *args: object, **kwargs: object) -> object:
+        calls.append(url)
+
+        class Resp:
+            def raise_for_status(self) -> None:  # noqa: D401 - for test only
+                """Pretend the request succeeded."""
+
+            def json(self) -> dict[str, object]:  # noqa: D401 - for test only
+                """Return a minimal payload."""
+                if url.endswith("/ingest"):
+                    return {"signals": ["s1"]}
+                if url.endswith("/score"):
+                    return {"score": 1}
+                if url.endswith("/generate"):
+                    return {"items": ["i1"]}
+                return {"task_id": 1}
+
+        return Resp()
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setenv("APPROVE_PUBLISHING", "true")
+    instance = DagsterInstance.ephemeral()
+    result = idea_job.execute_in_process(instance=instance)
+    assert result.success
+    assert calls == [
+        "http://signal-ingestion:8004/ingest",
+        "http://scoring-engine:5002/score",
+        "http://mockup-generation:8000/generate",
+        "http://marketplace-publisher:8001/publish",
+    ]
+
+
+def test_idea_sensor_triggers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure ``idea_sensor`` requests a run when enabled."""
+    monkeypatch.setenv("AUTO_RUN_IDEA", "true")
+    context = build_sensor_context()
+    requests = list(idea_sensor(context))
+    assert requests and isinstance(requests[0], RunRequest)

--- a/infrastructure/k8s/base/cronjobs/orchestrator-backup.yaml
+++ b/infrastructure/k8s/base/cronjobs/orchestrator-backup.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: orchestrator-backup
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: orchestrator
+              image: example/orchestrator:latest
+              imagePullPolicy: IfNotPresent
+              command: ["dagster", "job", "execute", "-m", "orchestrator.jobs", "-j", "backup_job"]

--- a/infrastructure/k8s/base/cronjobs/orchestrator-cleanup.yaml
+++ b/infrastructure/k8s/base/cronjobs/orchestrator-cleanup.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: orchestrator-cleanup
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: orchestrator
+              image: example/orchestrator:latest
+              imagePullPolicy: IfNotPresent
+              command: ["dagster", "job", "execute", "-m", "orchestrator.jobs", "-j", "cleanup_job"]

--- a/infrastructure/k8s/base/cronjobs/orchestrator-idea.yaml
+++ b/infrastructure/k8s/base/cronjobs/orchestrator-idea.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: orchestrator-idea
+spec:
+  schedule: "30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: orchestrator
+              image: example/orchestrator:latest
+              imagePullPolicy: IfNotPresent
+              command: ["dagster", "job", "execute", "-m", "orchestrator.jobs", "-j", "idea_job"]

--- a/infrastructure/k8s/base/kustomization.yaml
+++ b/infrastructure/k8s/base/kustomization.yaml
@@ -18,3 +18,6 @@ resources:
   - secret.yaml
   - loki-deployment.yaml
   - loki-service.yaml
+  - cronjobs/orchestrator-backup.yaml
+  - cronjobs/orchestrator-cleanup.yaml
+  - cronjobs/orchestrator-idea.yaml


### PR DESCRIPTION
## Summary
- add sensor to trigger idea job when enabled
- include sensor in Dagster repository definitions
- attach auth headers in orchestrator ops
- provide Kubernetes cronjobs for scheduled runs
- test orchestration with DagsterInstance

## Testing
- `flake8 backend/orchestrator/orchestrator backend/orchestrator/tests`
- `pydocstyle backend/orchestrator/orchestrator backend/orchestrator/tests`
- `mypy --ignore-missing-imports --follow-imports=skip backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/sensors.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/__init__.py backend/orchestrator/tests/test_jobs.py`
- `pytest backend/orchestrator/tests -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_b_687a4e9d5d4883318aa6d324c03f6508