### PR TITLE
Implement dashboard data pages

### DIFF
--- a/frontend/admin-dashboard/__tests__/dashboardPages.test.tsx
+++ b/frontend/admin-dashboard/__tests__/dashboardPages.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import AuditLogsPage from '../src/pages/dashboard/audit-logs';
+import OptimizationsPage from '../src/pages/dashboard/optimizations';
+import MetricsPage from '../src/pages/dashboard/metrics';
+
+jest.mock('../src/trpc', () => ({
+  trpc: {
+    auditLogs: { list: () => Promise.resolve({ total: 0, items: [] }) },
+    optimizations: { list: () => Promise.resolve([]) },
+    metrics: { list: () => Promise.resolve('') },
+  },
+}));
+
+describe('dashboard data pages render', () => {
+  it('audit logs', () => {
+    render(<AuditLogsPage />);
+    expect(
+      screen.getByRole('heading', { name: /audit logs/i })
+    ).toBeInTheDocument();
+  });
+
+  it('optimizations', () => {
+    render(<OptimizationsPage />);
+    expect(
+      screen.getByRole('heading', { name: /optimizations/i })
+    ).toBeInTheDocument();
+  });
+
+  it('metrics', () => {
+    render(<MetricsPage />);
+    expect(
+      screen.getByRole('heading', { name: /metrics/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/admin-dashboard/__tests__/navigation.test.tsx
+++ b/frontend/admin-dashboard/__tests__/navigation.test.tsx
@@ -39,6 +39,28 @@ test('navigates to Roles page when link clicked', async () => {
   expect(Router).toMatchObject({ pathname: '/dashboard/roles' });
 });
 
+test('navigates to Audit Logs page when link clicked', async () => {
+  Router.setCurrentUrl('/dashboard');
+  renderWithRouter(
+    <AdminLayout>
+      <div>Home</div>
+    </AdminLayout>
+  );
+  await userEvent.click(screen.getByText('AuditLogs'));
+  expect(Router).toMatchObject({ pathname: '/dashboard/audit-logs' });
+});
+
+test('navigates to Optimizations page when link clicked', async () => {
+  Router.setCurrentUrl('/dashboard');
+  renderWithRouter(
+    <AdminLayout>
+      <div>Home</div>
+    </AdminLayout>
+  );
+  await userEvent.click(screen.getByText('Optimizations'));
+  expect(Router).toMatchObject({ pathname: '/dashboard/optimizations' });
+});
+
 test('navigates to Maintenance page when link clicked', async () => {
   Router.setCurrentUrl('/dashboard');
   renderWithRouter(

--- a/frontend/admin-dashboard/__tests__/trpc.test.ts
+++ b/frontend/admin-dashboard/__tests__/trpc.test.ts
@@ -1,13 +1,30 @@
 import { trpc } from '../src/trpc';
 
 beforeEach(() => {
-  global.fetch = jest.fn(
-    () =>
-      Promise.resolve({
+  global.fetch = jest.fn((url: string) => {
+    if (url.includes('/audit-logs')) {
+      return Promise.resolve({
         ok: true,
-        json: async () => ({ result: { message: 'pong', user: 'test' } }),
-      }) as unknown as Response
-  );
+        json: async () => ({ total: 1, items: [] }),
+      }) as unknown as Response;
+    }
+    if (url.includes('/optimizations')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ['opt'],
+      }) as unknown as Response;
+    }
+    if (url.includes('/metrics')) {
+      return Promise.resolve({
+        ok: true,
+        text: async () => 'm',
+      }) as unknown as Response;
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ result: { message: 'pong', user: 'test' } }),
+    }) as unknown as Response;
+  });
 });
 
 afterEach(() => {
@@ -20,4 +37,23 @@ describe('tRPC ping', () => {
     expect(global.fetch).toHaveBeenCalled();
     expect(result.message).toBe('pong');
   });
+});
+
+test('auditLogs.list fetches data', async () => {
+  await trpc.auditLogs.list();
+  expect(global.fetch).toHaveBeenCalledWith(
+    'http://localhost:8000/audit-logs?limit=50&offset=0'
+  );
+});
+
+test('optimizations.list fetches data', async () => {
+  await trpc.optimizations.list();
+  expect(global.fetch).toHaveBeenCalledWith(
+    'http://localhost:8000/optimizations'
+  );
+});
+
+test('metrics.list fetches data', async () => {
+  await trpc.metrics.list();
+  expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/metrics');
 });

--- a/frontend/admin-dashboard/e2e/admin-flow.spec.ts
+++ b/frontend/admin-dashboard/e2e/admin-flow.spec.ts
@@ -16,4 +16,10 @@ test('login and publish design', async ({ page }) => {
   await expect(
     page.getByRole('heading', { name: /publish tasks/i })
   ).toBeVisible();
+
+  await page.getByRole('link', { name: /audit logs/i }).click();
+  await expect(page).toHaveURL(/dashboard\/audit-logs/);
+
+  await page.getByRole('link', { name: /optimizations/i }).click();
+  await expect(page).toHaveURL(/dashboard\/optimizations/);
 });

--- a/frontend/admin-dashboard/postcss.config.js
+++ b/frontend/admin-dashboard/postcss.config.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -41,6 +41,18 @@ export default function AdminLayout({
           <Link href="/dashboard/roles" className="block hover:underline">
             {t('roles')}
           </Link>
+          <Link href="/dashboard/audit-logs" className="block hover:underline">
+            {t('auditLogs')}
+          </Link>
+          <Link
+            href="/dashboard/optimizations"
+            className="block hover:underline"
+          >
+            {t('optimizations')}
+          </Link>
+          <Link href="/dashboard/metrics" className="block hover:underline">
+            {t('metrics')}
+          </Link>
           {process.env.NEXT_PUBLIC_ENABLE_ZAZZLE === 'true' && (
             <Link href="/dashboard/zazzle" className="block hover:underline">
               Zazzle

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -5,6 +5,8 @@
   "gallery": "Gallery",
   "abTests": "AB Tests",
   "roles": "Roles",
+  "auditLogs": "Audit Logs",
+  "optimizations": "Optimizations",
   "signalStream": "Signal Stream",
   "galleryPlaceholder": "Gallery page placeholder.",
   "heatmapPlaceholder": "Heatmap page placeholder.",

--- a/frontend/admin-dashboard/src/locales/es/common.json
+++ b/frontend/admin-dashboard/src/locales/es/common.json
@@ -5,6 +5,8 @@
   "gallery": "Galería",
   "abTests": "Pruebas A/B",
   "roles": "Roles",
+  "auditLogs": "Registros de Auditoría",
+  "optimizations": "Optimizaciones",
   "signalStream": "Flujo de señales",
   "galleryPlaceholder": "Página de galería en construcción.",
   "heatmapPlaceholder": "Página de mapa de calor en construcción.",

--- a/frontend/admin-dashboard/src/pages/api/auth/[...nextauth].ts
+++ b/frontend/admin-dashboard/src/pages/api/auth/[...nextauth].ts
@@ -1,7 +1,7 @@
-import NextAuth from 'next-auth';
+import NextAuth, { type NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 
-export const authOptions = {
+export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
       name: 'Credentials',

--- a/frontend/admin-dashboard/src/pages/dashboard/audit-logs.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/audit-logs.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import type { GetStaticProps } from 'next';
+import { useTranslation } from 'react-i18next';
+import { trpc, type AuditLog } from '../../trpc';
+
+export default function AuditLogsPage() {
+  const { t } = useTranslation();
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const result = await trpc.auditLogs.list();
+        setLogs(result.items);
+      } catch {
+        setLogs([]);
+      }
+    }
+    void load();
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <h1>{t('auditLogs')}</h1>
+      <ul>
+        {logs.map((log) => (
+          <li
+            key={log.id}
+          >{`${log.timestamp} ${log.username} ${log.action}`}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+  revalidate: 60,
+});

--- a/frontend/admin-dashboard/src/pages/dashboard/metrics.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/metrics.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import type { GetStaticProps } from 'next';
+import { useTranslation } from 'react-i18next';
+import { trpc } from '../../trpc';
+
+export default function MetricsPage() {
+  const { t } = useTranslation();
+  const [metrics, setMetrics] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setMetrics(await trpc.metrics.list());
+      } catch {
+        setMetrics('');
+      }
+    }
+    void load();
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <h1>{t('metrics')}</h1>
+      <pre>{metrics}</pre>
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+  revalidate: 60,
+});

--- a/frontend/admin-dashboard/src/pages/dashboard/optimizations.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/optimizations.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import type { GetStaticProps } from 'next';
+import { useTranslation } from 'react-i18next';
+import { trpc } from '../../trpc';
+
+export default function OptimizationsPage() {
+  const { t } = useTranslation();
+  const [items, setItems] = useState<string[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setItems(await trpc.optimizations.list());
+      } catch {
+        setItems([]);
+      }
+    }
+    void load();
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <h1>{t('optimizations')}</h1>
+      <ul>
+        {items.map((opt, idx) => (
+          <li key={idx}>{opt}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+  revalidate: 60,
+});


### PR DESCRIPTION
## Summary
- implement audit log, metrics and optimizations pages
- expose additional endpoints in `trpc.ts`
- update navigation and translations
- expand unit tests and e2e flows
- fix NextAuth type declaration
- configure PostCSS for Tailwind v4

## Testing
- `npm --prefix frontend/admin-dashboard run lint:eslint`
- `npm --prefix frontend/admin-dashboard run lint:css`
- `npm --prefix frontend/admin-dashboard run test`
- `npm --prefix frontend/admin-dashboard run test:e2e` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_b_687c21085d748331b10778d072c8c533