### PR TITLE
feat: improve notification reliability

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import Any
@@ -16,27 +17,45 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-def notify_failure(task_id: int, marketplace: str) -> None:
-    """Send Slack and PagerDuty alerts about a failed publish task."""
-    webhook = os.getenv("SLACK_WEBHOOK_URL")
+async def _dispatch_notifications(task_id: int, marketplace: str) -> None:
+    """Send Slack and PagerDuty alerts in the background."""
     payload: dict[str, Any] = {
         "text": f"Publish task {task_id} failed for {marketplace}",
     }
-    if webhook:
+    webhook = os.getenv("SLACK_WEBHOOK_URL")
+
+    async def slack() -> None:
+        if not webhook:
+            return
         try:
-            requests.post(webhook, json=payload, timeout=5)
+            await asyncio.to_thread(
+                requests.post, webhook, json=payload, timeout=2
+            )
         except requests.RequestException as exc:  # pragma: no cover - best effort
             logger.warning("notification failed: %s", exc)
 
-    try:  # Import lazily so monitoring is optional
-        from monitoring.pagerduty import notify_listing_issue
-    except Exception as exc:  # pragma: no cover - optional dependency
-        logger.debug("pagerduty unavailable: %s", exc)
-    else:
+    async def pagerduty() -> None:
         try:
-            notify_listing_issue(task_id, "failed")
+            from monitoring.pagerduty import notify_listing_issue
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.debug("pagerduty unavailable: %s", exc)
+            return
+        try:
+            await asyncio.to_thread(notify_listing_issue, task_id, "failed")
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning("pagerduty notification failed: %s", exc)
+
+    await asyncio.gather(slack(), pagerduty())
+
+
+def notify_failure(task_id: int, marketplace: str) -> None:
+    """Schedule notifications about a failed publish task."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning("no running loop to send notifications")
+        return
+    loop.create_task(_dispatch_notifications(task_id, marketplace))
 
 
 async def record_webhook(session: AsyncSession, task_id: int, status: str) -> None:

--- a/backend/marketplace-publisher/tests/test_notifications.py
+++ b/backend/marketplace-publisher/tests/test_notifications.py
@@ -17,11 +17,19 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
+import asyncio
+import logging
+
+import pytest
+import responses
+import requests
+
 from marketplace_publisher import notifications  # noqa: E402
 from monitoring import pagerduty  # noqa: E402
 
 
-def test_notify_failure_sends_slack_and_pagerduty(monkeypatch: Any) -> None:
+@pytest.mark.asyncio()
+async def test_notify_failure_sends_slack_and_pagerduty(monkeypatch: Any) -> None:
     """notify_failure should POST to Slack and trigger PagerDuty."""
     sent: dict[str, Any] = {}
 
@@ -39,9 +47,52 @@ def test_notify_failure_sends_slack_and_pagerduty(monkeypatch: Any) -> None:
     monkeypatch.setenv("PAGERDUTY_ROUTING_KEY", "key")
     monkeypatch.setattr(notifications.requests, "post", fake_post)
     monkeypatch.setattr(pagerduty, "notify_listing_issue", fake_pd)
+    monkeypatch.setattr(asyncio, "to_thread", lambda func, *a, **kw: func(*a, **kw))
 
     notifications.notify_failure(7, "etsy")
+    await asyncio.sleep(0)
 
     assert sent["url"] == "http://slack"
     assert "7" in sent["json"]["text"]
     assert pd_calls == [(7, "failed")]
+
+
+@pytest.mark.asyncio()
+async def test_notify_failure_handles_timeout(monkeypatch: Any, caplog: pytest.LogCaptureFixture) -> None:
+    """Timeouts should be logged without raising exceptions."""
+    pd_calls: list[tuple[int, str]] = []
+
+    def fake_pd(listing_id: int, state: str) -> None:
+        pd_calls.append((listing_id, state))
+
+    caplog.set_level(logging.WARNING)
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.POST, "http://slack", body=requests.Timeout())
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://slack")
+        monkeypatch.setattr(pagerduty, "notify_listing_issue", fake_pd)
+        monkeypatch.setattr(asyncio, "to_thread", lambda func, *a, **kw: func(*a, **kw))
+        notifications.notify_failure(9, "etsy")
+        await asyncio.sleep(0)
+
+    assert pd_calls == [(9, "failed")]
+    assert "notification failed" in caplog.text
+
+
+@pytest.mark.asyncio()
+async def test_notify_failure_pagerduty_timeout(monkeypatch: Any, caplog: pytest.LogCaptureFixture) -> None:
+    """PagerDuty timeouts should be logged without raising exceptions."""
+    caplog.set_level(logging.WARNING)
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise requests.Timeout()
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.POST, "http://slack", json={})
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://slack")
+        monkeypatch.setattr(pagerduty, "notify_listing_issue", boom)
+        monkeypatch.setattr(asyncio, "to_thread", lambda func, *a, **kw: func(*a, **kw))
+        notifications.notify_failure(11, "etsy")
+        await asyncio.sleep(0)
+
+    assert "pagerduty notification failed" in caplog.text

--- a/docs/publish_tasks.md
+++ b/docs/publish_tasks.md
@@ -10,3 +10,4 @@ All edits and retries are recorded in the audit log.
 
 If `SLACK_WEBHOOK_URL` is configured, failed publish attempts send a Slack notification.
 When `PAGERDUTY_ROUTING_KEY` is set, the failure also triggers a PagerDuty alert.
+Both notifications run as background tasks with a short timeout so publishing is never blocked.


### PR DESCRIPTION
## Summary
- run Slack and PagerDuty alerts in background with short timeout
- note background notifications in docs
- cover timeouts with tests

## Testing
- `pre-commit run --files backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/marketplace-publisher/tests/test_notifications.py docs/publish_tasks.md` *(failed: Username for 'https://github.com')*
- `pytest backend/marketplace-publisher/tests/test_notifications.py -k test_notify_failure_sends_slack_and_pagerduty -vv -W error` *(failed to collect tests)*

------
https://chatgpt.com/codex/tasks/task_b_687c4e8c7b788331b40c903da13588de