### PR TITLE
Add backend docstrings and fix docstyle

### DIFF
--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -136,7 +136,6 @@ class GeneratePayload(BaseModel):  # type: ignore[misc]
 @app.post("/generate")
 async def generate(payload: GeneratePayload) -> dict[str, list[str]]:
     """Schedule mockup generation tasks and return Celery task IDs."""
-
     task_ids = [
         celery_app.send_task(
             "mockup_generation.tasks.generate_mockup",


### PR DESCRIPTION
## Summary
- document generator module with clearer Google-style docstrings
- clean up blank line in API docstring
- run `docformatter` to normalize formatting

## Testing
- `docformatter --in-place --recursive backend`
- `pydocstyle backend`
- `flake8 backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/api.py backend/marketplace-publisher/src/marketplace_publisher/clients.py`
- `mypy backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/api.py backend/marketplace-publisher/src/marketplace_publisher/clients.py` *(fails: untyped decorators and missing stubs)*

------
https://chatgpt.com/codex/tasks/task_b_687c10635f748331aded47f9f97e318a