### PR TITLE
Add environment specific compose files

### DIFF
--- a/.github/workflows/tagged-build.yml
+++ b/.github/workflows/tagged-build.yml
@@ -1,0 +1,27 @@
+name: Release Docker Images
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build images
+        run: make docker-build
+      - name: Push images
+        env:
+          REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          TAG: ${{ github.ref_name }}
+        run: make docker-push REGISTRY=$REGISTRY TAG=$TAG

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,17 @@ TAG ?= latest
 ENV ?= dev
 
 up:
-	docker compose up -d
+	docker compose -f docker-compose.dev.yml up -d
+
+prod-up:
+	docker compose -f docker-compose.prod.yml up -d
 
 test:
-	docker compose -f docker-compose.test.yml up -d
+	docker compose -f docker-compose.dev.yml -f docker-compose.test.yml up -d
 	python -m pytest -W error -vv
 	npm test
 	npm run test:e2e
-	docker compose -f docker-compose.test.yml down
+	docker compose -f docker-compose.dev.yml -f docker-compose.test.yml down
 
 lint:
 	flake8 .
@@ -30,10 +33,10 @@ setup:
 	alembic -c backend/shared/db/alembic_marketplace_publisher.ini upgrade head
 	alembic -c backend/shared/db/alembic_signal_ingestion.ini upgrade head
 
-docker-build:
+	docker-build:
 	./scripts/build-images.sh
 
