### PR TITLE
Refactor Redis helpers

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from jose import JWTError, jwt
-from redis.asyncio import Redis
+from backend.shared.cache import get_async_client
 
 from .routes import router
 from backend.shared.tracing import configure_tracing
@@ -56,7 +56,7 @@ add_error_handlers(app)
 register_metrics(app)
 
 rate_limiter = UserRateLimiter(
-    Redis.from_url(str(settings.redis_url)),
+    get_async_client(),
     settings.rate_limit_per_user,
     settings.rate_limit_window,
 )

--- a/backend/api-gateway/src/api_gateway/rate_limiter.py
+++ b/backend/api-gateway/src/api_gateway/rate_limiter.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from redis.asyncio import Redis, WatchError
+from redis.asyncio import WatchError
+from backend.shared.cache import AsyncRedis
 
 
 class UserRateLimiter:
     """Manage request quotas for individual users."""
 
-    def __init__(self, redis: Redis, limit: int, window: int) -> None:
+    def __init__(self, redis: AsyncRedis, limit: int, window: int) -> None:
         """Instantiate the limiter with ``limit`` tokens per ``window`` seconds."""
         self._redis = redis
         self._limit = limit

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -27,7 +27,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from pydantic import BaseModel, ConfigDict
 
-from redis.asyncio import Redis
+from backend.shared.cache import get_async_client
 
 from sqlalchemy import func, update
 
@@ -72,7 +72,7 @@ def _identify_user(request: Request) -> str:
 
 
 rate_limiter = MarketplaceRateLimiter(
-    Redis.from_url(settings.redis_url),
+    get_async_client(),
     {
         Marketplace.redbubble: settings.rate_limit_redbubble,
         Marketplace.amazon_merch: settings.rate_limit_amazon_merch,

--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -8,7 +8,6 @@ from typing import Iterator
 import os
 import time
 
-import redis
 from redis.lock import Lock as RedisLock
 from celery import Task
 from prometheus_client import Counter, Gauge
@@ -59,7 +58,9 @@ GPU_LOCK_TIMEOUT = int(os.getenv("GPU_LOCK_TIMEOUT", "600"))
 GPU_QUEUE_PREFIX = os.getenv("GPU_QUEUE_PREFIX", "gpu")
 GPU_WORKER_INDEX = int(os.getenv("GPU_WORKER_INDEX", "-1"))
 
-redis_client = redis.Redis.from_url(REDIS_URL)
+from backend.shared.cache import SyncRedis, get_sync_client
+
+redis_client: SyncRedis = get_sync_client()
 
 generator = MockupGenerator()
 

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Coroutine, cast
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from redis.asyncio import Redis
+from backend.shared.cache import AsyncRedis, get_async_client
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
     Counter,
@@ -92,7 +92,7 @@ add_error_handlers(app)
 register_metrics(app)
 REDIS_URL = settings.redis_url
 CACHE_TTL_SECONDS = settings.score_cache_ttl
-redis_client = Redis.from_url(REDIS_URL)
+redis_client: AsyncRedis = get_async_client()
 start_centroid_scheduler()
 
 

--- a/backend/shared/cache.py
+++ b/backend/shared/cache.py
@@ -2,19 +2,62 @@
 
 from __future__ import annotations
 
+from typing import Any, Optional, TypeAlias
+
 import redis
 from redis import asyncio as aioredis
 
 from .config import settings
 
-__all__ = ["get_sync_client", "get_async_client"]
+SyncRedis: TypeAlias = redis.Redis
+AsyncRedis: TypeAlias = aioredis.Redis
+
+__all__ = [
+    "SyncRedis",
+    "AsyncRedis",
+    "get_sync_client",
+    "get_async_client",
+    "sync_get",
+    "sync_set",
+    "async_get",
+    "async_set",
+]
 
 
-def get_sync_client() -> redis.Redis:
+def get_sync_client() -> SyncRedis:
     """Return a synchronous Redis client."""
     return redis.Redis.from_url(settings.redis_url, decode_responses=True)
 
 
-def get_async_client() -> aioredis.Redis:
+def get_async_client() -> AsyncRedis:
     """Return an asynchronous Redis client."""
     return aioredis.Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def sync_get(key: str) -> Optional[str]:
+    """Return the value for ``key`` using the default synchronous client."""
+    return get_sync_client().get(key)
+
+
+def sync_set(key: str, value: str, ttl: int | None = None) -> None:
+    """Set ``key`` to ``value`` optionally expiring after ``ttl`` seconds."""
+    client = get_sync_client()
+    if ttl is None:
+        client.set(key, value)
+    else:
+        client.setex(key, ttl, value)
+
+
+async def async_get(key: str) -> Optional[str]:
+    """Return the value for ``key`` using the default asynchronous client."""
+    client = get_async_client()
+    return await client.get(key)
+
+
+async def async_set(key: str, value: str, ttl: int | None = None) -> None:
+    """Set ``key`` to ``value`` optionally expiring after ``ttl`` seconds."""
+    client = get_async_client()
+    if ttl is None:
+        await client.set(key, value)
+    else:
+        await client.setex(key, ttl, value)

--- a/backend/shared/currency.py
+++ b/backend/shared/currency.py
@@ -7,11 +7,11 @@ import logging
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Dict
 
+from backend.shared.cache import SyncRedis, get_sync_client
 from backend.shared.config import settings
 import os
 
 import requests
-import redis
 from apscheduler.schedulers.background import BackgroundScheduler
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ EXCHANGE_API_URL = os.environ.get(
 BASE_CURRENCY = os.environ.get("BASE_CURRENCY", "USD")
 REDIS_KEY = "exchange_rates"
 
-redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
+redis_client: SyncRedis = get_sync_client()
 scheduler = BackgroundScheduler()
 
 

--- a/backend/signal-ingestion/src/signal_ingestion/dedup.py
+++ b/backend/signal-ingestion/src/signal_ingestion/dedup.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import redis
-
+from backend.shared.cache import SyncRedis, get_sync_client
 from backend.shared.config import settings as shared_settings
 from .settings import settings
 
-redis_client = redis.Redis.from_url(shared_settings.redis_url, decode_responses=True)
+redis_client: SyncRedis = get_sync_client()
 BLOOM_KEY = "signals:bloom"
 
 


### PR DESCRIPTION
## Summary
- add typed helpers to cache module
- use helper clients in services

## Testing
- `flake8 backend/shared/cache.py backend/api-gateway/src/api_gateway/rate_limiter.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/dedup.py backend/mockup-generation/mockup_generation/tasks.py backend/shared/currency.py`
- `pydocstyle backend/shared/cache.py backend/api-gateway/src/api_gateway/rate_limiter.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/dedup.py backend/mockup-generation/mockup_generation/tasks.py backend/shared/currency.py`
- `pytest -q tests/test_latency_cache.py backend/signal-ingestion/tests/test_trending.py backend/mockup-generation/tests/test_gpu_lock.py backend/api-gateway/tests/test_rate_limit.py tests/test_concurrency.py backend/shared/tests/test_currency.py -q` *(fails: ModuleNotFoundError: No module named 'signal_ingestion')*

------
https://chatgpt.com/codex/tasks/task_b_687c723a6bc08331ae70c27c2983ce65