### PR TITLE
Add API Gateway OpenAPI generation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ The `blueprints` folder contains the full system blueprint.
 - [Log Aggregation](logs_with_loki.md)
 - [GPU Mockup Generation](mockup_generation.md)
 - Kafka schemas under `schemas/` are loaded into the registry configured by `SCHEMA_REGISTRY_URL`.
+- OpenAPI schemas under `openapi/` can be regenerated with `python scripts/generate_openapi.py`.
 
 The `scripts` directory provides helper scripts for setting up storage and CDN resources:
 


### PR DESCRIPTION
## Summary
- stub `backend.shared.currency` dependencies when generating OpenAPI docs
- assert spec objects exist during OpenAPI generation
- document how to regenerate OpenAPI schemas

## Testing
- `flake8 scripts/generate_openapi.py`
- `mypy scripts/generate_openapi.py`
- `black scripts/generate_openapi.py`
- `pytest -W error` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_b_687c3ff2c96083318bba1cb7225d3522