### PR TITLE
Update Makefile targets and workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,17 +28,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
           npm ci
-      - name: Lint Python
-        run: |
-          flake8 .
-          mypy backend --explicit-package-bases --exclude "tests"
-          pydocstyle .
-          docformatter --check --recursive .
-      - name: Audit Python dependencies
-        run: |
-          pip-audit -r requirements.txt -r requirements-dev.txt
-      - name: Lint JavaScript and CSS
-        run: |
-          npm run lint
-          npm run lint:css
-          npm run flow
+      - name: Run linters
+        run: make lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,16 +36,8 @@ jobs:
           npm ci --prefix frontend/admin-dashboard
           npx playwright install --with-deps
           python -m pip install -e .
-      - name: Start services
-        run: docker compose -f docker-compose.test.yml up -d
       - name: Run tests
-        run: |
-          pytest -vv
-          npm test
-          npm run test:e2e
-      - name: Stop services
-        if: always()
-        run: docker compose -f docker-compose.test.yml down
+        run: make test
 
   publish:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -8,25 +8,35 @@ up:
 	docker compose up -d
 
 test:
-	python -m pytest -W error
+	docker compose -f docker-compose.test.yml up -d
+	python -m pytest -W error -vv
+	npm test
+	npm run test:e2e
+	docker compose -f docker-compose.test.yml down
 
 lint:
-        python -m flake8
-        npm run lint
+	flake8 .
+	mypy backend --explicit-package-bases --exclude "tests"
+	pydocstyle .
+	docformatter --check --recursive .
+	pip-audit -r requirements.txt -r requirements-dev.txt
+	npm run lint
+	npm run lint:css
+	npm run flow
 
 setup:
-        alembic -c backend/shared/db/alembic_api_gateway.ini upgrade head
-        alembic -c backend/shared/db/alembic_scoring_engine.ini upgrade head
-        alembic -c backend/shared/db/alembic_marketplace_publisher.ini upgrade head
-        alembic -c backend/shared/db/alembic_signal_ingestion.ini upgrade head
+	alembic -c backend/shared/db/alembic_api_gateway.ini upgrade head
+	alembic -c backend/shared/db/alembic_scoring_engine.ini upgrade head
+	alembic -c backend/shared/db/alembic_marketplace_publisher.ini upgrade head
+	alembic -c backend/shared/db/alembic_signal_ingestion.ini upgrade head
 
 docker-build:
-        ./scripts/build-images.sh
+	./scripts/build-images.sh
 
 docker-push:
-        ./scripts/push-images.sh $(REGISTRY) $(TAG)
+	./scripts/push-images.sh $(REGISTRY) $(TAG)
 
 helm-deploy:
-        ./scripts/helm_deploy.sh $(REGISTRY) $(TAG) $(ENV)
+	./scripts/helm_deploy.sh $(REGISTRY) $(TAG) $(ENV)
 
 ci: lint test docker-build

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 Run the common tasks using the `Makefile`:
 
 ```bash
-make up    # start services with Docker Compose
-make test  # run Python tests
-make lint  # run linters for Python and JavaScript
+make up           # start services with Docker Compose
+make test         # run unit and integration tests
+make lint         # run all linters and type checkers
+make docker-build # build local Docker images
+make docker-push  # push images to REGISTRY with TAG
+make helm-deploy  # deploy charts with Helm
 ```
 
 ## Type Checking


### PR DESCRIPTION
## Summary
- add commands for lint, test, docker build/push and helm deployment
- document the make targets in the README
- call make targets from CI workflows

## Testing
- `make lint` *(fails: mypy found 126 errors)*
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687a78b47cac833183c4fdc974d0051b