### PR TITLE
Refactor JWT auth utilities

### DIFF
--- a/backend/analytics/auth.py
+++ b/backend/analytics/auth.py
@@ -2,60 +2,24 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime
 from typing import Any, Dict, Callable, cast
-from uuid import uuid4
 
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
 from sqlalchemy import select
 
+from backend.shared.auth import jwt as shared_jwt
 from backend.shared.db import session_scope
-from backend.shared.db.models import UserRole, RevokedToken
-from backend.shared.config import settings as shared_settings
+from backend.shared.db.models import UserRole
 
-SECRET_KEY = shared_settings.secret_key or "change_this"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
-
-auth_scheme = HTTPBearer()
-
-
-def create_access_token(data: Dict[str, Any]) -> str:
-    """Create a signed JWT access token with a unique ID."""
-    to_encode = data.copy()
-    expire = datetime.now(UTC) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    to_encode.update({"exp": expire, "jti": str(uuid4())})
-    return cast(str, jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM))
-
-
-def verify_token(
-    credentials: HTTPAuthorizationCredentials = Depends(auth_scheme),
-) -> Dict[str, Any]:
-    """Verify the provided JWT token and return its payload."""
-    token = credentials.credentials
-    try:
-        payload = cast(
-            Dict[str, Any], jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        )
-    except JWTError as exc:  # pragma: no cover - errors yield JWTError
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Invalid token",
-        ) from exc
-    jti = cast(str | None, payload.get("jti"))
-    if jti is not None:
-        with session_scope() as session:
-            exists = session.execute(
-                select(RevokedToken.id).where(RevokedToken.jti == jti)
-            ).scalar_one_or_none()
-        if exists is not None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Token revoked",
-            )
-    return payload
+# Re-export shared constants and helpers for backward compatibility
+create_access_token = shared_jwt.create_access_token
+verify_token = shared_jwt.verify_token
+revoke_token = shared_jwt.revoke_token
+auth_scheme = shared_jwt.auth_scheme
+SECRET_KEY = shared_jwt.SECRET_KEY
+ALGORITHM = shared_jwt.ALGORITHM
+ACCESS_TOKEN_EXPIRE_MINUTES = shared_jwt.ACCESS_TOKEN_EXPIRE_MINUTES
 
 
 def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
@@ -79,9 +43,3 @@ def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any
         return payload
 
     return _checker
-
-
-def revoke_token(jti: str, expires_at: datetime) -> None:
-    """Persist ``jti`` of a revoked token."""
-    with session_scope() as session:
-        session.add(RevokedToken(jti=jti, expires_at=expires_at))

--- a/backend/api-gateway/src/api_gateway/auth.py
+++ b/backend/api-gateway/src/api_gateway/auth.py
@@ -1,61 +1,23 @@
-"""JWT authentication utilities."""
+"""JWT authentication utilities for the API gateway."""
 
-from datetime import UTC, datetime, timedelta
-from typing import Any, Dict
-from uuid import uuid4
+from datetime import datetime
+from typing import Any, Dict, Callable, cast
 
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
 from sqlalchemy import select
-from typing import cast, Callable
 
+from backend.shared.auth import jwt as shared_jwt
 from backend.shared.db import session_scope
-from backend.shared.db.models import UserRole, RevokedToken
-from backend.shared.config import settings as shared_settings
+from backend.shared.db.models import UserRole
 
-
-SECRET_KEY = shared_settings.secret_key or "change_this"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
-
-auth_scheme = HTTPBearer()
-
-
-def create_access_token(data: Dict[str, Any]) -> str:
-    """Create a JWT token with a unique identifier."""
-    to_encode = data.copy()
-    expire = datetime.now(UTC) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    to_encode.update({"exp": expire, "jti": str(uuid4())})
-    return cast(str, jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM))
-
-
-def verify_token(
-    credentials: HTTPAuthorizationCredentials = Depends(auth_scheme),
-) -> Dict[str, Any]:
-    """Verify a JWT token and return the payload."""
-    token = credentials.credentials
-    try:
-        payload = cast(
-            Dict[str, Any], jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        )
-    except JWTError as exc:  # pragma: no cover
-        # jose raises JWTError for all issues
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-        ) from exc
-    jti = cast(str | None, payload.get("jti"))
-    if jti is not None:
-        with session_scope() as session:
-            exists = session.execute(
-                select(RevokedToken.id).where(RevokedToken.jti == jti)
-            ).scalar_one_or_none()
-        if exists is not None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Token revoked",
-            )
-    return payload
+# Re-export shared constants and helpers for backward compatibility
+create_access_token = shared_jwt.create_access_token
+verify_token = shared_jwt.verify_token
+revoke_token = shared_jwt.revoke_token
+auth_scheme = shared_jwt.auth_scheme
+SECRET_KEY = shared_jwt.SECRET_KEY
+ALGORITHM = shared_jwt.ALGORITHM
+ACCESS_TOKEN_EXPIRE_MINUTES = shared_jwt.ACCESS_TOKEN_EXPIRE_MINUTES
 
 
 def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
@@ -78,9 +40,3 @@ def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any
         return payload
 
     return _checker
-
-
-def revoke_token(jti: str, expires_at: datetime) -> None:
-    """Persist ``jti`` so the token cannot be used again."""
-    with session_scope() as session:
-        session.add(RevokedToken(jti=jti, expires_at=expires_at))

--- a/backend/shared/auth/jwt.py
+++ b/backend/shared/auth/jwt.py
@@ -1,0 +1,63 @@
+"""Shared JWT authentication utilities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Dict, Callable, cast
+from uuid import uuid4
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from sqlalchemy import select
+
+from backend.shared.db import session_scope
+from backend.shared.db.models import RevokedToken
+from backend.shared.config import settings as shared_settings
+
+SECRET_KEY = shared_settings.secret_key or "change_this"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+auth_scheme = HTTPBearer()
+
+
+def create_access_token(data: Dict[str, Any]) -> str:
+    """Return a signed JWT access token with a unique ``jti``."""
+    to_encode = data.copy()
+    expire = datetime.now(UTC) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire, "jti": str(uuid4())})
+    return cast(str, jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM))
+
+
+def verify_token(
+    credentials: HTTPAuthorizationCredentials = Depends(auth_scheme),
+) -> Dict[str, Any]:
+    """Validate ``credentials`` and return the decoded payload."""
+    token = credentials.credentials
+    try:
+        payload = cast(
+            Dict[str, Any], jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        )
+    except JWTError as exc:  # pragma: no cover - jose raises JWTError for any issue
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
+        ) from exc
+    jti = cast(str | None, payload.get("jti"))
+    if jti is not None:
+        with session_scope() as session:
+            exists = session.execute(
+                select(RevokedToken.id).where(RevokedToken.jti == jti)
+            ).scalar_one_or_none()
+        if exists is not None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Token revoked",
+            )
+    return payload
+
+
+def revoke_token(jti: str, expires_at: datetime) -> None:
+    """Persist ``jti`` so the token cannot be used again."""
+    with session_scope() as session:
+        session.add(RevokedToken(jti=jti, expires_at=expires_at))


### PR DESCRIPTION
## Summary
- centralize JWT helper functions under `backend/shared/auth/jwt.py`
- import shared helpers in analytics and API gateway auth modules

## Testing
- `flake8 backend/shared/auth/jwt.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py`
- `mypy backend/shared/auth/jwt.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py` *(fails: create_engine overload, missing stubs, etc.)*
- `pytest -q` *(fails: pkg_resources deprecation warning treated as error)*

------
https://chatgpt.com/codex/tasks/task_b_687c3bd4912c833189730f3691630f4e