### PR TITLE
Fix audit logging context

### DIFF
--- a/backend/api-gateway/src/api_gateway/audit.py
+++ b/backend/api-gateway/src/api_gateway/audit.py
@@ -22,3 +22,4 @@ def log_admin_action(
                 timestamp=datetime.utcnow(),
             )
         )
+        session.flush()


### PR DESCRIPTION
## Summary
- close session_scope context manager correctly

## Testing
- `flake8 backend/api-gateway/src/api_gateway/audit.py`
- `black backend/api-gateway/src/api_gateway/audit.py --check`
- `mypy backend/api-gateway/src/api_gateway/audit.py` *(fails: untyped decorator etc.)*

------
https://chatgpt.com/codex/tasks/task_b_687a991678b88331973a562d2205b421