### PR TITLE
Implement daily AB test summary

### DIFF
--- a/backend/feedback-loop/feedback_loop/scheduler.py
+++ b/backend/feedback-loop/feedback_loop/scheduler.py
@@ -43,6 +43,10 @@ def setup_scheduler(
         weights = update_weights_from_db(scoring_api)
         logger.info("updated marketplace weights %s", weights)
 
+    def daily_summary() -> None:
+        ab_manager.record_summary()
+        logger.info("recorded daily A/B test summary")
+
     scheduler.add_job(hourly_ingest, "interval", hours=1, next_run_time=None)
     # Run weight update a few minutes after the midnight ingestion so the
     # latest metrics are available before updating the scoring engine.
@@ -52,6 +56,13 @@ def setup_scheduler(
         "cron",
         hour=1,
         minute=0,
+        next_run_time=None,
+    )
+    scheduler.add_job(
+        daily_summary,
+        "cron",
+        hour=0,
+        minute=10,
         next_run_time=None,
     )
     if listing_ids:

--- a/backend/feedback-loop/tests/test_ab_testing.py
+++ b/backend/feedback-loop/tests/test_ab_testing.py
@@ -17,3 +17,20 @@ def test_budget_allocation(tmp_path) -> None:
         manager.record_result("B", False)
     allocation = manager.allocate_budget(total_budget=100.0)
     assert allocation.variant_a > allocation.variant_b
+
+
+def test_record_summary(tmp_path) -> None:
+    """Daily summary aggregates conversions for each variant."""
+    manager = ABTestManager(database_url=f"sqlite:///{tmp_path}/abtest.db")
+    for _ in range(3):
+        manager.record_result("A", True)
+    for _ in range(2):
+        manager.record_result("B", True)
+    manager.record_result("B", False)
+
+    manager.record_summary()
+
+    with manager.session_scope() as session:
+        summary = session.query(manager.daily_summary_class).one()
+        assert summary.conversions_a == 3
+        assert summary.conversions_b == 2

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@
 from tests.conftest import *  # noqa: F401,F403
 import warnings
 import os
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 import redis
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -60,6 +60,10 @@ sys.modules.setdefault(
     "opentelemetry.trace",
     SimpleNamespace(set_tracer_provider=lambda *a, **k: None),
 )
+
+# Stub LaunchDarkly client to avoid heavy dependency.
+ld_mod = sys.modules.setdefault("ldclient", ModuleType("ldclient"))
+ld_mod.LDClient = object
 
 os.makedirs("/run/secrets", exist_ok=True)
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")


### PR DESCRIPTION
## Summary
- extend ABTestManager with daily summary table
- record daily summary in scheduler
- test daily summary aggregation
- stub LaunchDarkly in test config

## Testing
- `flake8 backend/feedback-loop/feedback_loop/ab_testing.py backend/feedback-loop/feedback_loop/scheduler.py backend/feedback-loop/tests/test_ab_testing.py conftest.py`
- `mypy backend/feedback-loop/feedback_loop/ab_testing.py backend/feedback-loop/feedback_loop/scheduler.py --explicit-package-bases`
- `pytest backend/feedback-loop/tests/test_ab_testing.py -W error -vv --cov backend/feedback-loop/feedback_loop/ab_testing.py --cov backend/feedback-loop/tests/test_ab_testing.py --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_b_687c6790c77883319675820dce838ba3