### PR TITLE
Add PgBouncer support

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/db.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/db.py
@@ -88,7 +88,7 @@ class WebhookEvent(Base):
     task: Mapped["PublishTask"] = relationship("PublishTask", backref="events")
 
 
-engine = create_async_engine(settings.database_url, future=True)
+engine = create_async_engine(settings.effective_database_url, future=True)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
 
     app_name: str = "marketplace-publisher"
     log_level: str = "INFO"
-    database_url: AnyUrl = AnyUrl(shared_settings.database_url)
+    database_url: AnyUrl = AnyUrl(shared_settings.effective_database_url)
     redis_url: RedisDsn = RedisDsn(shared_settings.redis_url)
     rate_limit_redbubble: int = 60
     rate_limit_amazon_merch: int = 60

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     )
 
     database_url: AnyUrl = AnyUrl("sqlite:///shared.db")
+    pgbouncer_url: AnyUrl | None = None
     kafka_bootstrap_servers: str = "localhost:9092"
     schema_registry_url: HttpUrl = HttpUrl("http://localhost:8081")
     redis_url: RedisDsn = RedisDsn("redis://localhost:6379/0")
@@ -32,6 +33,11 @@ class Settings(BaseSettings):
         if value <= 0:
             raise ValueError("must be positive")
         return value
+
+    @property
+    def effective_database_url(self) -> AnyUrl:
+        """Return ``pgbouncer_url`` if set, otherwise ``database_url``."""
+        return self.pgbouncer_url or self.database_url
 
 
 Settings.model_rebuild()

--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -13,7 +13,7 @@ from backend.shared.config import settings
 
 __all__ = ["Base", "engine", "SessionLocal", "session_scope"]
 
-DATABASE_URL = settings.database_url
+DATABASE_URL = settings.effective_database_url
 engine = create_engine(DATABASE_URL, echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 

--- a/backend/shared/db/migrations/marketplace_publisher/env.py
+++ b/backend/shared/db/migrations/marketplace_publisher/env.py
@@ -17,7 +17,7 @@ fileConfig(config.config_file_name)
 
 def run_migrations_offline() -> None:
     """Run migrations in offline mode."""
-    url = config.get_main_option("sqlalchemy.url") or settings.database_url
+    url = config.get_main_option("sqlalchemy.url") or settings.effective_database_url
     context.configure(
         url=url,
         target_metadata=target_metadata,

--- a/backend/shared/db/migrations/signal_ingestion/env.py
+++ b/backend/shared/db/migrations/signal_ingestion/env.py
@@ -17,7 +17,7 @@ fileConfig(config.config_file_name)
 
 def run_migrations_offline() -> None:
     """Run migrations in offline mode."""
-    url = config.get_main_option("sqlalchemy.url") or settings.database_url
+    url = config.get_main_option("sqlalchemy.url") or settings.effective_database_url
     context.configure(
         url=url,
         target_metadata=target_metadata,

--- a/backend/signal-ingestion/src/signal_ingestion/database.py
+++ b/backend/signal-ingestion/src/signal_ingestion/database.py
@@ -13,7 +13,7 @@ from .models import Base
 from backend.shared.config import settings
 
 
-DATABASE_URL = settings.database_url
+DATABASE_URL = settings.effective_database_url
 engine = create_async_engine(DATABASE_URL, echo=False)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,6 +6,12 @@ services:
       service: postgres
     environment:
       POSTGRES_DB: app_test
+  pgbouncer:
+    extends:
+      file: docker-compose.dev.yml
+      service: pgbouncer
+    depends_on:
+      - postgres
   redis:
     extends:
       file: docker-compose.dev.yml

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -15,3 +15,10 @@ Architecture
 
 This diagram shows the high-level interaction between the dashboard and the
 backend services.
+
+PgBouncer
+---------
+
+PgBouncer provides lightweight connection pooling for PostgreSQL. Each service
+reads the ``PGBOUNCER_URL`` environment variable and connects to PgBouncer when
+set. If the variable is unset, the connection falls back to ``DATABASE_URL``.

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -24,15 +24,17 @@ def _load_settings(path: Path) -> type:
     dummy_shared.settings = SimpleNamespace(
         redis_url="redis://localhost:6379/0",
         database_url="sqlite:///db",
+        effective_database_url="sqlite:///db",
     )
     sys.modules.setdefault("backend.shared.config", dummy_shared)
     backend_shared = ModuleType("backend.shared")
     backend_shared.config = dummy_shared
     sys.modules.setdefault("backend.shared", backend_shared)
-    sys.modules.setdefault("selenium.webdriver", ModuleType("selenium.webdriver"))
-    sys.modules["selenium.webdriver"].Firefox = lambda *a, **k: SimpleNamespace(
-        get=lambda *a, **k: None
-    )
+    selenium_mod = sys.modules.setdefault("selenium", ModuleType("selenium"))
+    webdriver_mod = ModuleType("selenium.webdriver")
+    selenium_mod.webdriver = webdriver_mod
+    sys.modules.setdefault("selenium.webdriver", webdriver_mod)
+    webdriver_mod.Firefox = lambda *a, **k: SimpleNamespace(get=lambda *a, **k: None)
     sys.modules.setdefault(
         "opentelemetry.sdk.resources", ModuleType("opentelemetry.sdk.resources")
     )


### PR DESCRIPTION
## Summary
- respect `PGBOUNCER_URL` in configuration
- document PgBouncer usage
- enable PgBouncer in test compose file
- adjust config tests for new property

## Testing
- `flake8 backend/shared/config.py backend/shared/db/__init__.py backend/signal-ingestion/src/signal_ingestion/database.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/marketplace-publisher/src/marketplace_publisher/db.py backend/shared/db/migrations/signal_ingestion/env.py backend/shared/db/migrations/marketplace_publisher/env.py tests/test_settings_validation.py`
- `black backend/shared/config.py backend/shared/db/__init__.py backend/signal-ingestion/src/signal_ingestion/database.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/marketplace-publisher/src/marketplace_publisher/db.py backend/shared/db/migrations/signal_ingestion/env.py backend/shared/db/migrations/marketplace_publisher/env.py tests/test_settings_validation.py --quiet`
- `flake8 --select=D docs/architecture.rst`
- `pytest -W error -vv tests/test_settings_validation.py` *(fails: Coverage failure: total of 11 is less than fail-under=80)*
- `sphinx-build -b html docs docs/_build` *(fails to generate OpenAPI specs)*

------
https://chatgpt.com/codex/tasks/task_b_687c20fdbb008331bdcae03666fdef09