### PR TITLE
Add LaunchDarkly feature flags

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/clients.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/clients.py
@@ -180,6 +180,23 @@ class Society6Client(BaseClient):
         )
 
 
+class ZazzleClient(BaseClient):
+    """Client for the Zazzle API."""
+
+    def __init__(self) -> None:
+        """Configure endpoints and credentials from the environment."""
+        super().__init__(
+            "https://api.zazzle.com/v1",
+            os.getenv("ZAZZLE_TOKEN_URL"),
+            "ZAZZLE_CLIENT_ID",
+            "ZAZZLE_CLIENT_SECRET",
+            "ZAZZLE_API_KEY",
+            os.getenv("ZAZZLE_AUTHORIZE_URL"),
+            "ZAZZLE_REDIRECT_URI",
+            "ZAZZLE_SCOPE",
+        )
+
+
 class SeleniumFallback:
     """Publish a design using browser automation if APIs fail."""
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/db.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/db.py
@@ -37,6 +37,7 @@ class Marketplace(str, Enum):
     amazon_merch = "amazon_merch"
     etsy = "etsy"
     society6 = "society6"
+    zazzle = "zazzle"
 
 
 class PublishStatus(str, Enum):

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -168,6 +168,8 @@ async def publish(req: PublishRequest, background: BackgroundTasks) -> dict[str,
         "society6_integration"
     ):
         raise HTTPException(status_code=403, detail="Society6 integration disabled")
+    if req.marketplace == Marketplace.zazzle and not is_enabled("zazzle_integration"):
+        raise HTTPException(status_code=403, detail="Zazzle integration disabled")
     allowed = await rate_limiter.acquire(req.marketplace)
     if not allowed:
         logger.warning(

--- a/backend/marketplace-publisher/src/marketplace_publisher/pricing.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/pricing.py
@@ -13,6 +13,7 @@ FEE_PERCENT: Mapping[Marketplace, float] = {
     Marketplace.amazon_merch: 0.3,
     Marketplace.etsy: 0.15,
     Marketplace.society6: 0.25,
+    Marketplace.zazzle: 0.22,
 }
 
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
@@ -17,6 +17,7 @@ from .clients import (
     EtsyClient,
     RedbubbleClient,
     Society6Client,
+    ZazzleClient,
     SeleniumFallback,
 )
 from .trademark import is_trademarked
@@ -35,6 +36,7 @@ CLIENTS = {
     Marketplace.amazon_merch: AmazonMerchClient(),
     Marketplace.etsy: EtsyClient(),
     Marketplace.society6: Society6Client(),
+    Marketplace.zazzle: ZazzleClient(),
 }
 
 _fallback = SeleniumFallback()

--- a/backend/marketplace-publisher/tests/test_feature_flags.py
+++ b/backend/marketplace-publisher/tests/test_feature_flags.py
@@ -38,3 +38,35 @@ def test_society6_flag(monkeypatch: Any, tmp_path: Path) -> None:
             },
         )
         assert response.status_code == 403
