### PR TITLE
Enable runtime GPU slot scaling

### DIFF
--- a/backend/mockup-generation/tests/test_gpu_lock.py
+++ b/backend/mockup-generation/tests/test_gpu_lock.py
@@ -129,7 +129,7 @@ def test_gpu_slot(monkeypatch: pytest.MonkeyPatch) -> None:
     """Lock is acquired and released using the context manager."""
     fake = fakeredis.FakeRedis()
     monkeypatch.setattr(tasks, "redis_client", fake)
-    monkeypatch.setattr(tasks, "GPU_SLOTS", 1)
+    monkeypatch.setattr(tasks, "get_gpu_slots", lambda: 1)
 
     with tasks.gpu_slot():
         assert fake.lock("gpu_slot:0").locked()
@@ -140,7 +140,7 @@ def test_gpu_slot_contention(monkeypatch: pytest.MonkeyPatch) -> None:
     """Multiple workers should acquire the lock sequentially."""
     fake = fakeredis.FakeRedis()
     monkeypatch.setattr(tasks, "redis_client", fake)
-    monkeypatch.setattr(tasks, "GPU_SLOTS", 1)
+    monkeypatch.setattr(tasks, "get_gpu_slots", lambda: 1)
 
     order: list[str] = []
 

--- a/docs/mockup_generation.md
+++ b/docs/mockup_generation.md
@@ -12,4 +12,13 @@ docker build -f backend/mockup-generation/Dockerfile \
 ```
 
 The provided HorizontalPodAutoscaler manifests scale the deployment
-based on CPU, memory and the `celery_queue_length` metric.
+based on CPU, memory and the `celery_queue_length` metric. The number of
+concurrent GPU tasks is controlled by the Redis key `gpu_slots`. Update the
+key at runtime to change how many workers can acquire a GPU lock:
+
+```bash
+redis-cli set gpu_slots 2
+```
+
+An example HPA manifest lives in `infrastructure/k8s/examples/gpu-worker-hpa.yaml`
+and scales the `mockup-generation` deployment according to queue length.

--- a/infrastructure/k8s/examples/gpu-worker-hpa.yaml
+++ b/infrastructure/k8s/examples/gpu-worker-hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: mockup-generation
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mockup-generation
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: celery_queue_length
+          selector:
+            matchLabels:
+              queue: gpu
+        target:
+          type: AverageValue
+          averageValue: "3"


### PR DESCRIPTION
## Summary
- make GPU slots configurable at runtime via Redis
- patch tests for GPU slot configuration
- document GPU scaling and add a reference HPA

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_gpu_lock.py docs/mockup_generation.md infrastructure/k8s/examples/gpu-worker-hpa.yaml`
- `docformatter --check backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_gpu_lock.py docs/mockup_generation.md infrastructure/k8s/examples/gpu-worker-hpa.yaml`
- `pydocstyle backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_gpu_lock.py`
- `make test` *(failed: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_687c0b370b788331a69890003b2ac2b2