### PR TITLE
Update lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,5 +28,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
           npm ci
-      - name: Run linters
-        run: make lint
+      - name: Run Black
+        run: black --check .
+      - name: Run Flake8
+        run: flake8 .
+      - name: Run MyPy
+        run: mypy backend --explicit-package-bases --exclude "tests"
+      - name: Run ESLint/Prettier/Stylelint
+        run: npm run lint
+      - name: Run Flow
+        run: npm run flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,18 @@ updated.
 
 The hooks enforce Black, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Warnings are treated as errors, so commits will fail until issues are fixed.
 
+## CI Lint Commands
+
+The continuous integration workflow runs the following commands and fails on any warnings:
+
+```bash
+black --check .
+flake8 .
+mypy backend --explicit-package-bases --exclude "tests"
+npm run lint
+npm run flow
+```
+
 ## Commit Messages
 
 This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. Examples:


### PR DESCRIPTION
## Summary
- run black, flake8, mypy and JS linters individually in CI
- document lint commands in CONTRIBUTING

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q` *(fails: 68 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687c25bf3ea48331bcbfb6af631a4cf0