### PR TITLE
Implement query plan analysis job

### DIFF
--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -8,6 +8,7 @@ from .ops import (
     await_approval,
     backup_data,
     cleanup_data,
+    analyze_query_plans_op,
     generate_content,
     ingest_signals,
     publish_content,
@@ -36,3 +37,9 @@ def backup_job() -> None:
 def cleanup_job() -> None:
     """Job running periodic cleanup."""
     cleanup_data()
+
+
+@job(hooks={record_success, record_failure})
+def analyze_query_plans_job() -> None:
+    """Job collecting EXPLAIN plans for slow queries."""
+    analyze_query_plans_op()

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -169,3 +169,14 @@ def cleanup_data(  # type: ignore[no-untyped-def]
     context.log.info("running cleanup")
     maintenance.archive_old_mockups()
     maintenance.purge_stale_records()
+
+
+@op  # type: ignore[misc]
+def analyze_query_plans_op(  # type: ignore[no-untyped-def]
+    context,
+) -> None:
+    """Run query plan analysis script."""
+    context.log.info("analyzing slow queries")
+    from scripts import analyze_query_plans
+
+    analyze_query_plans.main()

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -2,13 +2,21 @@
 
 from dagster import Definitions
 
-from .jobs import backup_job, cleanup_job, idea_job
-from .schedules import daily_backup_schedule, hourly_cleanup_schedule
+from .jobs import analyze_query_plans_job, backup_job, cleanup_job, idea_job
+from .schedules import (
+    daily_backup_schedule,
+    hourly_cleanup_schedule,
+    daily_query_plan_schedule,
+)
 from .sensors import idea_sensor
 
 
 defs = Definitions(
-    jobs=[idea_job, backup_job, cleanup_job],
-    schedules=[daily_backup_schedule, hourly_cleanup_schedule],
+    jobs=[idea_job, backup_job, cleanup_job, analyze_query_plans_job],
+    schedules=[
+        daily_backup_schedule,
+        hourly_cleanup_schedule,
+        daily_query_plan_schedule,
+    ],
     sensors=[idea_sensor],
 )

--- a/backend/orchestrator/orchestrator/schedules.py
+++ b/backend/orchestrator/orchestrator/schedules.py
@@ -2,7 +2,7 @@
 
 from dagster import ScheduleEvaluationContext, schedule
 
-from .jobs import backup_job, cleanup_job
+from .jobs import backup_job, cleanup_job, analyze_query_plans_job
 
 
 @schedule(cron_schedule="0 0 * * *", job=backup_job, execution_timezone="UTC")
@@ -14,4 +14,12 @@ def daily_backup_schedule(_context: ScheduleEvaluationContext) -> dict[str, obje
 @schedule(cron_schedule="0 * * * *", job=cleanup_job, execution_timezone="UTC")
 def hourly_cleanup_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
     """Trigger ``cleanup_job`` every hour."""
+    return {}
+
+
+@schedule(
+    cron_schedule="30 6 * * *", job=analyze_query_plans_job, execution_timezone="UTC"
+)
+def daily_query_plan_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
+    """Trigger ``analyze_query_plans_job`` every morning."""
     return {}

--- a/backend/orchestrator/tests/test_jobs.py
+++ b/backend/orchestrator/tests/test_jobs.py
@@ -17,8 +17,9 @@ import pytest  # noqa: E402
 from dagster import DagsterInstance, RunRequest, build_sensor_context  # noqa: E402
 
 from orchestrator.schedules import (  # noqa: E402
-    daily_backup_schedule,  # noqa: E402
-    hourly_cleanup_schedule,  # noqa: E402
+    daily_backup_schedule,
+    daily_query_plan_schedule,
+    hourly_cleanup_schedule,
 )
 from orchestrator.sensors import idea_sensor  # noqa: E402
 
@@ -45,6 +46,13 @@ def test_cleanup_schedule_definition() -> None:
     """Hourly cleanup schedule is correctly configured."""
     assert hourly_cleanup_schedule.job == cleanup_job
     assert hourly_cleanup_schedule.cron_schedule == "0 * * * *"
+
+
+def test_query_plan_schedule_definition() -> None:
+    """Daily query plan schedule is correctly configured."""
+
+    assert daily_query_plan_schedule.job.name == "analyze_query_plans_job"
+    assert daily_query_plan_schedule.cron_schedule == "30 6 * * *"
 
 
 def test_idea_job_execution(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -32,3 +32,15 @@ Environment variables can override the storage paths:
 
 Dependencies for Python, JavaScript, and GitHub Actions are kept current via Dependabot.
 Weekly update PRs run on all `requirements*.txt`, `package.json` files, and workflow definitions. These PRs must pass the full test suite before merge.
+
+## Query Plan Analysis
+
+Slow database statements can be inspected using `scripts/analyze_query_plans.py`.
+The script reads from `pg_stat_statements` and prints `EXPLAIN` plans for the worst offenders.
+Use the optional `SLOW_QUERY_LIMIT` environment variable to adjust how many statements are inspected.
+
+```bash
+python scripts/analyze_query_plans.py
+```
+
+The `daily_query_plan_schedule` Dagster schedule runs the analysis once a day.

--- a/infrastructure/k8s/base/cronjobs/orchestrator-query-plan.yaml
+++ b/infrastructure/k8s/base/cronjobs/orchestrator-query-plan.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: orchestrator-query-plan
+spec:
+  schedule: "30 6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: orchestrator
+              image: example/orchestrator:latest
+              imagePullPolicy: IfNotPresent
+              command: ["dagster", "job", "execute", "-m", "orchestrator.jobs", "-j", "analyze_query_plans_job"]

--- a/infrastructure/k8s/base/kustomization.yaml
+++ b/infrastructure/k8s/base/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - cronjobs/orchestrator-backup.yaml
   - cronjobs/orchestrator-cleanup.yaml
   - cronjobs/orchestrator-idea.yaml
+  - cronjobs/orchestrator-query-plan.yaml

--- a/scripts/analyze_query_plans.py
+++ b/scripts/analyze_query_plans.py
@@ -1,42 +1,56 @@
 #!/usr/bin/env python
-"""Analyze query plans and suggest missing indexes."""
+"""
+Analyze query plans and suggest missing indexes.
+
+This script connects to the database defined by ``DATABASE_URL`` and
+inspects ``pg_stat_statements`` for the slowest queries. Each query is then
+passed to ``EXPLAIN`` so that the query planner output can be reviewed.
+The goal is to identify missing indexes or other optimisations.
+"""
 
 from __future__ import annotations
 
 import logging
 import os
+from typing import Iterable
 
 import psycopg2
 from psycopg2.extras import DictCursor
 
-QUERIES = [
-    ("signals_by_idea", "SELECT * FROM signals WHERE idea_id = %s LIMIT 1", (1,)),
-    (
-        "mockups_by_idea",
-        "SELECT * FROM mockups WHERE idea_id = %s LIMIT 1",
-        (1,),
-    ),
-    (
-        "listings_by_mockup",
-        "SELECT * FROM listings WHERE mockup_id = %s LIMIT 1",
-        (1,),
-    ),
-]
+SLOW_QUERY_SQL = """
+    SELECT query
+    FROM pg_stat_statements
+    WHERE calls > 0
+    ORDER BY mean_exec_time DESC
+    LIMIT %s
+"""
+
+DEFAULT_LIMIT = 5
+
+
+def _fetch_slow_queries(cur: DictCursor, limit: int) -> Iterable[str]:
+    """Return the ``limit`` slowest queries recorded by ``pg_stat_statements``."""
+    cur.execute(SLOW_QUERY_SQL, (limit,))
+    rows = cur.fetchall()
+    return [row["query"] for row in rows]
+
+
+def _explain_query(cur: DictCursor, query: str) -> str:
+    """Return the ``EXPLAIN`` plan for ``query``."""
+    cur.execute("EXPLAIN " + query)
+    return "\n".join(row[0] for row in cur.fetchall())
 
 
 def main() -> None:
-    """Run EXPLAIN on common queries and print query plans."""
-    dsn = os.getenv(
-        "DATABASE_URL",
-        "postgresql://user:password@localhost:5432/app",
-    )
+    """Print ``EXPLAIN`` plans for the slowest statements."""
+    dsn = os.getenv("DATABASE_URL", "postgresql://user:password@localhost:5432/app")
+    limit = int(os.getenv("SLOW_QUERY_LIMIT", str(DEFAULT_LIMIT)))
     conn = psycopg2.connect(dsn)
     try:
         with conn.cursor(cursor_factory=DictCursor) as cur:
-            for name, query, params in QUERIES:
-                cur.execute("EXPLAIN " + query, params)
-                plan = "\n".join(row[0] for row in cur.fetchall())
-                logging.info("%s:\n%s", name, plan)
+            for query in _fetch_slow_queries(cur, limit):
+                plan = _explain_query(cur, query)
+                logging.info("Query: %s\n%s", query, plan)
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
- analyze slow queries via pg_stat_statements
- document explain plan script usage
- orchestrate daily query analysis job
- schedule via Dagster and Kubernetes CronJob
- test schedule configuration

## Testing
- `flake8 backend/orchestrator/orchestrator/jobs.py`
- `flake8 backend/orchestrator/orchestrator/ops.py`
- `flake8 backend/orchestrator/orchestrator/repository.py`
- `flake8 backend/orchestrator/orchestrator/schedules.py`
- `flake8 backend/orchestrator/tests/test_jobs.py`
- `flake8 scripts/analyze_query_plans.py`
- `mypy scripts/analyze_query_plans.py`
- `docformatter --in-place backend/orchestrator/orchestrator/schedules.py`
- `python -m pytest backend/orchestrator/tests/test_jobs.py -W error -vv` *(fails: SystemError: <class 'DeprecationWarning'> returned a result with an exception set)*
- `npm test` *(fails: Cannot find module jest.js)*

------
https://chatgpt.com/codex/tasks/task_b_687c2b31a1b4833196f44cd1ab82a704