### PR TITLE
Add PagerDuty alert on publish failure

### DIFF
--- a/backend/marketplace-publisher/tests/test_notifications.py
+++ b/backend/marketplace-publisher/tests/test_notifications.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# Ensure local packages can be imported
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))
+# Add monitoring src to path
+sys.path.append(str(ROOT / "backend" / "monitoring" / "src"))
+
+import os
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from marketplace_publisher import notifications  # noqa: E402
+from monitoring import pagerduty  # noqa: E402
+
+
+def test_notify_failure_sends_slack_and_pagerduty(monkeypatch: Any) -> None:
+    """notify_failure should POST to Slack and trigger PagerDuty."""
+    sent: dict[str, Any] = {}
+
+    def fake_post(url: str, json: Any, timeout: int) -> None:  # noqa: D401
+        sent["url"] = url
+        sent["json"] = json
+        sent["timeout"] = timeout
+
+    pd_calls: list[tuple[int, str]] = []
+
+    def fake_pd(listing_id: int, state: str) -> None:  # noqa: D401
+        pd_calls.append((listing_id, state))
+
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://slack")
+    monkeypatch.setenv("PAGERDUTY_ROUTING_KEY", "key")
+    monkeypatch.setattr(notifications.requests, "post", fake_post)
+    monkeypatch.setattr(pagerduty, "notify_listing_issue", fake_pd)
+
+    notifications.notify_failure(7, "etsy")
+
+    assert sent["url"] == "http://slack"
+    assert "7" in sent["json"]["text"]
+    assert pd_calls == [(7, "failed")]

--- a/docs/publish_tasks.md
+++ b/docs/publish_tasks.md
@@ -9,3 +9,4 @@ Administrators can adjust listing metadata prior to publishing using the API Gat
 All edits and retries are recorded in the audit log.
 
 If `SLACK_WEBHOOK_URL` is configured, failed publish attempts send a Slack notification.
+When `PAGERDUTY_ROUTING_KEY` is set, the failure also triggers a PagerDuty alert.


### PR DESCRIPTION
## Summary
- send pagerduty alert from `notify_failure`
- document PagerDuty env var
- test notifications and retry failure

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/marketplace-publisher/tests/test_retry.py backend/marketplace-publisher/tests/test_notifications.py`
- `pydocstyle backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/marketplace-publisher/tests/test_retry.py backend/marketplace-publisher/tests/test_notifications.py`
- `docformatter --in-place docs/publish_tasks.md`
- `pytest backend/marketplace-publisher/tests/test_notifications.py backend/marketplace-publisher/tests/test_retry.py` *(fails: ModuleNotFoundError: No module named 'requests_oauthlib')*

------
https://chatgpt.com/codex/tasks/task_b_687c0ae674d48331873f97515cf2d72c