### PR TITLE
Instrument gpu_slot and document metrics

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -33,3 +33,13 @@ Each service scales between two and five replicas based on CPU and memory usage.
 The `signal-ingestion` deployment also reacts to queue pressure using a custom
 `celery_queue_length` metric.  When the average queue length exceeds 30 pending
 tasks, additional workers are spawned automatically.
+
+## GPU Slot Metrics
+
+GPU-bound workloads now expose lock usage information through Prometheus.
+The context manager `tasks.gpu_slot` updates two metrics:
+
+- ``gpu_slots_in_use`` – a gauge tracking the number of acquired GPU locks.
+- ``gpu_slot_acquire_total`` – a counter incremented whenever a slot is obtained.
+
+These metrics appear alongside existing ones on the ``/metrics`` endpoint.


### PR DESCRIPTION
## Summary
- add Prometheus gauge and counter for `gpu_slot`
- expose metrics on existing `/metrics` endpoint
- document new GPU slot metrics in performance docs

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py`
- `black backend/mockup-generation/mockup_generation/tasks.py`
- `docformatter -i docs/performance.md`
- `python -m pytest backend/mockup-generation/tests/test_gpu_lock.py::test_gpu_slot -vv` *(fails: ResponseError from fakeredis)*

------
https://chatgpt.com/codex/tasks/task_b_687c4e7eaed48331ae42e50c1a878c90