### PR TITLE
Add Loki logging handler

### DIFF
--- a/docs/logs_with_loki.md
+++ b/docs/logs_with_loki.md
@@ -1,6 +1,7 @@
 # Log Aggregation with Loki
 
-The monitoring service can send structured log messages to a Loki instance. Set
-`LOKI_URL` to the Loki HTTP endpoint and the metrics store will push a short log
-entry whenever metrics are written. Docker Compose and the Kubernetes base
-manifests include a Loki service listening on port `3100`.
+The monitoring service and all backend applications can send structured log
+messages to a Loki instance. Set the ``LOKI_URL`` environment variable to the
+Loki HTTP endpoint (e.g. ``http://loki:3100``) and each service will push JSON
+logs containing ``correlation_id`` and ``user`` fields. Docker Compose and the
+Kubernetes base manifests include a Loki service listening on port ``3100``.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,19 @@
+"""Tests for structured logging configuration."""
+
+# mypy: ignore-errors
+
+import json
+import logging
+
+from backend.shared.logging import configure_logging
+
+
+def test_loki_json_logging(caplog):
+    """Logs include correlation and user information in JSON."""
+    configure_logging()
+    caplog.set_level(logging.INFO)
+    logging.getLogger().info("test", extra={"correlation_id": "cid", "user": "alice"})
+    log = caplog.text.splitlines()[-1]
+    data = json.loads(log)
+    assert data["correlation_id"] == "cid"
+    assert data["user"] == "alice"


### PR DESCRIPTION
## Summary
- log to Loki when `LOKI_URL` is set
- document Loki configuration and structured fields
- test that JSON logging includes correlation ID and user info

## Testing
- `mypy --ignore-missing-imports --follow-imports skip backend/shared/logging.py tests/test_logging.py`
- `flake8 backend/shared/logging.py tests/test_logging.py`
- `pydocstyle backend/shared/logging.py tests/test_logging.py`
- `black backend/shared/logging.py tests/test_logging.py`
- `pytest -q` *(fails: 45 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687a8bb218c08331929c19d5222e0781