+
+
+def test_zazzle_flag(monkeypatch: Any, tmp_path: Path) -> None:
+    """Return 403 when Zazzle integration is disabled."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    from marketplace_publisher.db import Marketplace
+    from marketplace_publisher.main import app, rate_limiter
+    from marketplace_publisher import publisher
+    from backend.shared import feature_flags
+
+    rate_limiter._redis = fakeredis.aioredis.FakeRedis()
+    feature_flags.initialize()
+
+    class DummyClient:
+        def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
+            return "1"
+
+    publisher.CLIENTS[Marketplace.zazzle] = DummyClient()  # type: ignore[assignment]
+    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+
+    with TestClient(app) as client:
+        design = tmp_path / "a.png"
+        design.write_text("img")
+        response = client.post(
+            "/publish",
+            json={
+                "marketplace": Marketplace.zazzle.value,
+                "design_path": str(design),
+                "metadata": {},
+            },
+        )
+        assert response.status_code == 403

--- a/backend/shared/feature_flags.py
+++ b/backend/shared/feature_flags.py
@@ -1,11 +1,4 @@
-"""
-Feature flag utilities using Unleash with simple caching.
-
-Flags are read from an Unleash server when configuration is available. Results
-are cached for ``UNLEASH_CACHE_TTL`` seconds and fall back to values defined in
-``UNLEASH_DEFAULTS`` (JSON mapping from flag names to booleans) when Unleash is
-disabled or errors occur.
-"""
+"""Feature flag utilities supporting LaunchDarkly and environment overrides."""
 
 from __future__ import annotations
 
@@ -14,33 +7,55 @@ import os
 import time
 from typing import Any
 
+import redis
 from UnleashClient import UnleashClient
+from ldclient import LDClient
 
-_client: UnleashClient | None = None
+_unleash_client: UnleashClient | None = None
+_ld_client: LDClient | None = None
+_redis: redis.Redis[str] | None = None
 _cache: dict[str, tuple[bool, float]] = {}
 _cache_ttl: int = 30
 _defaults: dict[str, bool] = {}
+_env_flags: dict[str, bool] = {}
 
 
 def initialize() -> None:
-    """Initialize the global Unleash client if configuration is present."""
-    global _client, _cache_ttl, _defaults  # noqa: PLW0603
-    if _client is not None:
+    """Initialize clients and cache settings from the environment."""
+    global _unleash_client, _ld_client, _redis, _cache_ttl, _defaults, _env_flags
+    if _unleash_client or _ld_client:
         return
-    defaults_env = os.getenv("UNLEASH_DEFAULTS", "{}")
+
+    env_flags = os.getenv("FEATURE_FLAGS", "{}")
+    try:
+        _env_flags = {k: bool(v) for k, v in json.loads(env_flags).items()}
+    except json.JSONDecodeError:
+        _env_flags = {}
+
+    defaults_env = os.getenv("FEATURE_FLAGS_DEFAULTS", "{}")
     try:
         _defaults = {k: bool(v) for k, v in json.loads(defaults_env).items()}
     except json.JSONDecodeError:
         _defaults = {}
-    _cache_ttl = int(os.getenv("UNLEASH_CACHE_TTL", "30"))
+
+    _cache_ttl = int(os.getenv("FEATURE_FLAGS_CACHE_TTL", "30"))
+
+    redis_url = os.getenv("FEATURE_FLAGS_REDIS_URL")
+    if redis_url:
+        _redis = redis.Redis.from_url(redis_url, decode_responses=True)
+
     url = os.getenv("UNLEASH_URL")
     token = os.getenv("UNLEASH_API_TOKEN")
     app_name = os.getenv("UNLEASH_APP_NAME", "desainz")
     if url and token:
-        _client = UnleashClient(
+        _unleash_client = UnleashClient(
             url=url, app_name=app_name, custom_headers={"Authorization": token}
         )
-        _client.initialize_client()
+        _unleash_client.initialize_client()
+
+    sdk_key = os.getenv("LAUNCHDARKLY_SDK_KEY")
+    if sdk_key:
+        _ld_client = LDClient(sdk_key)
 
 
 def is_enabled(name: str, context: dict[str, Any] | None = None) -> bool:
@@ -51,23 +66,43 @@ def is_enabled(name: str, context: dict[str, Any] | None = None) -> bool:
         return cached[0]
 
     default = _defaults.get(name, False)
+    result = None
 
-    def _fallback(_: str, __: dict[str, Any]) -> bool:
-        return default
+    if name in _env_flags:
+        result = _env_flags[name]
 
-    if _client is None:
-        result = default
-    else:
+    if result is None and _redis is not None:
         try:
-            result = _client.is_enabled(name, context or {}, _fallback)
+            raw = _redis.get(name)
+            if raw is not None:
+                result = raw.lower() in {"1", "true", "yes"}
+        except Exception:
+            result = None
+
+    if result is None and _ld_client is not None:
+        try:
+            result = bool(
+                _ld_client.variation(name, context or {"key": "server"}, default)
+            )
         except Exception:
             result = default
+
+    if result is None and _unleash_client is not None:
+        try:
+            result = _unleash_client.is_enabled(name, context or {}, lambda *_: default)
+        except Exception:
+            result = default
+
+    if result is None:
+        result = default
 
     _cache[name] = (result, now + _cache_ttl)
     return result
 
 
 def shutdown() -> None:
-    """Gracefully close the Unleash client."""
-    if _client is not None:
-        _client.destroy()
+    """Gracefully close any open clients."""
+    if _unleash_client is not None:
+        _unleash_client.destroy()
+    if _ld_client is not None:
+        _ld_client.close()

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,23 +1,21 @@
 # Feature Flags
 
-Experimental features are toggled using [Unleash](https://www.getunleash.io/).
+Experimental features are toggled using [LaunchDarkly](https://launchdarkly.com/) or environment variables.
 
 ## Enabling a flag
 
-1. Start an Unleash server and create a feature with the desired name.
-2. Set the environment variables `UNLEASH_URL` and `UNLEASH_API_TOKEN` in the service.
-3. Optionally set `UNLEASH_APP_NAME` to override the default application name.
-4. Restart the service to load the flag configuration.
-
-Set ``UNLEASH_DEFAULTS`` to a JSON mapping of fallback values when no Unleash
-server is configured or if it cannot be reached. Results are cached for the
-number of seconds specified by ``UNLEASH_CACHE_TTL`` (default ``30``).
+1. Provide a `LAUNCHDARKLY_SDK_KEY` to fetch flags from LaunchDarkly.
+2. Set `FEATURE_FLAGS` to a JSON mapping of flag names to booleans for simple environment-based toggles.
+3. Set `FEATURE_FLAGS_REDIS_URL` to read overrides from Redis if desired.
+4. Results are cached for ``FEATURE_FLAGS_CACHE_TTL`` seconds (default ``30``).
 
 ## Disabling a flag
 
-Disable the feature from the Unleash dashboard or remove the environment
+Disable the feature from the LaunchDarkly dashboard or remove the environment
 variables to fall back to all flags being disabled.
 
 When the `society6_integration` flag is enabled, the marketplace publisher will
 accept requests targeting the `society6` marketplace. When disabled, such
 requests return HTTP 403.
+Similarly, the `zazzle_integration` flag controls access to the Zazzle publisher
+API and gated UI links.

--- a/frontend/admin-dashboard/__tests__/navigation.test.tsx
+++ b/frontend/admin-dashboard/__tests__/navigation.test.tsx
@@ -49,3 +49,15 @@ test('navigates to Maintenance page when link clicked', async () => {
   await userEvent.click(screen.getByText('Maintenance'));
   expect(Router).toMatchObject({ pathname: '/dashboard/maintenance' });
 });
+
+test('shows Zazzle link when flag enabled', () => {
+  process.env.NEXT_PUBLIC_ENABLE_ZAZZLE = 'true';
+  Router.setCurrentUrl('/dashboard');
+  renderWithRouter(
+    <AdminLayout>
+      <div>Home</div>
+    </AdminLayout>
+  );
+  expect(screen.getByText('Zazzle')).toBeInTheDocument();
+  delete process.env.NEXT_PUBLIC_ENABLE_ZAZZLE;
+});

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -41,6 +41,11 @@ export default function AdminLayout({
           <Link href="/dashboard/roles" className="block hover:underline">
             {t('roles')}
           </Link>
+          {process.env.NEXT_PUBLIC_ENABLE_ZAZZLE === 'true' && (
+            <Link href="/dashboard/zazzle" className="block hover:underline">
+              Zazzle
+            </Link>
+          )}
           <Link href="/dashboard/preferences" className="block hover:underline">
             {t('preferences')}
           </Link>

--- a/frontend/admin-dashboard/src/pages/dashboard/zazzle.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/zazzle.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function ZazzlePage() {
+  return <div>Zazzle integration coming soon.</div>;
+}
+
+export const getStaticProps = async () => ({ props: {}, revalidate: 60 });

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ aiosqlite
 locust
 
 UnleashClient
+launchdarkly-server-sdk
 
 pip-audit
 sphinxcontrib-openapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ Flask
 pydantic-settings
 psycopg2-binary
 UnleashClient
+launchdarkly-server-sdk
 sentry-sdk
 Deprecated


### PR DESCRIPTION
## Summary
- support LaunchDarkly, Redis and environment overrides for feature flags
- guard Zazzle marketplace integration behind a flag
- expose Zazzle link in dashboard when enabled
- document new feature flag configuration

## Testing
- `flake8 backend/shared/feature_flags.py backend/shared/tests/test_feature_flags.py backend/marketplace-publisher/src/marketplace_publisher/db.py backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/src/marketplace_publisher/pricing.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/tests/test_feature_flags.py`
- `mypy backend/shared/feature_flags.py backend/shared/tests/test_feature_flags.py backend/marketplace-publisher/src/marketplace_publisher/db.py backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/src/marketplace_publisher/pricing.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/tests/test_feature_flags.py` *(failed: Found 38 errors)*
- `pytest backend/shared/tests/test_feature_flags.py backend/marketplace-publisher/tests/test_feature_flags.py` *(failed: Segmentation fault)*
- `npm test` *(failed: missing jest)*

------
https://chatgpt.com/codex/tasks/task_b_687a927e36f48331ab0bced8ec7bf578