### PR TITLE
Setup JS linting and flow checks

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,8 @@
 [ignore]
 .*/node_modules/.*
 <PROJECT_ROOT>/frontend/admin-dashboard/scripts/.*
+<PROJECT_ROOT>/scripts/.*
+frontend/admin-dashboard/scripts/.*
 
 [libs]
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ CHANGELOG.md
 README.md
 .github/pull_request_template.md
 infrastructure/**
+frontend/admin-dashboard/coverage/**

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+node_modules/**
+frontend/admin-dashboard/coverage/**

--- a/frontend/admin-dashboard/.stylelintignore
+++ b/frontend/admin-dashboard/.stylelintignore
@@ -1,0 +1,1 @@
+coverage/**

--- a/frontend/admin-dashboard/__mocks__/styleMock.js
+++ b/frontend/admin-dashboard/__mocks__/styleMock.js
@@ -1,1 +1,3 @@
+// @flow
+
 module.exports = {};

--- a/frontend/admin-dashboard/babel.config.js
+++ b/frontend/admin-dashboard/babel.config.js
@@ -1,3 +1,5 @@
+// @flow
+
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],

--- a/frontend/admin-dashboard/eslint.config.mjs
+++ b/frontend/admin-dashboard/eslint.config.mjs
@@ -11,6 +11,9 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: ["coverage/**"],
+  },
 ];
 
 export default eslintConfig;

--- a/frontend/admin-dashboard/jest.config.js
+++ b/frontend/admin-dashboard/jest.config.js
@@ -1,3 +1,5 @@
+// @flow
+
 module.exports = {
   testEnvironment: 'jsdom',
   transform: {

--- a/frontend/admin-dashboard/package.json
+++ b/frontend/admin-dashboard/package.json
@@ -6,9 +6,12 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "node scripts/monitorAndStart.js",
-    "lint": "next lint",
+    "lint:eslint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
+    "lint:css": "stylelint \"**/*.{css,scss}\" --max-warnings=0 --allow-empty-input",
+    "format": "prettier \"**/*.{js,jsx,ts,tsx,css,scss,md}\" --write",
+    "lint": "npm run lint:eslint && npm run lint:css && npm run flow",
     "test": "node --trace-warnings -r ../../scripts/exit_on_warnings.js ./node_modules/jest/bin/jest.js --runInBand --ci",
-    "flow": "flow check --max-warnings=0",
+    "flow": "cd ../.. && flow check --max-warnings=0",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/frontend/admin-dashboard/postcss.config.js
+++ b/frontend/admin-dashboard/postcss.config.js
@@ -1,3 +1,5 @@
+// @flow
+
 module.exports = {
   plugins: {
     tailwindcss: {},


### PR DESCRIPTION
## Summary
- add Flow annotations to JS config files
- add ignore files for Prettier and Stylelint
- ignore coverage for ESLint flat config
- update admin dashboard package scripts for lint/format/flow
- tweak Flow config to ignore scripts

## Testing
- `npm run lint`
- `npm run lint` within `frontend/admin-dashboard`
- `npm run flow` within `frontend/admin-dashboard`
- `npm test`
- `pytest -W error -vv` *(fails: 64 errors)*
- `pre-commit run --files ...` *(failed: authentication required)*

------
https://chatgpt.com/codex/tasks/task_b_687a837403a083319005c59d0d82c388