### PR TITLE
Add cleanup logic for mockup generation

### DIFF
--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -172,5 +172,6 @@ def generate_mockup(
                     "tags": metadata.tags,
                 }
             )
+        generator.cleanup()
 
     return results


### PR DESCRIPTION
## Summary
- release diffusion pipeline and CUDA memory via new `cleanup()` method
- clean up resources after each batch generation
- verify cleanup behaviour and update upload tests

## Testing
- `flake8 backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_performance.py backend/mockup-generation/tests/test_tasks_upload.py`
- `mypy --ignore-missing-imports backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_performance.py backend/mockup-generation/tests/test_tasks_upload.py` *(fails: Library stubs not installed, function missing annotations)*
- `pydocstyle backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_performance.py backend/mockup-generation/tests/test_tasks_upload.py`
- `docformatter --check backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_performance.py backend/mockup-generation/tests/test_tasks_upload.py`
- `npm run lint`
- `npm run lint:css`
- `npm run flow`
- `pytest -W ignore::DeprecationWarning -q` *(fails: 76 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687c4a501c0c8331be96274be6de6068