### PR TITLE
Implement CORS and JWT secret rotation

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -20,6 +20,8 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
+from backend.shared.config import settings as shared_settings
+from fastapi.middleware.cors import CORSMiddleware
 
 
 configure_logging()
@@ -27,6 +29,13 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = os.getenv("SERVICE_NAME", "analytics")
 app = FastAPI(title="Analytics Service")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, SERVICE_NAME)
 configure_sentry(app, SERVICE_NAME)
 add_profiling(app)

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Callable, Coroutine, cast
 
 from fastapi import FastAPI, Request, Response, status
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from jose import JWTError, jwt
 from redis.asyncio import Redis
@@ -16,6 +17,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
+from backend.shared.config import settings as shared_settings
 from .rate_limiter import UserRateLimiter
 from .settings import settings
 from .auth import ALGORITHM, SECRET_KEY
@@ -26,6 +28,13 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = os.getenv("SERVICE_NAME", "api-gateway")
 app = FastAPI(title="API Gateway")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 configure_tracing(app, SERVICE_NAME)
 configure_sentry(app, SERVICE_NAME)

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -8,12 +8,21 @@ import uuid
 from typing import Callable, Coroutine
 
 from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from backend.shared.metrics import register_metrics
 from pydantic import BaseModel
 
 from .ab_testing import ABTestManager
+from backend.shared.config import settings as shared_settings
 
 app = FastAPI(title="Feedback Loop")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 register_metrics(app)
 logger = logging.getLogger(__name__)
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Coroutine, cast
 import json
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from redis.asyncio import Redis
 
@@ -36,10 +37,18 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared import init_feature_flags, is_enabled
 from backend.shared import add_error_handlers, configure_sentry
+from backend.shared.config import settings as shared_settings
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, settings.app_name)
 configure_sentry(app, settings.app_name)
 add_profiling(app)

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -8,12 +8,14 @@ import uuid
 from typing import Callable, Coroutine
 
 from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from backend.shared.logging import configure_logging
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared import add_error_handlers, configure_sentry
+from backend.shared.config import settings as shared_settings
 from backend.shared.metrics import register_metrics
 
 from .model_repository import list_models, register_model, set_default
@@ -23,6 +25,13 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = os.getenv("SERVICE_NAME", "mockup-generation")
 app = FastAPI(title="Mockup Generation Service")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, SERVICE_NAME)
 configure_sentry(app, SERVICE_NAME)
 add_profiling(app)

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -11,12 +11,14 @@ import httpx
 
 import psutil
 from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import Histogram
 from backend.shared.metrics import register_metrics
 
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared import add_error_handlers, configure_sentry
+from backend.shared.config import settings as shared_settings
 from backend.shared.db import session_scope
 from backend.shared.db.models import Idea, Listing, Mockup, Signal
 from sqlalchemy import func, select
@@ -32,6 +34,13 @@ metrics_store = TimescaleMetricsStore()
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, settings.app_name)
 configure_sentry(app, settings.app_name)
 add_profiling(app)

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -11,12 +11,14 @@ import uuid
 from typing import Callable, Coroutine, List, cast
 
 from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
+from backend.shared.config import settings as shared_settings
 from .metrics import MetricsAnalyzer, ResourceMetric
 from .storage import MetricsStore
 
@@ -26,6 +28,13 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = os.getenv("SERVICE_NAME", "optimization")
 app = FastAPI(title="Optimization Service")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, SERVICE_NAME)
 configure_sentry(app, SERVICE_NAME)
 add_profiling(app)

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Coroutine, cast
 
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
 from redis.asyncio import Redis
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
@@ -71,6 +72,13 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = os.getenv("SERVICE_NAME", "scoring-engine")
 app = FastAPI(title="Scoring Engine")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, SERVICE_NAME)
 configure_sentry(app, SERVICE_NAME)
 add_profiling(app)

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Callable, Coroutine, cast
 
 from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 
 from .logging_config import configure_logging
 from .settings import settings
@@ -15,10 +16,18 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 
 from backend.shared import add_error_handlers, configure_sentry
