### PR TITLE
Add storage upload to mockup task

### DIFF
--- a/backend/mockup-generation/mockup_generation/model_repository.py
+++ b/backend/mockup-generation/mockup_generation/model_repository.py
@@ -34,6 +34,10 @@ class GeneratedMockupInfo:
     prompt: str
     num_inference_steps: int
     seed: int
+    image_uri: str
+    title: str
+    description: str
+    tags: list[str]
 
 
 def register_model(
@@ -101,11 +105,25 @@ def get_default_model_id() -> str:
     return ident or "stabilityai/stable-diffusion-xl-base-1.0"
 
 
-def save_generated_mockup(prompt: str, num_inference_steps: int, seed: int) -> int:
+def save_generated_mockup(
+    prompt: str,
+    num_inference_steps: int,
+    seed: int,
+    image_uri: str,
+    title: str,
+    description: str,
+    tags: list[str],
+) -> int:
     """Persist generation parameters and return the created row id."""
     with session_scope() as session:
         obj = GeneratedMockup(
-            prompt=prompt, num_inference_steps=num_inference_steps, seed=seed
+            prompt=prompt,
+            num_inference_steps=num_inference_steps,
+            seed=seed,
+            image_uri=image_uri,
+            title=title,
+            description=description,
+            tags=tags,
         )
         session.add(obj)
         session.flush()
@@ -122,6 +140,10 @@ def list_generated_mockups() -> List[GeneratedMockupInfo]:
                 prompt=row.prompt,
                 num_inference_steps=row.num_inference_steps,
                 seed=row.seed,
+                image_uri=row.image_uri,
+                title=row.title,
+                description=row.description,
+                tags=row.tags,
             )
             for row in rows
         ]

--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -1,0 +1,89 @@
+"""Tests for upload step in generate_mockup."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import sys
+import warnings
+import pytest
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))  # noqa: E402
+
+from mockup_generation import tasks  # noqa: E402
+
+uc_mod = sys.modules.setdefault("UnleashClient", types.ModuleType("UnleashClient"))
+uc_mod.UnleashClient = object
+ld_mod = sys.modules.setdefault("ldclient", types.ModuleType("ldclient"))
+ld_mod.LDClient = object
+prom_mod = sys.modules.setdefault(
+    "prometheus_client", types.ModuleType("prometheus_client")
+)
+prom_mod.CONTENT_TYPE_LATEST = ""
+prom_mod.Counter = lambda *a, **k: types.SimpleNamespace(
+    labels=lambda *_, **__: types.SimpleNamespace(inc=lambda *_, **__: None)
+)
+prom_mod.Histogram = lambda *a, **k: types.SimpleNamespace(
+    labels=lambda *_, **__: types.SimpleNamespace(observe=lambda *_, **__: None)
+)
+prom_mod.generate_latest = lambda *a, **k: b""
+sys.modules.setdefault("pgvector.sqlalchemy", types.ModuleType("pgvector.sqlalchemy"))
+sys.modules["pgvector.sqlalchemy"].Vector = object
+warnings.filterwarnings("ignore", category=UserWarning)
+
+
+class DummyClient:
+    """Collect upload calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def upload_file(self, src: str, bucket: str, obj: str) -> None:
+        self.calls.append((src, bucket, obj))
+
+
+class DummyGenerator:
+    """Write a dummy file and return its path."""
+
+    def generate(self, prompt: str, output: str, num_inference_steps: int = 30):
+        Path(output).write_text("x")
+        return types.SimpleNamespace(image_path=output)
+
+
+class DummyListing:
+    """Simple listing data container."""
+
+    title = "t"
+    description = "d"
+    tags = ["a"]
+
+
+class DummyListingGen:
+    """Return :class:`DummyListing` objects."""
+
+    def generate(self, keywords: list[str]) -> DummyListing:
+        return DummyListing()
+
+
+def test_generate_mockup_upload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Image is uploaded using the storage client."""
+    monkeypatch.setattr(tasks, "generator", DummyGenerator())
+    monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
+    monkeypatch.setattr(tasks, "_get_storage_client", lambda: DummyClient())
+    monkeypatch.setattr(tasks, "remove_background", lambda img: img)
+    monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)
+    monkeypatch.setattr(tasks, "ensure_not_nsfw", lambda img: None)
+    monkeypatch.setattr(tasks, "validate_dpi_image", lambda img: True)
+    monkeypatch.setattr(tasks, "validate_color_space", lambda img: True)
+    monkeypatch.setattr(
+        tasks.model_repository, "save_generated_mockup", lambda *a, **k: 1
+    )
+    tasks.settings.s3_bucket = "b"
+    tasks.settings.s3_endpoint = "http://test"  # type: ignore
+
+    res = tasks.generate_mockup.run([["kw"]], str(tmp_path))
+    assert res[0]["uri"].startswith("http://test/b/generated-mockups/mockup_0.png")

--- a/backend/shared/db/migrations/scoring_engine/versions/0012_add_uri_and_metadata_to_generated_mockups.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0012_add_uri_and_metadata_to_generated_mockups.py
@@ -1,0 +1,39 @@
+"""Add columns storing mockup metadata."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0012"
+down_revision = "cd5ddd60e6bc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add columns for mockup storage URI and metadata."""
+    op.add_column(
+        "generated_mockups",
+        sa.Column("image_uri", sa.String(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "generated_mockups",
+        sa.Column("title", sa.String(length=200), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "generated_mockups",
+        sa.Column("description", sa.String(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "generated_mockups",
+        sa.Column("tags", sa.JSON(), nullable=False, server_default="[]"),
+    )
+
+
+def downgrade() -> None:
+    """Remove mockup storage and metadata columns."""
+    op.drop_column("generated_mockups", "tags")
+    op.drop_column("generated_mockups", "description")
+    op.drop_column("generated_mockups", "title")
+    op.drop_column("generated_mockups", "image_uri")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -223,6 +223,10 @@ class GeneratedMockup(Base):
     prompt: Mapped[str] = mapped_column(String)
     num_inference_steps: Mapped[int] = mapped_column(Integer)
     seed: Mapped[int] = mapped_column(Integer)
+    image_uri: Mapped[str] = mapped_column(String)
+    title: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str] = mapped_column(String)
+    tags: Mapped[list[str]] = mapped_column(JSON)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 


### PR DESCRIPTION
## Summary
- upload generated mockups to S3/MinIO in `generate_mockup`
- record uploaded URI and metadata in database
- create migration and adapt models
- extend repository helpers
- add regression tests

## Testing
- `flake8 backend/shared/db/models.py backend/mockup-generation/mockup_generation/model_repository.py backend/mockup-generation/mockup_generation/tasks.py backend/shared/db/migrations/scoring_engine/versions/0012_add_uri_and_metadata_to_generated_mockups.py backend/mockup-generation/tests/test_model_repository.py backend/mockup-generation/tests/test_tasks_upload.py`
- `pytest backend/mockup-generation/tests/test_model_repository.py backend/mockup-generation/tests/test_tasks_upload.py -q` *(fails: ImportError: cannot import name 'Vector' from 'pgvector.sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687aaabe678c83319b8f6a22f0dc6376