### PR TITLE
Add run failure alert sensor

### DIFF
--- a/backend/marketplace-publisher/tests/test_metrics.py
+++ b/backend/marketplace-publisher/tests/test_metrics.py
@@ -1,3 +1,5 @@
+"""Tests for marketplace metrics endpoints."""  # noqa: E402
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -8,6 +10,7 @@ import pytest
 
 @pytest.fixture()
 def _setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Create a temporary DB with sample metric."""
     async_url = f"sqlite+aiosqlite:///{tmp_path}/metrics.db"
     sync_url = f"sqlite:///{tmp_path}/metrics.db"
     monkeypatch.setenv("DATABASE_URL", async_url)
@@ -30,6 +33,7 @@ def _setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 def test_metrics_route(_setup) -> None:
+    """GET /metrics should return stored data."""
     app = _setup
     with TestClient(app) as client:
         resp = client.get("/metrics/1")

--- a/backend/marketplace-publisher/tests/test_notifications.py
+++ b/backend/marketplace-publisher/tests/test_notifications.py
@@ -1,3 +1,5 @@
+"""Tests for notification helpers."""  # noqa: E402
+
 from __future__ import annotations
 
 import sys
@@ -58,7 +60,9 @@ async def test_notify_failure_sends_slack_and_pagerduty(monkeypatch: Any) -> Non
 
 
 @pytest.mark.asyncio()
-async def test_notify_failure_handles_timeout(monkeypatch: Any, caplog: pytest.LogCaptureFixture) -> None:
+async def test_notify_failure_handles_timeout(
+    monkeypatch: Any, caplog: pytest.LogCaptureFixture
+) -> None:
     """Timeouts should be logged without raising exceptions."""
     pd_calls: list[tuple[int, str]] = []
 
@@ -80,8 +84,10 @@ async def test_notify_failure_handles_timeout(monkeypatch: Any, caplog: pytest.L
 
 
 @pytest.mark.asyncio()
-async def test_notify_failure_pagerduty_timeout(monkeypatch: Any, caplog: pytest.LogCaptureFixture) -> None:
-    """PagerDuty timeouts should be logged without raising exceptions."""
+async def test_notify_failure_pagerduty_timeout(
+    monkeypatch: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Handle PagerDuty timeouts gracefully."""
     caplog.set_level(logging.WARNING)
 
     def boom(*args: Any, **kwargs: Any) -> None:

--- a/backend/mockup-generation/tests/test_api_generate.py
+++ b/backend/mockup-generation/tests/test_api_generate.py
@@ -119,6 +119,8 @@ pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 class DummyResult:
+    """Return object from DummyCelery."""
+
     def __init__(self, id_: str) -> None:
         self.id = id_
 

--- a/backend/orchestrator/orchestrator/__init__.py
+++ b/backend/orchestrator/orchestrator/__init__.py
@@ -2,7 +2,7 @@
 
 from .jobs import cleanup_job, idea_job, backup_job
 from .schedules import daily_backup_schedule, hourly_cleanup_schedule
-from .sensors import idea_sensor
+from .sensors import idea_sensor, run_failure_notifier
 
 __all__ = [
     "idea_job",
@@ -11,4 +11,5 @@ __all__ = [
     "daily_backup_schedule",
     "hourly_cleanup_schedule",
     "idea_sensor",
+    "run_failure_notifier",
 ]

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -8,7 +8,7 @@ from .schedules import (
     hourly_cleanup_schedule,
     daily_query_plan_schedule,
 )
-from .sensors import idea_sensor
+from .sensors import idea_sensor, run_failure_notifier
 
 
 defs = Definitions(
@@ -18,5 +18,5 @@ defs = Definitions(
         hourly_cleanup_schedule,
         daily_query_plan_schedule,
     ],
-    sensors=[idea_sensor],
+    sensors=[idea_sensor, run_failure_notifier],
 )

--- a/backend/orchestrator/tests/test_failure_sensor.py
+++ b/backend/orchestrator/tests/test_failure_sensor.py
@@ -1,0 +1,43 @@
+"""Tests for run failure sensor notifications."""  # noqa: E402
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))
+
+from dagster import DagsterInstance, build_run_status_sensor_context
+
+from orchestrator.jobs import idea_job  # noqa: E402
+from orchestrator.sensors import run_failure_notifier  # noqa: E402
+
+
+@pytest.mark.asyncio()
+async def test_run_failure_notifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sensor should trigger PagerDuty alert on failure."""
+    calls: list[tuple[int, str]] = []
+
+    def fake_notify(listing_id: int, state: str) -> None:  # noqa: D401
+        calls.append((listing_id, state))
+
+    monkeypatch.setattr("orchestrator.sensors.notify_listing_issue", fake_notify)
+    monkeypatch.delenv("APPROVE_PUBLISHING", raising=False)
+
+    instance = DagsterInstance.ephemeral()
+    result = idea_job.execute_in_process(instance=instance, raise_on_error=False)
+    assert not result.success
+
+    event = result.get_run_failure_event()
+    context = build_run_status_sensor_context(
+        sensor_name="run_failure_notifier",
+        dagster_event=event,
+        dagster_instance=instance,
+        dagster_run=result.dagster_run,
+    )
+    run_failure_notifier(context)
+    assert calls and calls[0][1] == "failed"

--- a/backend/orchestrator/tests/test_ops_integration.py
+++ b/backend/orchestrator/tests/test_ops_integration.py
@@ -1,3 +1,5 @@
+"""Integration tests for orchestrator ops."""  # noqa: E402
+
 from __future__ import annotations
 
 import json
@@ -21,6 +23,7 @@ from orchestrator.jobs import idea_job
 
 @contextmanager
 def run_mock_server() -> Iterator[tuple[str, list[str]]]:
+    """Run a simple HTTP server collecting request paths."""
     calls: list[str] = []
 
     class Handler(BaseHTTPRequestHandler):

--- a/backend/orchestrator/workspace.yaml
+++ b/backend/orchestrator/workspace.yaml
@@ -1,2 +1,3 @@
 load_from:
   - python_module: orchestrator.repository
+  - python_module: orchestrator.sensors

--- a/backend/shared/auth/__init__.py
+++ b/backend/shared/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication helpers for API services."""

--- a/backend/shared/db/migrations/api_gateway/env.py
+++ b/backend/shared/db/migrations/api_gateway/env.py
@@ -15,7 +15,6 @@ config = context.config
 fileConfig(config.config_file_name)
 
 
-
 def run_migrations_offline() -> None:
     """Run migrations in offline mode."""
     url = config.get_main_option("sqlalchemy.url") or os.getenv(


### PR DESCRIPTION
## Summary
- notify on Dagster run failures via `run_failure_notifier`
- expose new sensor via orchestrator package and repository definitions
- load sensors module in Dagster workspace
- ensure tests include required docstrings and fix lints

## Testing
- `make lint` *(fails: mypy errors)*
- `pytest -W error -vv` *(fails: database connection errors)*

------
https://chatgpt.com/codex/tasks/task_b_687c72375dc4833182763eaf0af53967