### PR TITLE
Add autoscaler templates to Helm charts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,12 @@ jobs:
         run: npm run lint
       - name: Run Flow
         run: npm run flow
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.12.3'
+      - name: Lint Helm charts
+        run: |
+          for chart in infrastructure/helm/*/Chart.yaml; do
+            helm lint "$(dirname "$chart")"
+          done

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,6 +32,14 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
    ```
 2. Provide environment variables via ConfigMaps and mount sensitive values using Kubernetes Secrets. The applications automatically load secrets from `/run/secrets`.
 3. Configure ingress and TLS termination for external access. An ingress controller such as NGINX is recommended.
+4. Deploy individual services using the Helm charts in `infrastructure/helm`. Each chart exposes
+   values for the container image tag, environment variables and optional horizontal pod
+   autoscaler settings:
+
+   ```bash
+   helm install orchestrator infrastructure/helm/orchestrator \
+     -f infrastructure/helm/orchestrator/values-dev.yaml
+   ```
 
 ## Cloud Providers
 

--- a/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
+++ b/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
@@ -25,3 +25,8 @@ spec:
             httpGet:
               path: /ready
               port: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/ai-mockup-generation/templates/hpa.yaml
+++ b/infrastructure/helm/ai-mockup-generation/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ai-mockup-generation.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ai-mockup-generation.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/ai-mockup-generation/values-dev.yaml
+++ b/infrastructure/helm/ai-mockup-generation/values-dev.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/ai-mockup-generation/values-prod.yaml
+++ b/infrastructure/helm/ai-mockup-generation/values-prod.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/ai-mockup-generation/values-staging.yaml
+++ b/infrastructure/helm/ai-mockup-generation/values-staging.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/ai-mockup-generation/values.yaml
+++ b/infrastructure/helm/ai-mockup-generation/values.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/all-services/values.yaml
+++ b/infrastructure/helm/all-services/values.yaml
@@ -8,6 +8,13 @@ signal-ingestion:
     type: ClusterIP
     port: 80
   resources: {}
+  env: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
 
 data-storage:
   replicaCount: 1
@@ -19,6 +26,13 @@ data-storage:
     type: ClusterIP
     port: 80
   resources: {}
+  env: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
 
 scoring-engine:
   replicaCount: 1
@@ -30,6 +44,13 @@ scoring-engine:
     type: ClusterIP
     port: 80
   resources: {}
+  env: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
 
 ai-mockup-generation:
   replicaCount: 1
@@ -41,6 +62,13 @@ ai-mockup-generation:
     type: ClusterIP
     port: 80
   resources: {}
+  env: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
 
 marketplace-publisher:
   replicaCount: 1
@@ -52,6 +80,13 @@ marketplace-publisher:
     type: ClusterIP
     port: 80
   resources: {}
+  env: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
 
 feedback-loop:
   replicaCount: 1
@@ -63,6 +98,13 @@ feedback-loop:
     type: ClusterIP
     port: 80
   resources: {}
+  env: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
 
 orchestrator:
   replicaCount: 1
@@ -74,6 +116,13 @@ orchestrator:
     type: ClusterIP
     port: 80
   resources: {}
+  env: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
 
 backup-jobs:
   image:

--- a/infrastructure/helm/backup-jobs/templates/cronjob.yaml
+++ b/infrastructure/helm/backup-jobs/templates/cronjob.yaml
@@ -19,4 +19,8 @@ spec:
                   value: {{ .Values.bucket | quote }}
                 - name: MINIO_DATA_PATH
                   value: {{ .Values.minioDataPath | quote }}
+{{- range $key, $value := .Values.extraEnv }}
+                - name: {{ $key }}
+                  value: {{ $value | quote }}
+{{- end }}
               command: ["python", "/app/backup.py"]

--- a/infrastructure/helm/backup-jobs/values-dev.yaml
+++ b/infrastructure/helm/backup-jobs/values-dev.yaml
@@ -5,3 +5,6 @@ image:
 schedule: "0 2 * * *"
 bucket: my-backup-bucket
 minioDataPath: /data
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/helm/backup-jobs/values-prod.yaml
+++ b/infrastructure/helm/backup-jobs/values-prod.yaml
@@ -5,3 +5,6 @@ image:
 schedule: "0 2 * * *"
 bucket: my-backup-bucket
 minioDataPath: /data
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/helm/backup-jobs/values-staging.yaml
+++ b/infrastructure/helm/backup-jobs/values-staging.yaml
@@ -5,3 +5,6 @@ image:
 schedule: "0 2 * * *"
 bucket: my-backup-bucket
 minioDataPath: /data
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/helm/backup-jobs/values.yaml
+++ b/infrastructure/helm/backup-jobs/values.yaml
@@ -5,3 +5,6 @@ image:
 schedule: "0 2 * * *"
 bucket: my-backup-bucket
 minioDataPath: /data
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/helm/data-storage/templates/deployment.yaml
+++ b/infrastructure/helm/data-storage/templates/deployment.yaml
@@ -17,3 +17,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/data-storage/templates/hpa.yaml
+++ b/infrastructure/helm/data-storage/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "data-storage.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "data-storage.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/data-storage/values-dev.yaml
+++ b/infrastructure/helm/data-storage/values-dev.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/data-storage/values-prod.yaml
+++ b/infrastructure/helm/data-storage/values-prod.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/data-storage/values-staging.yaml
+++ b/infrastructure/helm/data-storage/values-staging.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/data-storage/values.yaml
+++ b/infrastructure/helm/data-storage/values.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/feedback-loop/templates/deployment.yaml
+++ b/infrastructure/helm/feedback-loop/templates/deployment.yaml
@@ -25,3 +25,8 @@ spec:
             httpGet:
               path: /ready
               port: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/feedback-loop/templates/hpa.yaml
+++ b/infrastructure/helm/feedback-loop/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "feedback-loop.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "feedback-loop.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/feedback-loop/values-dev.yaml
+++ b/infrastructure/helm/feedback-loop/values-dev.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/feedback-loop/values-prod.yaml
+++ b/infrastructure/helm/feedback-loop/values-prod.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/feedback-loop/values-staging.yaml
+++ b/infrastructure/helm/feedback-loop/values-staging.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/feedback-loop/values.yaml
+++ b/infrastructure/helm/feedback-loop/values.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/marketplace-publisher/templates/deployment.yaml
+++ b/infrastructure/helm/marketplace-publisher/templates/deployment.yaml
@@ -25,3 +25,8 @@ spec:
             httpGet:
               path: /ready
               port: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/marketplace-publisher/templates/hpa.yaml
+++ b/infrastructure/helm/marketplace-publisher/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "marketplace-publisher.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "marketplace-publisher.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/marketplace-publisher/values-dev.yaml
+++ b/infrastructure/helm/marketplace-publisher/values-dev.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/marketplace-publisher/values-prod.yaml
+++ b/infrastructure/helm/marketplace-publisher/values-prod.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/marketplace-publisher/values-staging.yaml
+++ b/infrastructure/helm/marketplace-publisher/values-staging.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/marketplace-publisher/values.yaml
+++ b/infrastructure/helm/marketplace-publisher/values.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/orchestrator/templates/deployment.yaml
+++ b/infrastructure/helm/orchestrator/templates/deployment.yaml
@@ -25,3 +25,8 @@ spec:
             httpGet:
               path: /ready
               port: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/orchestrator/templates/hpa.yaml
+++ b/infrastructure/helm/orchestrator/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "orchestrator.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/orchestrator/values-dev.yaml
+++ b/infrastructure/helm/orchestrator/values-dev.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/orchestrator/values-prod.yaml
+++ b/infrastructure/helm/orchestrator/values-prod.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/orchestrator/values-staging.yaml
+++ b/infrastructure/helm/orchestrator/values-staging.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/orchestrator/values.yaml
+++ b/infrastructure/helm/orchestrator/values.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/scoring-engine/templates/deployment.yaml
+++ b/infrastructure/helm/scoring-engine/templates/deployment.yaml
@@ -25,3 +25,8 @@ spec:
             httpGet:
               path: /ready
               port: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/scoring-engine/templates/hpa.yaml
+++ b/infrastructure/helm/scoring-engine/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "scoring-engine.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "scoring-engine.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/scoring-engine/values-dev.yaml
+++ b/infrastructure/helm/scoring-engine/values-dev.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/scoring-engine/values-prod.yaml
+++ b/infrastructure/helm/scoring-engine/values-prod.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/scoring-engine/values-staging.yaml
+++ b/infrastructure/helm/scoring-engine/values-staging.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/scoring-engine/values.yaml
+++ b/infrastructure/helm/scoring-engine/values.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/signal-ingestion/templates/deployment.yaml
+++ b/infrastructure/helm/signal-ingestion/templates/deployment.yaml
@@ -25,3 +25,8 @@ spec:
             httpGet:
               path: /ready
               port: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/signal-ingestion/templates/hpa.yaml
+++ b/infrastructure/helm/signal-ingestion/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "signal-ingestion.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "signal-ingestion.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/signal-ingestion/values-dev.yaml
+++ b/infrastructure/helm/signal-ingestion/values-dev.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/signal-ingestion/values-prod.yaml
+++ b/infrastructure/helm/signal-ingestion/values-prod.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/signal-ingestion/values-staging.yaml
+++ b/infrastructure/helm/signal-ingestion/values-staging.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/signal-ingestion/values.yaml
+++ b/infrastructure/helm/signal-ingestion/values.yaml
@@ -7,3 +7,14 @@ service:
   type: ClusterIP
   port: 80
 resources: {}
+
+# Environment variables
+env: {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70


### PR DESCRIPTION
## Summary
- allow configuring image tags and environment variables in Helm values
- add HorizontalPodAutoscaler template for each service
- document Helm chart usage
- lint Helm charts in CI

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `npm ci --legacy-peer-deps`
- `pytest -W error -q` *(fails: TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_b_687c2b2931d48331885743c6c357232f