### PR TITLE
Expand OpenAPI generation

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,5 +26,6 @@ sentry-sdk
 Deprecated
 testing.postgresql
 sphinxcontrib-mermaid
+openapi-schema-validator
 opentelemetry-exporter-otlp
 python-jose[cryptography]

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -2,65 +2,92 @@
 """Generate OpenAPI specs for microservices."""
 from __future__ import annotations
 
-import importlib
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
+from typing import Iterable
+
+from openapi_schema_validator import OAS30Validator
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-SERVICES = {
-    "analytics": {"module": "backend.analytics.api", "app": "app"},
-    "optimization": {"module": "backend.optimization.api", "app": "app"},
-    "signal-ingestion": {
-        "module": "signal_ingestion.main",
-        "app": "app",
-        "path": PROJECT_ROOT / "backend" / "signal-ingestion" / "src",
-    },
-    "marketplace-publisher": {
-        "module": "marketplace_publisher.main",
-        "app": "app",
-        "path": PROJECT_ROOT / "backend" / "marketplace-publisher" / "src",
-    },
-    "monitoring": {
-        "module": "monitoring.main",
-        "app": "app",
-        "path": PROJECT_ROOT / "backend" / "monitoring" / "src",
-    },
-    "api-gateway": {
-        "module": "api_gateway.main",
-        "app": "app",
-        "path": PROJECT_ROOT / "backend" / "api-gateway" / "src",
-    },
-}
+os.environ.setdefault("KAFKA_SKIP", "1")
+os.environ.setdefault("SELENIUM_SKIP", "1")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///openapi.db")
+os.environ.setdefault("ABTEST_DB_URL", "sqlite:///abtest.db")
+
+DOCS_OPENAPI_DIR = PROJECT_ROOT / "docs" / "openapi"
+DOCS_INDEX = PROJECT_ROOT / "docs" / "openapi_specs.rst"
+
+
+def discover_main_files(base: Path) -> Iterable[Path]:
+    """Yield all FastAPI ``main.py`` files."""
+    return base.glob("backend/*/**/main.py")
+
+
+def ensure_doc(service: str) -> None:
+    """Create minimal RST page for ``service`` if missing."""
+    DOCS_OPENAPI_DIR.mkdir(exist_ok=True)
+    doc_path = DOCS_OPENAPI_DIR / f"{service}.rst"
+    if not doc_path.exists():
+        title = f"{service.replace('-', ' ').title()} API"
+        doc_path.write_text(
+            f"{title}\n{'=' * len(title)}\n\n.. openapi:: ../../openapi/{service}.json\n   :encoding: utf-8\n",
+            encoding="utf-8",
+        )
+
+    if DOCS_INDEX.exists():
+        lines = DOCS_INDEX.read_text(encoding="utf-8").splitlines()
+    else:
+        lines = ["OpenAPI Specifications", "======================", "", ".. toctree::", "   :maxdepth: 1", ""]
+
+    entry = f"   openapi/{service}"
+    if entry not in lines:
+        lines.append(entry)
+        DOCS_INDEX.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 OPENAPI_DIR = PROJECT_ROOT / "openapi"
 OPENAPI_DIR.mkdir(exist_ok=True)
 
-for name, spec in SERVICES.items():
-    extra_path = spec.get("path")
-    if extra_path:
-        sys.path.insert(0, str(extra_path))
-    module_name = spec["module"]
-    if module_name == "main":
-        module_path = extra_path / "main.py" if extra_path else Path("main.py")
-        spec_obj = importlib.util.spec_from_file_location(
-            "service_template_main", module_path
-        )
-        module = importlib.util.module_from_spec(spec_obj)
-        assert spec_obj.loader is not None
-        spec_obj.loader.exec_module(module)
+
+def generate_from_file(main_file: Path) -> None:
+    """Load FastAPI ``app`` from ``main_file`` and write its spec."""
+    service = main_file.parts[1]
+    service_root = PROJECT_ROOT / "backend" / service
+    src_dir = service_root / "src"
+    if src_dir.exists():
+        sys.path.insert(0, str(src_dir))
     else:
-        module = importlib.import_module(module_name)
-    app = getattr(module, spec["app"])
-    if hasattr(app, "openapi"):
-        data = app.openapi()
-    else:
-        continue
-    path = OPENAPI_DIR / f"{name}.json"
+        sys.path.insert(0, str(service_root))
+
+    package_dir = main_file.parent
+    package = package_dir.name if (package_dir / "__init__.py").exists() else ""
+    module_name = f"{package}.main" if package else "main"
+    spec_obj = importlib.util.spec_from_file_location(module_name, main_file)
+    module = importlib.util.module_from_spec(spec_obj)
+    if package and package not in sys.modules:
+        pkg_spec = importlib.machinery.ModuleSpec(package, loader=None)
+        pkg = importlib.util.module_from_spec(pkg_spec)
+        pkg.__path__ = [str(package_dir)]
+        sys.modules[package] = pkg
+    sys.modules[module_name] = module
+    assert spec_obj.loader is not None
+    spec_obj.loader.exec_module(module)
+    app = getattr(module, "app", None)
+    if not app or not hasattr(app, "openapi"):
+        return
+    data = app.openapi()
+    OAS30Validator.check_schema(data)
+    path = OPENAPI_DIR / f"{service}.json"
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    ensure_doc(service)
+
+
+for main_file in discover_main_files(PROJECT_ROOT):
+    generate_from_file(main_file)
 
 # scoring-engine manual spec
 sys.path.insert(0, str(PROJECT_ROOT / "backend" / "scoring-engine"))
@@ -127,3 +154,7 @@ spec = {
 (OPENAPI_DIR / "scoring-engine.json").write_text(
     json.dumps(spec, indent=2), encoding="utf-8"
 )
+OAS30Validator.check_schema(spec)
+ensure_doc("scoring-engine")
+
+


### PR DESCRIPTION
## Summary
- expand `generate_openapi.py` to auto-discover FastAPI services
- validate specs with `openapi-schema-validator`
- write docs pages for each service
- add validator dependency

## Testing
- `pip install pre-commit` *(passed)*
- `python scripts/generate_openapi.py` *(failed: connection to postgres refused)*

------
https://chatgpt.com/codex/tasks/task_b_687a7c26595c8331a7e78c7c5177660c