### PR TITLE
Add trending endpoint

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -56,7 +56,7 @@ add_error_handlers(app)
 register_metrics(app)
 
 rate_limiter = UserRateLimiter(
-    Redis.from_url(settings.redis_url),
+    Redis.from_url(str(settings.redis_url)),
     settings.rate_limit_per_user,
     settings.rate_limit_window,
 )

--- a/backend/api-gateway/tests/test_trending.py
+++ b/backend/api-gateway/tests/test_trending.py
@@ -1,0 +1,33 @@
+"""Tests for trending keywords endpoint."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+sys.path.append(
+    str(Path(__file__).resolve().parents[2] / "signal-ingestion" / "src")
+)  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+import pytest  # noqa: E402
+
+import api_gateway.main as main_module  # noqa: E402
+import api_gateway.routes as routes  # noqa: E402
+
+client = TestClient(main_module.app)
+
+
+def test_trending_keywords(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return mocked popular keywords."""
+    monkeypatch.setattr(routes, "get_trending", lambda limit=10: ["foo", "bar"])
+    resp = client.get("/trending?limit=2")
+    assert resp.status_code == 200
+    assert resp.json() == ["foo", "bar"]
+
+
+def test_trending_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return empty list when no keywords available."""
+    monkeypatch.setattr(routes, "get_trending", lambda limit=10: [])
+    resp = client.get("/trending")
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -5,22 +5,26 @@ from __future__ import annotations
 from fastapi import FastAPI
 from flask import Flask
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-    OTLPSpanExporter as OTLPGrpcSpanExporter,
-)
+# The exporter classes are imported lazily within ``configure_tracing`` to avoid
+# heavy dependencies and noisy warnings during package import.
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-    OTLPSpanExporter as OTLPHTTPSpanExporter,
-)
 import os
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 
 def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     """Configure basic tracing for ``app``."""
+    if os.getenv("OTEL_SDK_DISABLED", "false").lower() in {"true", "1"}:
+        return
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter as OTLPGrpcSpanExporter,
+    )
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter as OTLPHTTPSpanExporter,
+    )
     resource = Resource.create({"service.name": service_name})
     provider = TracerProvider(resource=resource)
     endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")

--- a/backend/signal-ingestion/src/signal_ingestion/trending.py
+++ b/backend/signal-ingestion/src/signal_ingestion/trending.py
@@ -27,3 +27,10 @@ def store_keywords(keywords: Iterable[str]) -> None:
         pipe.zincrby(TRENDING_KEY, 1, word)
     pipe.expire(TRENDING_KEY, settings.trending_ttl)
     pipe.execute()
+
+
+def get_trending(limit: int = 10) -> list[str]:
+    """Return up to ``limit`` most popular keywords."""
+    client = get_sync_client()
+    words = client.zrevrange(TRENDING_KEY, 0, limit - 1)
+    return [w.decode("utf-8") if isinstance(w, bytes) else w for w in words]

--- a/docs/source/api/api-gateway.rst
+++ b/docs/source/api/api-gateway.rst
@@ -1,0 +1,5 @@
+API Gateway HTTP API
+====================
+
+``GET /trending``
+    Return the most popular keywords observed by the ingestion service.


### PR DESCRIPTION
## Summary
- support retrieving popular keywords from Redis in signal ingestion
- expose `/trending` route in the API gateway
- document the new endpoint
- test normal and empty cases for `/trending`
- make tracing opt‑out when OTEL_SDK_DISABLED is set
- fix Redis URL handling

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/trending.py backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_trending.py`
- `mypy backend/api-gateway/tests/test_trending.py` *(fails: found 2 errors in unmodified files)*
- `pytest backend/api-gateway/tests/test_trending.py -q` *(fails: coverage 37% < 80)*

------
https://chatgpt.com/codex/tasks/task_b_687c3bc750bc833184c0532c9f36aa41