### PR TITLE
Add Alembic merge docs

### DIFF
--- a/backend/shared/db/migrations/example_merge_revision.py
+++ b/backend/shared/db/migrations/example_merge_revision.py
@@ -1,0 +1,18 @@
+"""Example Alembic merge revision."""
+
+from __future__ import annotations
+
+revision = "0001_example_merge"
+down_revision = ("0001a", "0001b")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge branches by creating an empty revision."""
+    pass
+
+
+def downgrade() -> None:
+    """Reverse the merge revision."""
+    pass

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -37,6 +37,26 @@ alembic -c backend/shared/db/<config>.ini merge -m "merge heads" HEADS
 
 Commit the resulting merge file so that the migration chain has a single head.
 
+## Generating a Merge Revision
+
+Use the ``heads`` command to inspect whether multiple heads exist:
+
+```bash
+alembic -c backend/shared/db/alembic_scoring_engine.ini heads
+```
+
+If more than one head is present, specify each head when creating a merge
+revision:
+
+```bash
+alembic -c backend/shared/db/alembic_scoring_engine.ini merge \
+  -m "merge heads" HEADS
+```
+
+The new revision resembles
+`backend/shared/db/migrations/example_merge_revision.py` and keeps the history
+linear.
+
 ## Verifying Migrations
 
 Run the migration tests to ensure each service's migrations apply cleanly on an


### PR DESCRIPTION
## Summary
- document how to generate a merge migration
- provide example merge revision

## Testing
- `black backend/shared/db/migrations/example_merge_revision.py`
- `flake8 backend/shared/db/migrations/example_merge_revision.py`
- `pydocstyle backend/shared/db/migrations/example_merge_revision.py`
- `mypy backend/shared/db/migrations/example_merge_revision.py --strict --ignore-missing-imports` *(fails: missing types in other modules)*
- `pytest -k migrations -vv` *(fails: 77 errors during collection)*
- `pre-commit run --files docs/migrations.md backend/shared/db/migrations/example_merge_revision.py` *(failed: asked for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_b_687c2e57306c833180f4cc297f5e9c2b