### PR TITLE
Enable dynamic rules reload

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -84,7 +84,7 @@ async def startup() -> None:
         / "config"
         / "marketplace_rules.yaml"
     )
-    load_rules(rules_path)
+    load_rules(rules_path, watch=True)
     init_feature_flags()
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ mypy
 pydocstyle
 flake8-docstrings
 docformatter
+watchdog
 vcrpy
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ opentelemetry-exporter-jaeger
 apscheduler
 pgvector
 watchtower
+watchdog
 Flask
 pydantic-settings
 psycopg2-binary

--- a/tests/test_rules_watcher.py
+++ b/tests/test_rules_watcher.py
@@ -1,0 +1,71 @@
+"""Test automatic reloading of marketplace rules."""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Iterator
+import types
+from enum import Enum
+
+sys.path.append(
+    str(
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "marketplace-publisher"
+        / "src"
+    )
+)
+
+
+class _Marketplace(str, Enum):
+    redbubble = "redbubble"
+
+
+stub_db = types.ModuleType("marketplace_publisher.db")
+stub_db.Marketplace = _Marketplace  # type: ignore[attr-defined]
+sys.modules["marketplace_publisher.db"] = stub_db
+
+import pytest
+
+from marketplace_publisher import rules
+
+Marketplace = _Marketplace
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _stop_watcher() -> Iterator[None]:
+    """Stop watcher after each test."""
+    yield
+    rules.stop_watching_rules()
+
+
+def _write_rules(path: Path, limit: int) -> None:
+    path.write_text(
+        (
+            "redbubble:\n"
+            f"  max_file_size_mb: 10\n"
+            f"  max_width: 100\n"
+            f"  max_height: 100\n"
+            f"  upload_limit: {limit}\n"
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_reload_on_change(tmp_path: Path) -> None:
+    """Rules should reload when the file changes."""
+    rules_path = tmp_path / "rules.yaml"
+    _write_rules(rules_path, 5)
+    rules.load_rules(rules_path, watch=True)
+    assert rules.get_upload_limit(Marketplace.redbubble) == 5
+
+    _write_rules(rules_path, 7)
+    # give watchdog some time to process the event
+    for _ in range(10):
+        if rules.get_upload_limit(Marketplace.redbubble) == 7:
+            break
+        time.sleep(0.1)
+
+    assert rules.get_upload_limit(Marketplace.redbubble) == 7


### PR DESCRIPTION
## Summary
- watch marketplace rules file with watchdog for automatic reloads
- start watcher on service startup
- add unit test for rule reloading logic
- include watchdog dependency

## Testing
- `mypy backend/marketplace-publisher/src/marketplace_publisher/rules.py tests/test_rules_watcher.py --ignore-missing-imports --follow-imports=skip`
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/rules.py tests/test_rules_watcher.py`
- `pytest tests/test_rules_watcher.py -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_b_687c4e816b248331b15329ff3674b0bc