### PR TITLE
Ensure Kafka consumer closed on shutdown

### DIFF
--- a/backend/shared/kafka/utils.py
+++ b/backend/shared/kafka/utils.py
@@ -57,3 +57,7 @@ class KafkaConsumerWrapper:
             schema = self._schemas[message.topic]
             validate(value, schema)
             yield message.topic, value
+
+    def close(self) -> None:
+        """Close the underlying Kafka consumer."""
+        self._consumer.close()


### PR DESCRIPTION
## Summary
- add `close()` to KafkaConsumerWrapper
- close Kafka consumer when scoring-engine shuts down
- test consumer shutdown closes the wrapper

## Testing
- `python -m pip install -r requirements.txt -r requirements-dev.txt`
- `python -m pip install sphinx myst-parser sphinxcontrib-mermaid`
- `sphinx-build -W -b html docs docs/_build/html` *(fails: AttributeError in marketplace_publisher settings)*
- `python -m pytest -W error -vv` *(fails: database connection errors)*


------
https://chatgpt.com/codex/tasks/task_b_687c5d3ccaec8331ac8b0ff0fc1206e8