-docker-push:
+	docker-push:
 	./scripts/push-images.sh $(REGISTRY) $(TAG)
 
 helm-deploy:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 Run the common tasks using the `Makefile`:
 
 ```bash
-make up           # start services with Docker Compose
+make up           # start services with Docker Compose for development
+make prod-up      # start services with the production compose file
 make test         # run unit and integration tests
 make lint         # run all linters and type checkers
 make docker-build # build local Docker images
@@ -39,7 +40,7 @@ start to register the provided JSON schemas.
 Base Kubernetes manifests are available under `infrastructure/k8s`.
 
 PgBouncer connection pooling is available via the `pgbouncer` service in
-`docker-compose.yml`. Point `DATABASE_URL` at port `6432` to leverage pooling.
+`docker-compose.dev.yml`. Point `DATABASE_URL` at port `6432` to leverage pooling.
 Execute `scripts/analyze_query_plans.py` periodically to inspect query plans and
 identify missing indexes.
 
@@ -55,3 +56,13 @@ See [docs/security.md](docs/security.md) for the rotation procedure.
 
 1. Ensure all commits follow the Conventional Commits specification.
 2. Run `./scripts/release.sh <registry>` to generate the changelog, tag the release and publish versioned Docker images.
+
+### Production deployment
+
+Start the infrastructure stack in production mode using:
+
+```bash
+make prod-up
+```
+
+The `docker-compose.prod.yml` file uses prebuilt images and is intended for use on servers.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,174 @@
+version: '3.8'
+
+services:
+  postgres:
+    build: ./docker/postgres
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "user"]
+      interval: 10s
+      retries: 5
+
+  pgbouncer:
+    build: ./docker/pgbouncer
+    ports:
+      - "6432:6432"
+    depends_on:
+      - postgres
+
+  redis:
+    build: ./docker/redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    ports:
+      - "2181:2181"
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: 'yes'
+    volumes:
+      - zookeeper-data:/bitnami/zookeeper
+    healthcheck:
+      test: ["CMD", "zkServer.sh", "status"]
+      interval: 10s
+      retries: 5
+
+  kafka:
+    build: ./docker/kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    depends_on:
+      - zookeeper
+    volumes:
+      - kafka-data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      retries: 5
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:latest
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+    depends_on:
+      - kafka
+
+  kafka-init:
+    image: bitnami/kafka:latest
+    depends_on:
+      - kafka
+    volumes:
+      - ./docker/kafka/create-topics.sh:/create-topics.sh:ro
+    entrypoint: ["/bin/bash", "/create-topics.sh"]
+    restart: 'no'
+
+  minio:
+    build: ./docker/minio
+    ports:
+      - "9000:9000"
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+    command: server /data
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      retries: 5
+
+  # Optional GPU-based service
+  mockup-generation:
+    build: ./backend/mockup-generation
+    profiles:
+      - gpu
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+    secrets:
+      - openai_api_key
+      - stability_ai_api_key
+      - huggingface_token
+
+  # Optional monitoring stack
+  monitoring:
+    build: ./backend/monitoring
+    command: python -m monitoring.main
+    profiles:
+      - monitoring
+    ports:
+      - "8000:8000"
+    environment:
+      LOKI_URL: http://loki:3100
+    depends_on:
+      - loki
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=8000"
+
+  loki:
+    image: grafana/loki:latest
+    profiles:
+      - monitoring
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  prometheus:
+    image: prom/prometheus:latest
+    profiles:
+      - monitoring
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:latest
+    profiles:
+      - monitoring
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres-data:
+  redis-data:
+  zookeeper-data:
+  kafka-data:
+  minio-data:
+secrets:
+  secret_key:
+    file: ./secrets/secret_key.txt
+  openai_api_key:
+    file: ./secrets/openai_api_key.txt
+  stability_ai_api_key:
+    file: ./secrets/stability_ai_api_key.txt
+  huggingface_token:
+    file: ./secrets/huggingface_token.txt

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,171 @@
+version: '3.8'
+services:
+  postgres:
+    image: ghcr.io/example/postgres:latest
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "user"]
+      interval: 10s
+      retries: 5
+
+  pgbouncer:
+    image: ghcr.io/example/pgbouncer:latest
+    ports:
+      - "6432:6432"
+    depends_on:
+      - postgres
+
+  redis:
+    image: ghcr.io/example/redis:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    ports:
+      - "2181:2181"
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: 'yes'
+    volumes:
+      - zookeeper-data:/bitnami/zookeeper
+    healthcheck:
+      test: ["CMD", "zkServer.sh", "status"]
+      interval: 10s
+      retries: 5
+
+  kafka:
+    image: ghcr.io/example/kafka:latest
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    depends_on:
+      - zookeeper
+    volumes:
+      - kafka-data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      retries: 5
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:latest
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+    depends_on:
+      - kafka
+
+  kafka-init:
+    image: bitnami/kafka:latest
+    depends_on:
+      - kafka
+    volumes:
+      - ./docker/kafka/create-topics.sh:/create-topics.sh:ro
+    entrypoint: ["/bin/bash", "/create-topics.sh"]
+    restart: 'no'
+
+  minio:
+    image: ghcr.io/example/minio:latest
+    ports:
+      - "9000:9000"
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+    command: server /data
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      retries: 5
+
+  mockup-generation:
+    image: ghcr.io/example/mockup-generation:latest
+    profiles:
+      - gpu
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+    secrets:
+      - openai_api_key
+      - stability_ai_api_key
+      - huggingface_token
+
+  monitoring:
+    image: ghcr.io/example/monitoring:latest
+    command: python -m monitoring.main
+    profiles:
+      - monitoring
+    ports:
+      - "8000:8000"
+    environment:
+      LOKI_URL: http://loki:3100
+    depends_on:
+      - loki
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=8000"
+
+  loki:
+    image: grafana/loki:latest
+    profiles:
+      - monitoring
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  prometheus:
+    image: prom/prometheus:latest
+    profiles:
+      - monitoring
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:latest
+    profiles:
+      - monitoring
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres-data:
+  redis-data:
+  zookeeper-data:
+  kafka-data:
+  minio-data:
+secrets:
+  secret_key:
+    file: ./secrets/secret_key.txt
+  openai_api_key:
+    file: ./secrets/openai_api_key.txt
+  stability_ai_api_key:
+    file: ./secrets/stability_ai_api_key.txt
+  huggingface_token:
+    file: ./secrets/huggingface_token.txt

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,11 +1,20 @@
 version: '3.8'
 services:
   postgres:
+    extends:
+      file: docker-compose.dev.yml
+      service: postgres
     environment:
       POSTGRES_DB: app_test
   redis:
+    extends:
+      file: docker-compose.dev.yml
+      service: redis
     environment:
       REDIS_DB: 1
   kafka:
+    extends:
+      file: docker-compose.dev.yml
+      service: kafka
     environment:
       KAFKA_BROKER_ID: 99


### PR DESCRIPTION
## Summary
- add dedicated compose files for dev, test, and prod
- update Makefile commands for dev and prod stacks
- refresh README with new docker compose instructions
- build-and-push on tag creation via GitHub Actions

## Testing
- `docker compose -f docker-compose.dev.yml config`
- `docker compose -f docker-compose.dev.yml -f docker-compose.test.yml config`
- `docker compose -f docker-compose.prod.yml config`
- `make test` *(fails: Cannot connect to the Docker daemon)*
- `make lint` *(fails: flake8 not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a8bb4d3908331bfda71e7f5705cd9