### PR TITLE
Add PG aggregate setup for optimization

### DIFF
--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -100,6 +100,13 @@ async def start_metrics_collection() -> None:
     asyncio.create_task(_run())
 
 
+@app.on_event("startup")
+async def create_continuous_aggregate() -> None:
+    """Create hourly aggregate view if PostgreSQL is used."""
+    if not store._use_sqlite:
+        store.create_hourly_continuous_aggregate()
+
+
 class MetricIn(BaseModel):
     """Request body for submitting a resource metric."""
 

--- a/backend/optimization/tests/test_materialized_view.py
+++ b/backend/optimization/tests/test_materialized_view.py
@@ -1,0 +1,31 @@
+"""Tests for continuous aggregate creation on startup."""
+
+from __future__ import annotations
+
+import warnings
+import shutil
+import psycopg2
+import pytest
+from fastapi.testclient import TestClient
+from testing.postgresql import Postgresql
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+from backend.optimization import api as opt_api
+from backend.optimization.storage import MetricsStore
+
+
+@pytest.mark.skipif(shutil.which("initdb") is None, reason="initdb not available")
+def test_materialized_view_created() -> None:
+    """Ensure the hourly aggregate view exists after startup."""
+    with Postgresql() as pg:
+        url = pg.url()
+        opt_api.store = MetricsStore(url)
+        with TestClient(opt_api.app):
+            pass
+        with psycopg2.connect(url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM pg_matviews WHERE matviewname='metrics_hourly'"
+                )
+                assert cur.fetchone() is not None


### PR DESCRIPTION
## Summary
- create hourly metrics aggregation view in PG
- invoke aggregate creation on service startup
- ensure aggregate creation when PG is available

## Testing
- `flake8 backend/optimization/storage.py backend/optimization/api.py backend/optimization/tests/test_materialized_view.py`
- `black --check backend/optimization/storage.py backend/optimization/api.py backend/optimization/tests/test_materialized_view.py`
- `pydocstyle backend/optimization/storage.py backend/optimization/api.py backend/optimization/tests/test_materialized_view.py`
- `docformatter --check backend/optimization/storage.py backend/optimization/api.py backend/optimization/tests/test_materialized_view.py`
- `mypy backend/optimization/api.py backend/optimization/storage.py --ignore-missing-imports` *(fails: see logs)*
- `python -m pytest backend/optimization/tests/test_materialized_view.py -W error -vv` *(skipped: initdb not available)*
- `python -m pytest -W error -vv` *(fails: many import errors)*

------
https://chatgpt.com/codex/tasks/task_b_687c6796a4748331b4afe5ef11f3a53a