### PR TITLE
Fix metrics initialization order

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -56,7 +56,6 @@ configure_tracing(app, settings.app_name)
 configure_sentry(app, settings.app_name)
 add_profiling(app)
 add_error_handlers(app)
-register_metrics(app)
 
 
 def _identify_user(request: Request) -> str:
@@ -116,6 +115,9 @@ async def add_correlation_id(
     response = await call_next(request)
     response.headers["X-Correlation-ID"] = correlation_id
     return response
+
+
+register_metrics(app)
 
 
 class PublishRequest(BaseModel):

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -37,7 +37,6 @@ configure_tracing(app, SERVICE_NAME)
 configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
-register_metrics(app)
 
 
 class ModelCreate(BaseModel):  # type: ignore[misc]
@@ -81,6 +80,9 @@ async def add_correlation_id(
     response = await call_next(request)
     response.headers["X-Correlation-ID"] = correlation_id
     return response
+
+
+register_metrics(app)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- move metrics registration after middleware setup for publisher and mockup generation apps

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py`
- `black backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py`
- `docformatter --check backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py`
- `pydocstyle backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py`
- `mypy backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py` *(fails: various missing stubs)*
- `pytest tests/test_metrics_endpoints.py -vv -W error` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_b_687c0aef613083318570479d96a3e4cc