### PR TITLE
Implement trending topic cache

### DIFF
--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import uuid
+import asyncio
 import logging
 import json
 from datetime import datetime
@@ -80,6 +81,17 @@ REDIS_URL = settings.redis_url
 CACHE_TTL_SECONDS = settings.score_cache_ttl
 redis_client = Redis.from_url(REDIS_URL)
 start_centroid_scheduler()
+
+
+async def trending_factor(topics: list[str]) -> float:
+    """Return multiplier based on cached trending topics."""
+    if not topics:
+        return 1.0
+    scores = await asyncio.gather(
+        *[redis_client.zscore("trending:keywords", t) for t in topics]
+    )
+    max_score = max((s or 0.0) for s in scores)
+    return 1.0 + max_score / 100.0
 
 
 def _identify_user(request: Request) -> str:
@@ -189,8 +201,9 @@ async def score_signal(payload: ScoreRequest) -> JSONResponse:
     )
     median_engagement = float(payload.median_engagement or 0)
     topics = payload.topics or []
+    factor = await trending_factor(topics)
     with SCORE_TIME_HISTOGRAM.time():
-        score = calculate_score(signal, median_engagement, topics)
+        score = calculate_score(signal, median_engagement, topics, factor)
     await redis_client.setex(key, CACHE_TTL_SECONDS, score)
     return JSONResponse({"score": score, "cached": False})
 

--- a/backend/shared/cache.py
+++ b/backend/shared/cache.py
@@ -1,0 +1,20 @@
+"""Utility helpers for Redis connections."""
+
+from __future__ import annotations
+
+import redis
+from redis import asyncio as aioredis
+
+from .config import settings
+
+__all__ = ["get_sync_client", "get_async_client"]
+
+
+def get_sync_client() -> redis.Redis:
+    """Return a synchronous Redis client."""
+    return redis.Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def get_async_client() -> aioredis.Redis:
+    """Return an asynchronous Redis client."""
+    return aioredis.Redis.from_url(settings.redis_url, decode_responses=True)

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     schema_registry_url: str = "http://localhost:8081"
     redis_url: str = "redis://localhost:6379/0"
     score_cache_ttl: int = 3600
+    trending_ttl: int = 3600
     s3_endpoint: str | None = None
     s3_access_key: str | None = None
     s3_secret_key: str | None = None

--- a/backend/signal-ingestion/src/signal_ingestion/tasks.py
+++ b/backend/signal-ingestion/src/signal_ingestion/tasks.py
@@ -25,6 +25,7 @@ from .normalization import NormalizedSignal, normalize
 from .publisher import publish
 from .retention import purge_old_signals
 from .settings import settings
+from .trending import extract_keywords, store_keywords
 
 
 ADAPTERS: dict[str, BaseAdapter] = {
@@ -58,6 +59,7 @@ async def _ingest_from_adapter(session: AsyncSession, adapter: BaseAdapter) -> N
         await session.commit()
         publish("signals", key)
         publish("signals.ingested", json.dumps(clean_row))
+        store_keywords(extract_keywords(signal_data.title))
 
 
 @app.task(name="signal_ingestion.ingest_adapter")  # type: ignore[misc]

--- a/backend/signal-ingestion/src/signal_ingestion/trending.py
+++ b/backend/signal-ingestion/src/signal_ingestion/trending.py
@@ -1,0 +1,29 @@
+"""Store and retrieve trending keywords in Redis."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from backend.shared.cache import get_sync_client
+from backend.shared.config import settings
+
+TRENDING_KEY = "trending:keywords"
+_WORD_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def extract_keywords(text: str | None) -> list[str]:
+    """Return lowercase tokens extracted from ``text``."""
+    if not text:
+        return []
+    return [m.group(0).lower() for m in _WORD_RE.finditer(text)]
+
+
+def store_keywords(keywords: Iterable[str]) -> None:
+    """Increment counts for ``keywords`` and refresh TTL."""
+    client = get_sync_client()
+    pipe = client.pipeline()
+    for word in keywords:
+        pipe.zincrby(TRENDING_KEY, 1, word)
+    pipe.expire(TRENDING_KEY, settings.trending_ttl)
+    pipe.execute()

--- a/backend/signal-ingestion/tests/test_trending.py
+++ b/backend/signal-ingestion/tests/test_trending.py
@@ -1,0 +1,23 @@
+"""Tests for trending keyword cache."""
+
+from __future__ import annotations
+
+import fakeredis
+
+from signal_ingestion import trending
+from backend.shared import cache
+from backend.shared.config import settings
+
+
+def test_store_keywords_sets_ttl(monkeypatch):
+    """`store_keywords` refreshes TTL on the sorted set."""
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(cache, "get_sync_client", lambda: fake)
+    trending.store_keywords(["foo", "bar"])
+    ttl1 = fake.ttl(trending.TRENDING_KEY)
+    assert 0 < ttl1 <= settings.trending_ttl
+    trending.store_keywords(["foo"])
+    ttl2 = fake.ttl(trending.TRENDING_KEY)
+    assert ttl2 > 0
+    assert ttl2 <= settings.trending_ttl
+    assert ttl2 >= ttl1 - 1


### PR DESCRIPTION
## Summary
- add `shared.cache` for convenient Redis access
- store trending keywords in `signal-ingestion` and expose helper
- use trending keywords when computing freshness in scoring engine
- test Redis expiry with fakeredis
- configure shared settings with `trending_ttl`

## Testing
- `python -m flake8`
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `pytest -W error` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687a722f39208331b72ccc50be6731a4