### PR TITLE
Add runtime locale switching

### DIFF
--- a/docs/admin_dashboard_trpc.md
+++ b/docs/admin_dashboard_trpc.md
@@ -14,3 +14,11 @@ The dashboard uses a custom Tailwind setup defined in `tailwind.config.ts`. The 
 extends the default palette with a `brand` color and sets the sans and mono font
 families from CSS variables. This ensures consistent colors and fonts across all
 components.
+
+## Translation Workflow
+
+The dashboard supports multiple languages through the `i18next` library. Locale
+files live under `frontend/admin-dashboard/src/locales`, organized by language.
+Add or update strings in these JSON files and commit them with the code change.
+Run `npm run lint` to ensure the translation files are formatted correctly.
+For a detailed guide, see [docs/i18n.md](i18n.md).

--- a/frontend/admin-dashboard/__tests__/localeSwitch.test.tsx
+++ b/frontend/admin-dashboard/__tests__/localeSwitch.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
-import i18n from '../src/i18n';
+import { changeLanguage } from '../src/i18n';
 import { ToggleButton } from '../src/components/ToggleButton';
 
 test('switches locale at runtime', async () => {
@@ -7,10 +7,10 @@ test('switches locale at runtime', async () => {
   const button = screen.getByTestId('toggle-button');
   expect(button).toHaveTextContent('Off');
   await act(async () => {
-    await i18n.changeLanguage('es');
+    await changeLanguage('es');
   });
   expect(button).toHaveTextContent('Apagado');
   await act(async () => {
-    await i18n.changeLanguage('en');
+    await changeLanguage('en');
   });
 });

--- a/frontend/admin-dashboard/app/ideas/page.tsx
+++ b/frontend/admin-dashboard/app/ideas/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { trpc, type Idea } from '../../src/trpc';

--- a/frontend/admin-dashboard/app/layout.tsx
+++ b/frontend/admin-dashboard/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import '../src/styles/globals.css';
+import { LanguageSwitcher } from '../src/components/LanguageSwitcher';
+import i18n from '../src/i18n';
 
 export const metadata: Metadata = {
   title: 'Admin Dashboard',
@@ -13,8 +15,13 @@ export default function RootLayout({
   children: ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang={i18n.language}>
+      <body>
+        <div className="p-2">
+          <LanguageSwitcher />
+        </div>
+        {children}
+      </body>
     </html>
   );
 }

--- a/frontend/admin-dashboard/app/metrics/page.tsx
+++ b/frontend/admin-dashboard/app/metrics/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { trpc, type AnalyticsData } from '../../src/trpc';

--- a/frontend/admin-dashboard/app/mockups/page.tsx
+++ b/frontend/admin-dashboard/app/mockups/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useTranslation } from 'react-i18next';

--- a/frontend/admin-dashboard/app/page.tsx
+++ b/frontend/admin-dashboard/app/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useTranslation } from 'react-i18next';
 
 export default function Home() {

--- a/frontend/admin-dashboard/app/publish/page.tsx
+++ b/frontend/admin-dashboard/app/publish/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { trpc, type PublishTask } from '../../src/trpc';

--- a/frontend/admin-dashboard/app/signals/page.tsx
+++ b/frontend/admin-dashboard/app/signals/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { trpc, type Signal } from '../../src/trpc';

--- a/frontend/admin-dashboard/e2e/locale-switch.spec.ts
+++ b/frontend/admin-dashboard/e2e/locale-switch.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('user can switch languages', async ({ page }) => {
+  await page.goto('/');
+  await page.getByTestId('lang-es').click();
+  await expect(page.getByRole('heading', { name: /panel de administraci\u00f3n/i })).toBeVisible();
+  await page.getByTestId('lang-en').click();
+  await expect(page.getByRole('heading', { name: /admin dashboard/i })).toBeVisible();
+});

--- a/frontend/admin-dashboard/src/components/LanguageSwitcher.tsx
+++ b/frontend/admin-dashboard/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { changeLanguage, supportedLngs } from '../i18n';
+
+export function LanguageSwitcher() {
+  const { t } = useTranslation();
+  return (
+    <div className="space-x-2" data-testid="language-switcher">
+      {supportedLngs.map((lng) => (
+        <button
+          key={lng}
+          type="button"
+          onClick={() => changeLanguage(lng)}
+          data-testid={`lang-${lng}`}
+        >
+          {t(lng === 'en' ? 'english' : 'spanish')}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/admin-dashboard/src/i18n.ts
+++ b/frontend/admin-dashboard/src/i18n.ts
@@ -1,19 +1,35 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import enCommon from './locales/en/common.json';
-import esCommon from './locales/es/common.json';
+export const supportedLngs = ['en', 'es'] as const;
+export type SupportedLng = (typeof supportedLngs)[number];
+
+const loaders: Record<SupportedLng, () => Promise<Record<string, string>>> = {
+  en: async () => (await import('./locales/en/common.json')).default,
+  es: async () => (await import('./locales/es/common.json')).default,
+};
+
+async function loadResources(lng: SupportedLng) {
+  const resources = await loaders[lng]();
+  if (!i18n.hasResourceBundle(lng, 'translation')) {
+    i18n.addResourceBundle(lng, 'translation', resources);
+  }
+}
 
 void i18n.use(initReactI18next).init({
-  resources: {
-    en: { translation: enCommon },
-    es: { translation: esCommon },
-  },
+  resources: {},
   lng: 'en',
   fallbackLng: 'en',
   interpolation: {
     escapeValue: false,
   },
 });
+
+void loadResources('en');
+
+export async function changeLanguage(lng: SupportedLng) {
+  await loadResources(lng);
+  await i18n.changeLanguage(lng);
+}
 
 export default i18n;

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import AuthButton from '../components/AuthButton';
+import { LanguageSwitcher } from '../components/LanguageSwitcher';
 
 export default function AdminLayout({
   children,
@@ -49,8 +50,9 @@ export default function AdminLayout({
         </nav>
       </aside>
       <div className="flex flex-col flex-1">
-        <header className="bg-gray-100 p-4 shadow flex items-center">
+        <header className="bg-gray-100 p-4 shadow flex items-center space-x-4">
           <span className="flex-1">{t('title')}</span>
+          <LanguageSwitcher />
           <AuthButton />
         </header>
         <main className="p-4 flex-1 overflow-auto">{children}</main>

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -34,5 +34,7 @@
   "mockups": "Mockups",
   "metrics": "Metrics",
   "revenue": "Revenue",
-  "conversions": "Conversions"
+  "conversions": "Conversions",
+  "english": "English",
+  "spanish": "Spanish"
 }

--- a/frontend/admin-dashboard/src/locales/es/common.json
+++ b/frontend/admin-dashboard/src/locales/es/common.json
@@ -34,5 +34,7 @@
   "mockups": "Mockups",
   "metrics": "Métricas",
   "revenue": "Ingresos",
-  "conversions": "Conversiones"
+  "conversions": "Conversiones",
+  "english": "Inglés",
+  "spanish": "Español"
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/analytics.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/analytics.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
-import { trpc, type AnalyticsData } from '../../../../../src/trpc';
+import { trpc, type AnalyticsData } from '../../trpc';
 
 export default function AnalyticsPage() {
   const { t } = useTranslation();

--- a/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
-import { trpc, type GalleryItem } from '../../../../../src/trpc';
+import { trpc, type GalleryItem } from '../../trpc';
 
 export default function GalleryPage() {
   const { t } = useTranslation();

--- a/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
-import { trpc, type HeatmapEntry } from '../../../../../src/trpc';
+import { trpc, type HeatmapEntry } from '../../trpc';
 
 export default function HeatmapPage() {
   const { t } = useTranslation();

--- a/frontend/admin-dashboard/src/pages/dashboard/index.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
-import { trpc, type Signal } from '../../../../../src/trpc';
+import { trpc, type Signal } from '../../trpc';
 
 const StatusIndicator = dynamic(
   () => import('../../components/StatusIndicator')

--- a/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { trpc, type PublishTask } from '../../../../../src/trpc';
+import { trpc, type PublishTask } from '../../trpc';
 
 export default function PublishPage() {
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- load i18n language files on demand and export changeLanguage
- insert `LanguageSwitcher` UI into layouts
- allow Next.js app pages to run as client components
- reference local trpc client in old pages
- document i18n workflow for the dashboard
- add Playwright coverage for language switching

## Testing
- `npm run lint`
- `python -m pytest` *(fails: AttributeError from OTLPSpanExporter)*
- `npm test`
- `npm run test:e2e` *(fails: build errors for PostCSS/Tailwind)*

------
https://chatgpt.com/codex/tasks/task_b_687a8676d3448331815f57104b63c5bc