### PR TITLE
Fix signal ingestion sanitization

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/tasks.py
+++ b/backend/signal-ingestion/src/signal_ingestion/tasks.py
@@ -57,15 +57,16 @@ async def _ingest_from_adapter(session: AsyncSession, adapter: BaseAdapter) -> N
             continue
         add_key(key)
         clean_row = purge_row(signal_data.asdict())
+        sanitized_json = json.dumps(clean_row)
         signal = Signal(
             source=adapter.__class__.__name__,
-            content=str(clean_row),
-            embedding=generate_embedding(json.dumps(clean_row)),
+            content=sanitized_json,
+            embedding=generate_embedding(sanitized_json),
         )
         session.add(signal)
         await session.commit()
         publish("signals", key)
-        publish("signals.ingested", json.dumps(clean_row))
+        publish("signals.ingested", sanitized_json)
         store_keywords(extract_keywords(signal_data.title))
 
 


### PR DESCRIPTION
## Summary
- sanitize signals and store as JSON
- test that PII is redacted during ingestion

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/tasks.py backend/signal-ingestion/tests/test_parallel_ingestion.py`
- `pydocstyle backend/signal-ingestion/src/signal_ingestion/tasks.py backend/signal-ingestion/tests/test_parallel_ingestion.py`
- `black backend/signal-ingestion/src/signal_ingestion/tasks.py backend/signal-ingestion/tests/test_parallel_ingestion.py`
- `docformatter -r -i backend/signal-ingestion/src/signal_ingestion/tasks.py backend/signal-ingestion/tests/test_parallel_ingestion.py`
- `mypy --ignore-missing-imports backend/signal-ingestion/src/signal_ingestion/tasks.py backend/signal-ingestion/tests/test_parallel_ingestion.py` *(fails: unused-ignore and other errors)*
- `pytest backend/signal-ingestion/tests/test_parallel_ingestion.py -k redacts -vv` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_b_687aaac3a3ec8331bf4ff34fb7254f26