+from backend.shared.config import settings as shared_settings
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, settings.app_name)
 configure_sentry(app, settings.app_name)
 add_profiling(app)

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     s3_secret_key: str | None = None
     s3_bucket: str | None = None
     secret_key: str | None = None
+    allowed_origins: list[str] = ["*"]
 
 
 settings = Settings()

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -9,12 +9,14 @@ from typing import Callable, Coroutine, cast
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from fastapi import Depends, FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 
 from .database import get_session, init_db
 from .scheduler import create_scheduler
 from .ingestion import ingest
 from .logging_config import configure_logging
 from .settings import settings
+from backend.shared.config import settings as shared_settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
@@ -24,6 +26,13 @@ from backend.shared import add_error_handlers, configure_sentry
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 configure_tracing(app, settings.app_name)
 configure_sentry(app, settings.app_name)
 add_profiling(app)

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,3 +24,15 @@ This project relies on environment variables for configuration.
 3. Deploy to a staging environment and verify the rollout.
 4. Promote the secret to production after validation.
 5. Remove the previous version when all services consume the new secret.
+
+### JWT secret rotation
+
+The `SECRET_KEY` used to sign JWT tokens is loaded from `/run/secrets` in
+production. To rotate it safely:
+
+1. Deploy the new secret alongside the old one and update the `secret_key`
+   environment variable.
+2. Insert all active token identifiers into the `revoked_tokens` table so old
+   credentials are rejected.
+3. Redeploy the services to pick up the new secret and remove the old one when
+   all clients have refreshed their tokens.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Global pytest fixtures for the test suite."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,43 @@
+"""Verify CORS headers for all FastAPI services."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+SERVICES = [
+    ("backend/service-template/src", "main"),
+    ("backend/api-gateway/src", "api_gateway.main"),
+    ("backend/signal-ingestion/src", "signal_ingestion.main"),
+    ("backend/feedback-loop/feedback_loop", "feedback_loop.main"),
+    ("backend/marketplace-publisher/src", "marketplace_publisher.main"),
+    ("backend/mockup-generation/mockup_generation", "mockup_generation.api"),
+    ("backend/analytics", "backend.analytics.api"),
+    ("backend/optimization", "backend.optimization.api"),
+    ("backend/scoring-engine/scoring_engine", "scoring_engine.app"),
+    ("backend/monitoring/src", "monitoring.main"),
+]
+
+
+@pytest.mark.parametrize("base,module", SERVICES)
+def test_cors_headers(base: str, module: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allowed origins are returned in CORS preflight responses."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://example.com")
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / base))
+    mod = importlib.import_module(module)
+    importlib.reload(mod)
+    app = getattr(mod, "app")
+    with TestClient(app) as client:
+        resp = client.options(
+            "/ready",
+            headers={
+                "Origin": "https://example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("access-control-allow-origin") == "https://example.com"

--- a/tests/test_revoked_token.py
+++ b/tests/test_revoked_token.py
@@ -1,0 +1,41 @@
+"""Ensure revoked JWT tokens are rejected."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "backend" / "analytics"))
+
+from backend.analytics import api  # noqa: E402
+from backend.analytics.auth import (
+    ALGORITHM,
+    SECRET_KEY,
+    create_access_token,
+)
+from backend.shared.db import SessionLocal  # noqa: E402
+from backend.shared.db.models import RevokedToken, UserRole  # noqa: E402
+from jose import jwt
+
+client = TestClient(api.app)
+
+
+def test_revoked_token_rejected() -> None:
+    """Access is denied when the token is revoked."""
+    token = create_access_token({"sub": "admin"})
+    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    jti = str(payload["jti"])
+    expires_at = datetime.now(UTC) + timedelta(minutes=30)
+    with SessionLocal() as session:
+        session.add(UserRole(username="admin", role="admin"))
+        session.add(RevokedToken(jti=jti, expires_at=expires_at))
+        session.commit()
+    resp = client.get(
+        "/marketplace_metrics/1/export",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Token revoked"


### PR DESCRIPTION
## Summary
- add allowed_origins setting
- configure CORS on all FastAPI services
- document JWT secret rotation
- add revoked token and CORS tests

## Testing
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: various untyped errors)*
- `pytest -W error` *(fails: 68 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687a7228c20c833186e43edfa33d7e6f