### PR TITLE
Add RLS policies and session user handling

### DIFF
--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Any, Iterator
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import Session, sessionmaker
 
 from .base import Base
@@ -20,12 +20,28 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, futu
 
 @contextmanager
 def session_scope(username: str | None = None) -> Iterator[Session]:
-    """Return a transactional scope optionally setting RLS user."""
+    """
+    Return a transactional scope optionally setting RLS user.
+
+    When ``username`` is provided, the ``app.current_username`` setting is
+    configured on every transaction so that row-level security policies relying
+    on it are consistently enforced.
+    """
     session: Session = SessionLocal()
+
     if username is not None:
-        session.execute(
-            text("SET LOCAL app.current_username = :user"), {"user": username}
-        )
+
+        @event.listens_for(session, "after_begin")  # type: ignore[misc]
+        def _set_username(  # noqa: D401 -- event listener, not a docstring
+            _session: Session,
+            _transaction: Any,
+            connection: Any,
+        ) -> None:
+            connection.execute(
+                text("SET LOCAL app.current_username = :user"),
+                {"user": username},
+            )
+
     try:
         yield session
         session.commit()

--- a/backend/shared/db/migrations/api_gateway/versions/0007_add_audit_log_rls.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0007_add_audit_log_rls.py
@@ -1,0 +1,34 @@
+"""Add row-level security policy for audit_logs table."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0007"
+down_revision = "7165ae776380"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enable RLS on audit_logs table."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY audit_logs_is_self ON audit_logs
+        USING (username = current_setting('app.current_username')::text)
+        WITH CHECK (username = current_setting('app.current_username')::text)
+        """
+    )
+
+
+def downgrade() -> None:
+    """Disable RLS on audit_logs table."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("DROP POLICY IF EXISTS audit_logs_is_self ON audit_logs")
+    op.execute("ALTER TABLE audit_logs DISABLE ROW LEVEL SECURITY")

--- a/backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py
@@ -1,0 +1,57 @@
+"""Add row-level security policies for ideas and signals."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enable RLS on ideas and signals tables."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.add_column(
+        "ideas",
+        sa.Column("username", sa.String(length=50), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "signals",
+        sa.Column("username", sa.String(length=50), nullable=False, server_default=""),
+    )
+    op.execute("ALTER TABLE ideas ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY ideas_is_self ON ideas
+        USING (username = current_setting('app.current_username')::text)
+        WITH CHECK (username = current_setting('app.current_username')::text)
+        """
+    )
+    op.execute("ALTER TABLE signals ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY signals_is_self ON signals
+        USING (username = current_setting('app.current_username')::text)
+        WITH CHECK (username = current_setting('app.current_username')::text)
+        """
+    )
+    op.alter_column("ideas", "username", server_default=None)
+    op.alter_column("signals", "username", server_default=None)
+
+
+def downgrade() -> None:
+    """Remove RLS on ideas and signals tables."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("DROP POLICY IF EXISTS signals_is_self ON signals")
+    op.execute("ALTER TABLE signals DISABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS ideas_is_self ON ideas")
+    op.execute("ALTER TABLE ideas DISABLE ROW LEVEL SECURITY")
+    op.drop_column("signals", "username")
+    op.drop_column("ideas", "username")


### PR DESCRIPTION
## Summary
- add RLS policy migrations for ideas, signals and audit_logs tables
- keep `app.current_username` set on every transaction
- verify RLS enforcement for ideas, signals and audit logs

## Testing
- `flake8 backend/shared/db/__init__.py tests/test_rls.py backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0007_add_audit_log_rls.py`
- `mypy backend/shared/db/__init__.py tests/test_rls.py backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0007_add_audit_log_rls.py --follow-imports=skip --ignore-missing-imports`
- `pydocstyle backend/shared/db/__init__.py tests/test_rls.py backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0007_add_audit_log_rls.py`
- `docformatter --check backend/shared/db/__init__.py tests/test_rls.py backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0007_add_audit_log_rls.py`
- `npm install --silent`
- `npm test --silent` *(fails: Cannot find module 'frontend/admin-dashboard/node_modules/jest/bin/jest.js')*
- `pytest -W error -vv tests/test_rls.py` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_b_687c2b37b3ac8331b5231fd70bebc946