### PR TITLE
Implement /stats endpoint

### DIFF
--- a/backend/feedback-loop/feedback_loop/ab_testing.py
+++ b/backend/feedback-loop/feedback_loop/ab_testing.py
@@ -105,6 +105,19 @@ class ABTestManager:
         with self.session_scope() as session:
             session.add(TestResult(variant=variant, success=success))
 
+    def conversion_totals(self) -> Mapping[str, int]:
+        """Return cumulative conversions for each variant."""
+        with self.session_scope() as session:
+            results = session.execute(
+                select(TestResult.variant, func.count())
+                .where(TestResult.success.is_(True))
+                .group_by(TestResult.variant)
+            ).all()
+        totals: dict[str, int] = {"A": 0, "B": 0}
+        for variant, count in results:
+            totals[variant] = int(count)
+        return totals
+
     def _variant_stats(self) -> Mapping[str, tuple[int, int]]:
         """Return successes and failures for each variant."""
         with self.session_scope() as session:

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -34,6 +34,13 @@ class AllocationResponse(BaseModel):
     variant_b: float
 
 
+class StatsResponse(BaseModel):
+    """Conversion totals for A/B test variants."""
+
+    conversions_a: int
+    conversions_b: int
+
+
 manager = ABTestManager(
     database_url=os.environ.get("ABTEST_DB_URL", "sqlite:///abtest.db")
 )
@@ -106,6 +113,16 @@ async def get_allocation(total_budget: float = 100.0) -> AllocationResponse:
     allocation = manager.allocate_budget(total_budget)
     return AllocationResponse(
         variant_a=allocation.variant_a, variant_b=allocation.variant_b
+    )
+
+
+@app.get("/stats", response_model=StatsResponse)
+async def get_stats() -> StatsResponse:
+    """Return total conversions for both variants."""
+    totals = manager.conversion_totals()
+    return StatsResponse(
+        conversions_a=totals["A"],
+        conversions_b=totals["B"],
     )
 
 

--- a/backend/feedback-loop/tests/test_main.py
+++ b/backend/feedback-loop/tests/test_main.py
@@ -25,3 +25,18 @@ def test_impression_conversion_allocation(tmp_path) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert set(data) == {"variant_a", "variant_b"}
+
+
+def test_stats_endpoint(tmp_path) -> None:
+    """/stats should return conversion totals."""
+    main.manager = ABTestManager(database_url="sqlite:///:memory:")
+    client = TestClient(main.app)
+
+    for _ in range(3):
+        client.post("/conversion", params={"variant": "A"})
+    for _ in range(2):
+        client.post("/conversion", params={"variant": "B"})
+
+    resp = client.get("/stats")
+    assert resp.status_code == 200
+    assert resp.json() == {"conversions_a": 3, "conversions_b": 2}

--- a/docs/api/microservices_endpoints.rst
+++ b/docs/api/microservices_endpoints.rst
@@ -93,3 +93,21 @@ weights requires the ``X-Weights-Token`` header::
        "seasonality": 0.1
    }
    -> 200
+
+Feedback Loop
+-------------
+
+Examples derived from ``backend/feedback-loop/tests/test_main.py``::
+
+   POST /impression?variant=A
+   -> 200
+   POST /conversion?variant=B
+   -> 200
+   GET /allocation?total_budget=100
+   -> 200
+   GET /stats
+   -> 200
+   {
+       "conversions_a": 3,
+       "conversions_b": 2
+   }

--- a/docs/openapi/feedback-loop.rst
+++ b/docs/openapi/feedback-loop.rst
@@ -1,0 +1,5 @@
+Feedback Loop API
+=================
+
+.. openapi:: ../../openapi/feedback-loop.json
+   :encoding: utf-8

--- a/docs/openapi_specs.rst
+++ b/docs/openapi_specs.rst
@@ -15,3 +15,5 @@ automatically generated using ``scripts/generate_openapi.py``.
    openapi/scoring-engine
    openapi/signal-ingestion
    openapi/mockup-generation
+   openapi/feedback-loop
+   openapi/workspace

--- a/openapi/feedback-loop.json
+++ b/openapi/feedback-loop.json
@@ -1,0 +1,307 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Feedback Loop",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/metrics": {
+      "get": {
+        "summary": "Metrics",
+        "operationId": "metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/impression": {
+      "post": {
+        "summary": "Record Impression",
+        "description": "Persist a variant impression.",
+        "operationId": "record_impression_impression_post",
+        "parameters": [
+          {
+            "name": "variant",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Variant"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Record Impression Impression Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/conversion": {
+      "post": {
+        "summary": "Record Conversion",
+        "description": "Persist a variant conversion.",
+        "operationId": "record_conversion_conversion_post",
+        "parameters": [
+          {
+            "name": "variant",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Variant"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Record Conversion Conversion Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/allocation": {
+      "get": {
+        "summary": "Get Allocation",
+        "description": "Return promotion budget allocation using Thompson Sampling.",
+        "operationId": "get_allocation_allocation_get",
+        "parameters": [
+          {
+            "name": "total_budget",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": 100.0,
+              "title": "Total Budget"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllocationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats": {
+      "get": {
+        "summary": "Get Stats",
+        "description": "Return total conversions for both variants.",
+        "operationId": "get_stats_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AllocationResponse": {
+        "properties": {
+          "variant_a": {
+            "type": "number",
+            "title": "Variant A"
+          },
+          "variant_b": {
+            "type": "number",
+            "title": "Variant B"
+          }
+        },
+        "type": "object",
+        "required": [
+          "variant_a",
+          "variant_b"
+        ],
+        "title": "AllocationResponse",
+        "description": "Budget allocation response payload."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "StatsResponse": {
+        "properties": {
+          "conversions_a": {
+            "type": "integer",
+            "title": "Conversions A"
+          },
+          "conversions_b": {
+            "type": "integer",
+            "title": "Conversions B"
+          }
+        },
+        "type": "object",
+        "required": [
+          "conversions_a",
+          "conversions_b"
+        ],
+        "title": "StatsResponse",
+        "description": "Conversion totals for A/B test variants."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `conversion_totals` in ABTestManager
- expose GET `/stats` that returns total conversions per variant
- document the new endpoint and update OpenAPI specs
- provide unit tests for `/stats`

## Testing
- `pytest backend/feedback-loop/tests/test_main.py -q`
- `pre-commit` *(fails: attempts to fetch hooks from GitHub)*

------
https://chatgpt.com/codex/tasks/task_b_687c6c3dff4c83319e6ef36bad42db2c