### PR TITLE
Enhance settings validation

### DIFF
--- a/backend/api-gateway/src/api_gateway/settings.py
+++ b/backend/api-gateway/src/api_gateway/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pydantic import RedisDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from backend.shared.config import settings as shared_settings
@@ -13,9 +14,17 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
 
     app_name: str = "api-gateway"
-    redis_url: str = shared_settings.redis_url
+    redis_url: RedisDsn = RedisDsn(shared_settings.redis_url)
     rate_limit_per_user: int = 60
     rate_limit_window: int = 60
 
+    @field_validator("rate_limit_per_user", "rate_limit_window")
+    @classmethod
+    def _positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("must be positive")
+        return value
 
-settings = Settings()
+
+Settings.model_rebuild()
+settings: Settings = Settings()

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pydantic import AnyUrl, HttpUrl, RedisDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from backend.shared.config import settings as shared_settings
@@ -14,18 +15,33 @@ class Settings(BaseSettings):
 
     app_name: str = "marketplace-publisher"
     log_level: str = "INFO"
-    database_url: str = shared_settings.database_url
-    redis_url: str = shared_settings.redis_url
+    database_url: AnyUrl = AnyUrl(shared_settings.database_url)
+    redis_url: RedisDsn = RedisDsn(shared_settings.redis_url)
     rate_limit_redbubble: int = 60
     rate_limit_amazon_merch: int = 60
     rate_limit_etsy: int = 60
     rate_limit_society6: int = 60
     rate_limit_window: int = 60
     max_attempts: int = 3
-    unleash_url: str | None = None
+    unleash_url: HttpUrl | None = None
     unleash_api_token: str | None = None
     unleash_app_name: str = "marketplace-publisher"
-    slack_webhook_url: str | None = None
+    slack_webhook_url: HttpUrl | None = None
+
+    @field_validator(
+        "rate_limit_redbubble",
+        "rate_limit_amazon_merch",
+        "rate_limit_etsy",
+        "rate_limit_society6",
+        "rate_limit_window",
+        "max_attempts",
+    )
+    @classmethod
+    def _positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("must be positive")
+        return value
 
 
-settings = Settings()
+Settings.model_rebuild()
+settings: Settings = Settings()

--- a/backend/mockup-generation/mockup_generation/settings.py
+++ b/backend/mockup-generation/mockup_generation/settings.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
 
 
 class Settings(BaseSettings):
@@ -14,7 +17,15 @@ class Settings(BaseSettings):
 
     stability_ai_api_key: str | None = None
     openai_api_key: str | None = None
-    fallback_provider: str = "stability"
+    fallback_provider: Literal["stability", "openai"] = "stability"
+
+    @field_validator("fallback_provider")
+    @classmethod
+    def _valid_provider(cls, value: str) -> str:
+        if value not in {"stability", "openai"}:
+            raise ValueError("invalid provider")
+        return value
 
 
-settings = Settings()
+Settings.model_rebuild()
+settings: Settings = Settings()

--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -15,5 +16,13 @@ class Settings(BaseSettings):
     sla_threshold_hours: float = 2.0
     SLA_THRESHOLD_HOURS: float = 2.0
 
+    @field_validator("sla_threshold_hours")
+    @classmethod
+    def _positive(cls, value: float) -> float:
+        if value <= 0:
+            raise ValueError("must be positive")
+        return value
 
-settings = Settings()
+
+Settings.model_rebuild()
+settings: Settings = Settings()

--- a/backend/service-template/src/settings.py
+++ b/backend/service-template/src/settings.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
 
 
 class Settings(BaseSettings):
@@ -11,7 +14,13 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
 
     app_name: str = "service-template"
-    log_level: str = "INFO"
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+
+    @field_validator("log_level")
+    @classmethod
+    def _valid_level(cls, value: str) -> str:
+        return value
 
 
-settings = Settings()
+Settings.model_rebuild()
+settings: Settings = Settings()

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -1,0 +1,93 @@
+"""Tests for environment variable validation in settings classes."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_settings(path: Path) -> type:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("settings", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.path.insert(0, str(ROOT))
+
+    dummy_shared = ModuleType("backend.shared.config")
+    dummy_shared.settings = SimpleNamespace(
+        redis_url="redis://localhost:6379/0",
+        database_url="sqlite:///db",
+    )
+    sys.modules.setdefault("backend.shared.config", dummy_shared)
+    backend_shared = ModuleType("backend.shared")
+    backend_shared.config = dummy_shared
+    sys.modules.setdefault("backend.shared", backend_shared)
+    sys.modules.setdefault("selenium.webdriver", ModuleType("selenium.webdriver"))
+    sys.modules["selenium.webdriver"].Firefox = lambda *a, **k: SimpleNamespace(
+        get=lambda *a, **k: None
+    )
+    sys.modules.setdefault(
+        "opentelemetry.sdk.resources", ModuleType("opentelemetry.sdk.resources")
+    )
+    sys.modules.setdefault("opentelemetry.trace", ModuleType("opentelemetry.trace"))
+    sys.modules.setdefault(
+        "opentelemetry.instrumentation.fastapi",
+        ModuleType("opentelemetry.instrumentation.fastapi"),
+    )
+
+    spec.loader.exec_module(module)
+    return module.Settings
+
+
+SISettings = _load_settings(
+    ROOT / "backend" / "signal-ingestion" / "src" / "signal_ingestion" / "settings.py"
+)
+MGSettings = _load_settings(
+    ROOT / "backend" / "mockup-generation" / "mockup_generation" / "settings.py"
+)
+AGSettings = _load_settings(
+    ROOT / "backend" / "api-gateway" / "src" / "api_gateway" / "settings.py"
+)
+MPSettings = _load_settings(
+    ROOT
+    / "backend"
+    / "marketplace-publisher"
+    / "src"
+    / "marketplace_publisher"
+    / "settings.py"
+)
+
+
+def test_signal_ingestion_invalid_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid ingest interval should raise a ``ValidationError``."""
+    monkeypatch.setenv("INGEST_INTERVAL_MINUTES", "0")
+    with pytest.raises(ValidationError):
+        SISettings()
+
+
+def test_mockup_generation_invalid_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unsupported provider names should be rejected."""
+    monkeypatch.setenv("FALLBACK_PROVIDER", "bogus")
+    with pytest.raises(ValidationError):
+        MGSettings()
+
+
+def test_api_gateway_invalid_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An invalid Redis URL should raise ``ValidationError``."""
+    monkeypatch.setenv("REDIS_URL", "not a url")
+    with pytest.raises(ValidationError):
+        AGSettings()
+
+
+def test_marketplace_invalid_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Webhook URLs must be valid HTTP URLs."""
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "not-a-url")
+    with pytest.raises(ValidationError):
+        MPSettings()


### PR DESCRIPTION
## Summary
- add strict typing and validators to backend service Settings
- type the global settings variables
- supply stubs for loading settings modules in tests
- test invalid env values for settings

## Testing
- `flake8 backend/api-gateway/src/api_gateway/settings.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/mockup-generation/mockup_generation/settings.py backend/service-template/src/settings.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/monitoring/src/monitoring/settings.py backend/shared/config.py tests/test_settings_validation.py`
- `mypy backend/api-gateway/src/api_gateway/settings.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/mockup-generation/mockup_generation/settings.py backend/service-template/src/settings.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/monitoring/src/monitoring/settings.py backend/shared/config.py tests/test_settings_validation.py`
- `pytest -W error tests/test_settings_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687c106b6eb88331a82f514b119b5d6e