### PR TITLE
Update weight updater to POST weights and schedule nightly

### DIFF
--- a/backend/feedback-loop/feedback_loop/scheduler.py
+++ b/backend/feedback-loop/feedback_loop/scheduler.py
@@ -45,7 +45,9 @@ def setup_scheduler(
         logger.info("updated marketplace weights %s", weights)
 
     scheduler.add_job(hourly_ingest, "interval", hours=1, next_run_time=None)
-    scheduler.add_job(nightly_update, "cron", hour=0, minute=0, next_run_time=None)
+    # Run weight update a few minutes after the midnight ingestion so the
+    # latest metrics are available before updating the scoring engine.
+    scheduler.add_job(nightly_update, "cron", hour=0, minute=5, next_run_time=None)
     scheduler.add_job(
         nightly_marketplace_update,
         "cron",

--- a/backend/feedback-loop/feedback_loop/weight_updater.py
+++ b/backend/feedback-loop/feedback_loop/weight_updater.py
@@ -53,7 +53,11 @@ def update_weights(
         "seasonality": 1.0,
     }
 
-    response = requests.post(f"{api_url}/weights/feedback", json=weights, timeout=5)
-    response.raise_for_status()
+    try:
+        response = requests.post(f"{api_url}/weights/feedback", json=weights, timeout=5)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        logger.exception("failed to update weights: %s", exc)
+        raise
     logger.info("updated weights: %s", weights)
     return weights

--- a/backend/feedback-loop/tests/test_scheduler.py
+++ b/backend/feedback-loop/tests/test_scheduler.py
@@ -1,0 +1,30 @@
+"""Tests for feedback loop scheduler."""
+
+from pathlib import Path
+import sys
+import importlib.util
+
+from apscheduler.triggers.cron import CronTrigger
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT.parent))
+sys.path.append(str(ROOT / "feedback-loop"))
+
+SPEC = importlib.util.spec_from_file_location(
+    "feedback_loop.scheduler",
+    ROOT / "feedback-loop" / "feedback_loop" / "scheduler.py",
+)
+scheduler_mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(scheduler_mod)
+
+setup_scheduler = scheduler_mod.setup_scheduler
+
+
+def test_nightly_update_schedule() -> None:
+    """Nightly update should run at 00:05."""
+    scheduler = setup_scheduler([], "http://api")
+    job = next(j for j in scheduler.get_jobs() if j.func.__name__ == "nightly_update")
+    assert isinstance(job.trigger, CronTrigger)
+    assert job.trigger.fields[5].expressions[0].start == 0  # hour
+    assert job.trigger.fields[6].expressions[0].start == 5  # minute

--- a/backend/feedback-loop/tests/test_weight_updater.py
+++ b/backend/feedback-loop/tests/test_weight_updater.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Any
 import sys
 import importlib.util
+import pytest
+from requests import RequestException
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT.parent))
@@ -32,3 +34,11 @@ def test_update_weights(requests_mock: Any) -> None:
     assert requests_mock.request_history[0].json() == weights
     assert weights["engagement"] == 0.1
     assert round(weights["community_fit"], 2) == 0.47
+
+
+def test_update_weights_error(requests_mock: Any) -> None:
+    """The function should raise for non-2xx responses."""
+    url = "http://example.com"
+    requests_mock.post(f"{url}/weights/feedback", status_code=500)
+    with pytest.raises(RequestException):
+        update_weights(url, [{"ctr": 0.1, "conversion_rate": 0.2}])


### PR DESCRIPTION
## Summary
- send weight updates via POST `/weights/feedback` and log errors
- schedule nightly weight update five minutes after midnight
- cover new logic in tests

## Testing
- `pytest -W error --cov=backend/feedback-loop/feedback_loop --cov-report=term --cov-report=xml --cov-fail-under=0 backend/feedback-loop/tests/test_weight_updater.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_687aaac7e3b08331bcd36013b7ae6ea1