### PR TITLE
Add Selenium config and tests

### DIFF
--- a/backend/marketplace-publisher/config/marketplace_rules.yaml
+++ b/backend/marketplace-publisher/config/marketplace_rules.yaml
@@ -3,18 +3,38 @@ redbubble:
   max_width: 8000
   max_height: 8000
   upload_limit: 50
+  selectors:
+    url: "https://www.redbubble.com/upload"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"
 amazon_merch:
   max_file_size_mb: 25
   max_width: 15000
   max_height: 15000
   upload_limit: 100
+  selectors:
+    url: "https://merch.amazon.com/create"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"
 etsy:
   max_file_size_mb: 20
   max_width: 10000
   max_height: 10000
   upload_limit: 80
+  selectors:
+    url: "https://www.etsy.com/new"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"
 society6:
   max_file_size_mb: 15
   max_width: 10000
   max_height: 10000
   upload_limit: 70
+  selectors:
+    url: "https://www.society6.com/sell"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"

--- a/backend/marketplace-publisher/src/marketplace_publisher/rules.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rules.py
@@ -20,6 +20,7 @@ class MarketplaceRules:
     max_height: int
     upload_limit: int
     allowed_formats: list[str] | None = None
+    selectors: Mapping[str, str] | None = None
 
 
 class RulesRegistry:
@@ -53,6 +54,15 @@ def get_upload_limit(marketplace: Marketplace) -> int | None:
         raise RuntimeError(msg)
     rules = rules_registry.get(marketplace)
     return rules.upload_limit if rules else None
+
+
+def get_selectors(marketplace: Marketplace) -> Mapping[str, str] | None:
+    """Return Selenium selectors for ``marketplace`` if configured."""
+    if rules_registry is None:
+        msg = "rules not loaded"
+        raise RuntimeError(msg)
+    rules = rules_registry.get(marketplace)
+    return rules.selectors if rules else None
 
 
 def validate_mockup(marketplace: Marketplace, path: Path) -> None:

--- a/tests/test_selenium_e2e.py
+++ b/tests/test_selenium_e2e.py
@@ -1,0 +1,88 @@
+"""End-to-end tests for ``SeleniumFallback``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+import pytest
+
+from marketplace_publisher.clients import SeleniumFallback
+from marketplace_publisher import rules
+from marketplace_publisher.db import Marketplace
+import selenium.webdriver
+
+
+@pytest.fixture(autouse=True)
+def _enable_selenium(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Use the real Firefox driver for these tests."""
+    monkeypatch.delenv("SELENIUM_SKIP", raising=False)
+    monkeypatch.setattr(
+        "selenium.webdriver.Firefox",
+        selenium.webdriver.Firefox,
+        raising=False,
+    )
+
+
+def _write_rules(tmp_path: Path, page: Path, bad: bool = False) -> Path:
+    """Return rules file path with selectors for the test page."""
+    selectors = {
+        "url": page.as_uri(),
+        "upload_input": "#upload" if not bad else "#missing",
+        "title_input": "#title",
+        "submit_button": "#submit",
+    }
+    data = {
+        "redbubble": {
+            "max_file_size_mb": 10,
+            "max_width": 8000,
+            "max_height": 8000,
+            "upload_limit": 50,
+            "selectors": selectors,
+        }
+    }
+    path = tmp_path / "rules.yaml"
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+def _write_page(tmp_path: Path) -> Path:
+    """Write a simple HTML page used by tests and return its path."""
+    page = tmp_path / "page.html"
+    page.write_text(
+        """
+        <html>
+        <body>
+        <input type='file' id='upload'/>
+        <input type='text' id='title'/>
+        <button id='submit' onclick="this.setAttribute('data-clicked','1')">Submit</button>
+        </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    return page
+
+
+def test_selenium_publish_success(tmp_path: Path) -> None:
+    """Publishing with valid selectors should not create screenshots."""
+    page = _write_page(tmp_path)
+    rules_path = _write_rules(tmp_path, page)
+    rules.load_rules(rules_path)
+    design = tmp_path / "design.png"
+    design.write_text("img")
+    fallback = SeleniumFallback(screenshot_dir=tmp_path)
+    fallback.publish(Marketplace.redbubble, design, {"title": "t"})
+    assert not list(tmp_path.glob("*.png"))
+
+
+def test_selenium_publish_failure_with_screenshot(tmp_path: Path) -> None:
+    """Failures should store a screenshot in the specified directory."""
+    page = _write_page(tmp_path)
+    rules_path = _write_rules(tmp_path, page, bad=True)
+    rules.load_rules(rules_path)
+    design = tmp_path / "design.png"
+    design.write_text("img")
+    fallback = SeleniumFallback(screenshot_dir=tmp_path)
+    with pytest.raises(Exception):
+        fallback.publish(Marketplace.redbubble, design, {"title": "t"})
+    assert list(tmp_path.glob("*.png"))


### PR DESCRIPTION
## Summary
- configure per-marketplace Selenium selectors in `marketplace_rules.yaml`
- expose selectors via `get_selectors`
- automate browser actions with retries and screenshots
- add headless Selenium e2e tests

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/rules.py tests/test_selenium_e2e.py`
- `mypy --config-file pyproject.toml backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/rules.py tests/test_selenium_e2e.py` *(fails: Library stubs not installed)*
- `PYTHONPATH=backend/marketplace-publisher/src pytest -W error -vv tests/test_selenium_e2e.py` *(fails: ModuleNotFoundError: No module named 'selenium.webdriver.firefox')*
- `npm install --legacy-peer-deps --ignore-scripts`
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_687c4a6086788331824fe369be72534d