### PR TITLE
Implement Kafka consumer for scoring engine

### DIFF
--- a/backend/scoring-engine/tests/test_consumer.py
+++ b/backend/scoring-engine/tests/test_consumer.py
@@ -1,0 +1,43 @@
+"""Tests for the Kafka consumer used by the scoring engine."""
+
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+from threading import Event
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+from sqlalchemy import select
+
+from scoring_engine.app import consume_signals
+from backend.shared.db import session_scope
+from backend.shared.db.models import Embedding
+
+
+class DummyConsumer:
+    """Yield predetermined Kafka messages."""
+
+    def __init__(self, messages: list[tuple[str, dict[str, object]]]) -> None:
+        self._messages = messages
+
+    def __iter__(self) -> object:
+        """Return iterator over stored messages."""
+        return iter(self._messages)
+
+
+def test_consume_signals_stores_embeddings() -> None:
+    """Store embeddings from Kafka messages into the database."""
+    embedding = [0.0] * 768
+    embedding[0] = 1.0
+    consumer = DummyConsumer(
+        [("signals.ingested", {"embedding": embedding, "source": "src"})]
+    )
+    stop = Event()
+    consume_signals(stop, consumer)
+    with session_scope() as session:
+        row = session.scalar(select(Embedding))
+        assert row is not None
+        assert row.source == "src"
+        assert row.embedding[0] == 1.0


### PR DESCRIPTION
## Summary
- add background Kafka consumer using `KafkaConsumerWrapper` in `scoring_engine.app`
- store ingested embeddings in `Embedding` table
- start and stop the consumer on application lifecycle events
- test consumer logic with dummy Kafka consumer

## Testing
- `flake8 backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_consumer.py`
- `pytest backend/scoring-engine/tests/test_consumer.py -vv` *(fails: Coverage failure)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build/html`


------
https://chatgpt.com/codex/tasks/task_b_687a99228d9c8331a2845db1daeadc11