### PR TITLE
Embed license bundle into images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,19 @@ Use these prefixes so the release script can determine the next semantic version
 ## Releasing
 
 Run `./scripts/release.sh <registry>` after your changes are merged. The script updates `CHANGELOG.md`, creates a git tag, builds Docker images and pushes them with the new version number.
+
+## Third-Party Licenses
+
+Generate the bundled `LICENSES` file with:
+
+```bash
+python scripts/collect_licenses.py
+```
+
+Copy this file into all Docker contexts and ensure each Dockerfile includes:
+
+```Dockerfile
+COPY LICENSES /licenses/LICENSES
+```
+
+The resulting images must contain `/licenses/LICENSES` in the final layer.

--- a/LICENSES
+++ b/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/backend/mockup-generation/Dockerfile
+++ b/backend/mockup-generation/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y git python3-pip && rm -rf /var/lib/apt/
 
 COPY requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt
+COPY LICENSES /licenses/LICENSES
 
 COPY . .
 

--- a/backend/mockup-generation/LICENSES
+++ b/backend/mockup-generation/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/docker/backup/Dockerfile
+++ b/docker/backup/Dockerfile
@@ -2,4 +2,5 @@ FROM python:3.11-slim
 RUN apt-get update && apt-get install -y postgresql-client awscli && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY scripts/backup.py /app/backup.py
+COPY LICENSES /licenses/LICENSES
 ENTRYPOINT ["python", "/app/backup.py"]

--- a/docker/backup/LICENSES
+++ b/docker/backup/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -2,4 +2,6 @@ FROM bitnami/kafka:latest
 
 EXPOSE 9092 9093
 
+COPY LICENSES /licenses/LICENSES
+
 HEALTHCHECK --interval=10s --retries=5 CMD kafka-topics.sh --bootstrap-server localhost:9092 --list > /dev/null

--- a/docker/kafka/LICENSES
+++ b/docker/kafka/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/docker/minio/Dockerfile
+++ b/docker/minio/Dockerfile
@@ -2,4 +2,6 @@ FROM minio/minio:latest
 
 EXPOSE 9000
 
+COPY LICENSES /licenses/LICENSES
+
 HEALTHCHECK --interval=10s --retries=5 CMD mc ready local

--- a/docker/minio/LICENSES
+++ b/docker/minio/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/docker/pgbouncer/Dockerfile
+++ b/docker/pgbouncer/Dockerfile
@@ -1,4 +1,5 @@
 FROM pgbouncer/pgbouncer:latest
 COPY pgbouncer.ini /etc/pgbouncer/
+COPY LICENSES /licenses/LICENSES
 EXPOSE 6432
 HEALTHCHECK --interval=10s --retries=5 CMD pgbouncer --version

--- a/docker/pgbouncer/LICENSES
+++ b/docker/pgbouncer/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -6,4 +6,6 @@ RUN apt-get update \
 # Expose Postgres port
 EXPOSE 5432
 
+COPY LICENSES /licenses/LICENSES
+
 HEALTHCHECK --interval=10s --retries=5 CMD pg_isready -U "$POSTGRES_USER"

--- a/docker/postgres/LICENSES
+++ b/docker/postgres/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -2,4 +2,6 @@ FROM redis:7-alpine
 
 EXPOSE 6379
 
+COPY LICENSES /licenses/LICENSES
+
 HEALTHCHECK --interval=10s --retries=5 CMD redis-cli ping | grep PONG

--- a/docker/redis/LICENSES
+++ b/docker/redis/LICENSES
@@ -1,0 +1,20 @@
+Python packages:
+Pygments 2.19.2 - BSD License
+black 25.1.0 - MIT License
+click 8.2.1 - UNKNOWN
+iniconfig 2.1.0 - MIT License
+isort 6.0.1 - MIT License
+mypy 1.16.1 - MIT License
+mypy_extensions 1.1.0 - UNKNOWN
+nodeenv 1.9.1 - BSD License
+packaging 25.0 - Apache Software License; BSD License
+pathspec 0.12.1 - Mozilla Public License 2.0 (MPL 2.0)
+platformdirs 4.3.8 - MIT License
+pluggy 1.6.0 - MIT License
+pyright 1.1.403 - MIT
+pytest 8.4.1 - MIT License
+ruff 0.12.2 - MIT License
+typing_extensions 4.14.1 - UNKNOWN
+
+Node packages:
+desainz@1.0.0 UNKNOWN - ISC

--- a/scripts/collect_licenses.py
+++ b/scripts/collect_licenses.py
@@ -1,0 +1,50 @@
+"""Collect license information for Python and Node packages."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def _python_licenses() -> list[str]:
+    """Return formatted license lines for installed Python packages."""
+    result = subprocess.run(
+        ["pip-licenses", "--format=json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    packages: list[dict[str, str]] = json.loads(result.stdout)
+    return [f"{p['Name']} {p['Version']} - {p['License']}" for p in packages]
+
+
+def _node_licenses() -> list[str]:
+    """Return formatted license lines for installed Node packages."""
+    try:
+        result = subprocess.run(
+            ["license-checker", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return ["license-checker not found"]
+
+    packages: dict[str, dict[str, str]] = json.loads(result.stdout)
+    lines = []
+    for name, info in packages.items():
+        version = info.get("version", "UNKNOWN")
+        license_ = info.get("licenses", "UNKNOWN")
+        lines.append(f"{name} {version} - {license_}")
+    return lines
+
+
+def main() -> None:
+    """Generate the LICENSES file."""
+    content = ["Python packages:"] + _python_licenses() + ["", "Node packages:"] + _node_licenses()
+    Path("LICENSES").write_text("\n".join(content) + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- gather licenses from Python and Node dependencies
- place LICENSES file in each Docker context and copy in all Dockerfiles
- document how to regenerate and add the license bundle

## Testing
- `pre-commit run --files scripts/collect_licenses.py docker/backup/Dockerfile docker/kafka/Dockerfile docker/minio/Dockerfile docker/postgres/Dockerfile docker/pgbouncer/Dockerfile docker/redis/Dockerfile backend/mockup-generation/Dockerfile CONTRIBUTING.md` *(fails: asks for github credentials)*
- `python -m pytest -W error` *(fails: 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687a6fddbfc08331bd3f9a91730bdfd3