### PR TITLE
Add OTEL collector config

### DIFF
--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -5,22 +5,30 @@ from __future__ import annotations
 from fastapi import FastAPI
 from flask import Flask
 from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter as OTLPGrpcSpanExporter,
+)
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter as OTLPHTTPSpanExporter,
+)
 import os
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 
 def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     """Configure basic tracing for ``app``."""
     resource = Resource.create({"service.name": service_name})
     provider = TracerProvider(resource=resource)
-    exporter = OTLPSpanExporter(
-        endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
-    )
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+    protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    if protocol == "grpc":
+        exporter = OTLPGrpcSpanExporter(endpoint=endpoint)
+    else:
+        exporter = OTLPHTTPSpanExporter(endpoint=endpoint)
     processor = BatchSpanProcessor(exporter)
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
@@ -28,4 +36,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]
+        FlaskInstrumentor().instrument_app(app)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -133,6 +133,14 @@ services:
       - "prometheus.path=/metrics"
       - "prometheus.port=8000"
 
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    profiles:
+      - monitoring
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
   loki:
     image: grafana/loki:latest
     profiles:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -130,6 +130,14 @@ services:
       - "prometheus.path=/metrics"
       - "prometheus.port=8000"
 
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    profiles:
+      - monitoring
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
   loki:
     image: grafana/loki:latest
     profiles:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -24,3 +24,8 @@ services:
       service: kafka
     environment:
       KAFKA_BROKER_ID: 99
+
+  otel-collector:
+    extends:
+      file: docker-compose.dev.yml
+      service: otel-collector

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,14 @@ services:
       - "prometheus.path=/metrics"
       - "prometheus.port=8000"
 
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    profiles:
+      - monitoring
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
   loki:
     image: grafana/loki:latest
     profiles:

--- a/docs/logs_with_loki.md
+++ b/docs/logs_with_loki.md
@@ -5,3 +5,10 @@ messages to a Loki instance. Set the ``LOKI_URL`` environment variable to the
 Loki HTTP endpoint (e.g. ``http://loki:3100``) and each service will push JSON
 logs containing ``correlation_id`` and ``user`` fields. Docker Compose and the
 Kubernetes base manifests include a Loki service listening on port ``3100``.
+
+An ``otel-collector`` container is available in all Docker Compose
+configurations. Services send traces to this collector by setting the
+``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable to
+``http://otel-collector:4318``. The communication protocol can be adjusted with
+``OTEL_EXPORTER_OTLP_PROTOCOL`` which defaults to ``http/protobuf``. Both HTTP
+``4318`` and gRPC ``4317`` ports are exposed by the collector.


### PR DESCRIPTION
## Summary
- use env var for OTEL collector endpoint and protocol
- run OTEL collector container in docker-compose files
- document tracing setup for Loki/OTEL

## Testing
- `flake8 backend/shared/tracing.py`
- `mypy backend/shared/tracing.py --ignore-missing-imports --follow-imports=skip`
- `docformatter --in-place backend/shared/tracing.py docs/logs_with_loki.md`
- `make test` *(fails: docker not found)*
- `sphinx-build -b html docs docs/_build` *(fails: missing docs dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687c2e57dc208331a9d2ee1ac8208529