### PR TITLE
Implement adapter whitelist support

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/ingestion.py
+++ b/backend/signal-ingestion/src/signal_ingestion/ingestion.py
@@ -12,7 +12,13 @@ from .tasks import ADAPTERS as TASK_ADAPTERS, schedule_ingestion
 
 
 async def ingest(session: AsyncSession) -> None:
-    """Schedule ingestion tasks for all adapters."""
+    """Schedule ingestion tasks for enabled adapters."""
     await purge_old_signals(session, settings.signal_retention_days)
-    adapter_names = list(TASK_ADAPTERS.keys())
-    await asyncio.to_thread(schedule_ingestion, adapter_names)
+    if settings.enabled_adapters is None:
+        adapter_names = list(TASK_ADAPTERS.keys())
+    else:
+        adapter_names = [
+            name for name in TASK_ADAPTERS.keys() if name in settings.enabled_adapters
+        ]
+    if adapter_names:
+        await asyncio.to_thread(schedule_ingestion, adapter_names)

--- a/backend/signal-ingestion/src/signal_ingestion/scheduler.py
+++ b/backend/signal-ingestion/src/signal_ingestion/scheduler.py
@@ -23,6 +23,8 @@ async def ingest_job() -> None:
 def create_scheduler() -> AsyncIOScheduler:
     """Return scheduler configured to run ingestion periodically."""
     scheduler = AsyncIOScheduler()
+    if settings.enabled_adapters is not None and not settings.enabled_adapters:
+        return scheduler
     scheduler.add_job(
         ingest_job,
         trigger=IntervalTrigger(minutes=settings.ingest_interval_minutes),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,3 +26,4 @@ application settings classes.
 | `LOG_LEVEL` | Logging verbosity |
 | `APPROVE_PUBLISHING` | Require publishing approval flag |
 | `ALLOWED_ORIGINS` | Comma separated whitelist of origins for CORS |
+| `ENABLED_ADAPTERS` | Comma separated list of ingestion adapters to run; if unset all adapters are used |


### PR DESCRIPTION
## Summary
- allow selecting adapters via ENABLED_ADAPTERS env var
- filter adapters in ingestion routine and scheduler
- document ENABLED_ADAPTERS configuration

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/signal-ingestion/src/signal_ingestion/scheduler.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `black --check backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/signal-ingestion/src/signal_ingestion/scheduler.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `mypy --follow-imports=skip backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/signal-ingestion/src/signal_ingestion/scheduler.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `pydocstyle backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/signal-ingestion/src/signal_ingestion/scheduler.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `docformatter --in-place docs/configuration.md`
- `pytest -W error backend/signal-ingestion/tests/test_scheduler.py` *(failed: Expected string or URL object)*


------
https://chatgpt.com/codex/tasks/task_b_687c42b8aa9c8331b44f156bb4e410bd