### PR TITLE
Improve request validation

### DIFF
--- a/backend/api-gateway/src/api_gateway/models.py
+++ b/backend/api-gateway/src/api_gateway/models.py
@@ -1,0 +1,25 @@
+"""Pydantic models for API Gateway request bodies."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UsernameRequest(BaseModel):
+    """Request body containing a username."""
+
+    username: str
+
+
+class RoleAssignment(BaseModel):
+    """Request body for assigning a role to a user."""
+
+    role: str
+
+
+class MetadataPatch(BaseModel):
+    """Arbitrary metadata payload."""
+
+    model_config = ConfigDict(extra="allow")

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import AnyUrl, HttpUrl, RedisDsn, field_validator
+from pydantic import AnyUrl, Field, HttpUrl, RedisDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -25,7 +25,15 @@ class Settings(BaseSettings):
     s3_secret_key: str | None = None
     s3_bucket: str | None = None
     secret_key: str | None = None
-    allowed_origins: list[str] = ["*"]
+    allowed_origins: list[str] = Field(default_factory=list)
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def _split_origins(cls, value: str | list[str]) -> list[str]:
+        """Parse comma separated origins from environment variables."""
+        if isinstance(value, str):
+            return [v.strip() for v in value.split(",") if v.strip()]
+        return value
 
     @field_validator("score_cache_ttl", "trending_ttl")
     @classmethod

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,3 +25,4 @@ application settings classes.
 | `SCHEMA_REGISTRY_URL` | Schema Registry endpoint |
 | `LOG_LEVEL` | Logging verbosity |
 | `APPROVE_PUBLISHING` | Require publishing approval flag |
+| `ALLOWED_ORIGINS` | Comma separated whitelist of origins for CORS |

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,72 @@
+"""Validation error tests for API endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+# API Gateway setup
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")
+)
+from api_gateway.main import app as gateway_app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared.db import session_scope  # noqa: E402
+from backend.shared.db.models import UserRole  # noqa: E402
+
+client = TestClient(gateway_app)
+
+
+def test_issue_token_validation() -> None:
+    """Missing username should return validation error."""
+    resp = client.post("/auth/token", json={})
+    assert resp.status_code == 422
+
+
+def test_assign_role_validation() -> None:
+    """Invalid request body should raise 422."""
+    token = create_access_token({"sub": "admin"})
+    with session_scope() as session:
+        session.add(UserRole(username="admin", role="admin"))
+        session.flush()
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.post("/roles/test", headers=headers, json={})
+    assert resp.status_code == 422
+
+
+# Marketplace publisher setup
+sys.path.append(
+    str(
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "marketplace-publisher"
+        / "src"
+    )
+)
+from marketplace_publisher import main as mp_main  # noqa: E402
+
+publisher_client = TestClient(mp_main.app)
+
+
+@pytest.mark.asyncio()
+async def test_update_task_metadata_validation(monkeypatch, tmp_path: Path) -> None:
+    """Non-object metadata payload should be rejected."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    monkeypatch.setattr(
+        mp_main, "engine", create_async_engine("sqlite+aiosqlite:///:memory:")
+    )
+    session_factory = async_sessionmaker(mp_main.engine, expire_on_commit=False)
+    monkeypatch.setattr(mp_main, "SessionLocal", session_factory)
+    await mp_main.init_db()
+    async with session_factory() as session:
+        task = await mp_main.create_task(
+            session,
+            marketplace=mp_main.Marketplace.redbubble,
+            design_path="design.png",
+        )
+    resp = publisher_client.patch(f"/tasks/{task.id}", json=[])
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- restrict allowed origins to a configurable list
- validate gateway request bodies with Pydantic models
- validate marketplace metadata updates with Pydantic
- document the new `ALLOWED_ORIGINS` setting
- add tests covering validation failures

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q` *(fails: TypeError from pgvector)*
- `sphinx-build -b html docs docs/_build` *(fails: handler for builder-inited)*

------
https://chatgpt.com/codex/tasks/task_b_687c25b7f57c83318bca4e0e6cb92b43