### PR TITLE
Add storage setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ make docker-push  # push images to REGISTRY with TAG
 make helm-deploy  # deploy charts with Helm
 ```
 
+## Storage setup
+
+Create the buckets required by the blueprint and apply the lifecycle policy:
+
+```bash
+scripts/setup_storage.sh desainz-bucket --minio  # omit --minio for AWS S3
+```
+
 ## Type Checking
 
 Run Flow across the repository with:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,13 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
    ```bash
    python scripts/register_schemas.py
    ```
-4. Secrets can be stored in files under `secrets/` and referenced as Docker secrets. The services read them from `/run/secrets`.
+4. Initialize the object storage bucket used by the services:
+
+   ```bash
+   scripts/setup_storage.sh desainz-bucket --minio  # omit --minio for AWS S3
+   ```
+
+5. Secrets can be stored in files under `secrets/` and referenced as Docker secrets. The services read them from `/run/secrets`.
 
 ## Kubernetes
 

--- a/scripts/setup_storage.sh
+++ b/scripts/setup_storage.sh
@@ -1,12 +1,31 @@
 #!/usr/bin/env bash
 
-# Setup S3 or MinIO bucket structure based on the blueprint
+# Setup S3 or MinIO buckets and lifecycle policies based on the blueprint.
 # Usage: ./setup_storage.sh <bucket-name> [--minio]
 
 set -euo pipefail
 
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <bucket-name> [--minio]" >&2
+  exit 1
+fi
+
 BUCKET="$1"
 USE_MINIO="${2:-}"
+
+create_bucket() {
+  if [ "$USE_MINIO" = "--minio" ]; then
+    if ! mc ls "$BUCKET" >/dev/null 2>&1; then
+      mc mb "$BUCKET"
+    fi
+    mc ilm add --transition-days 365 --transition-storage-class GLACIER "$BUCKET" >/dev/null
+  else
+    if ! aws s3api head-bucket --bucket "$BUCKET" >/dev/null 2>&1; then
+      aws s3api create-bucket --bucket "$BUCKET"
+    fi
+    aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" --lifecycle-configuration '{"Rules":[{"ID":"ArchiveAfter12Months","Prefix":"","Status":"Enabled","Transitions":[{"Days":365,"StorageClass":"GLACIER"}]}]}'
+  fi
+}
 
 create_path() {
   local path="$1"
@@ -16,6 +35,8 @@ create_path() {
     aws s3 cp /dev/null "s3://${BUCKET}/${path}placeholder" >/dev/null
   fi
 }
+
+create_bucket
 
 for DIR in raw-signals generated-mockups published-assets backups; do
   create_path "${DIR}/"


### PR DESCRIPTION
## Summary
- extend `scripts/setup_storage.sh` to create buckets and set lifecycle policies
- reference storage setup in docs and README

## Testing
- `make lint` *(fails: missing docstrings in repository)*
- `make test` *(fails: `docker` command not found)*
- `sphinx-build -W -b html docs docs/_build/html` *(fails: builder-inited extension error)*

------
https://chatgpt.com/codex/tasks/task_b_687c0af3787c83319484d6f323eca56d