### PR TITLE
Add kube manifests for missing services

### DIFF
--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -2,6 +2,25 @@
 
 This document outlines how to deploy desAInz to AWS, Google Cloud Platform and Microsoft Azure using container images.
 
+## Kubernetes
+
+The repository ships with Kustomize manifests under `infrastructure/k8s`. Apply
+the base configuration to any cluster with:
+
+```bash
+kubectl apply -k infrastructure/k8s/base
+```
+
+For local testing with Minikube use the overlay which exposes each service via
+`NodePort`:
+
+```bash
+kubectl apply -k infrastructure/k8s/overlays/minikube
+```
+
+Check that all Pods are running and inspect logs using `kubectl get pods` and
+`kubectl logs`.
+
 ## AWS
 
 1. **Build and push images** to Amazon Elastic Container Registry (ECR).

--- a/infrastructure/k8s/base/ai-mockup-generation-deployment.yaml
+++ b/infrastructure/k8s/base/ai-mockup-generation-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-mockup-generation
+  labels:
+    app: ai-mockup-generation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai-mockup-generation
+  template:
+    metadata:
+      labels:
+        app: ai-mockup-generation
+    spec:
+      containers:
+        - name: ai-mockup-generation
+          image: example/ai-mockup-generation:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5003
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/ai-mockup-generation-service.yaml
+++ b/infrastructure/k8s/base/ai-mockup-generation-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-mockup-generation
+spec:
+  type: ClusterIP
+  selector:
+    app: ai-mockup-generation
+  ports:
+    - port: 80
+      targetPort: 5003

--- a/infrastructure/k8s/base/ai-mockup-generation-servicemonitor.yaml
+++ b/infrastructure/k8s/base/ai-mockup-generation-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ai-mockup-generation
+  labels:
+    app: ai-mockup-generation
+spec:
+  selector:
+    matchLabels:
+      app: ai-mockup-generation
+  endpoints:
+    - path: /metrics
+      targetPort: 80
+      interval: 30s

--- a/infrastructure/k8s/base/feedback-loop-deployment.yaml
+++ b/infrastructure/k8s/base/feedback-loop-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feedback-loop
+  labels:
+    app: feedback-loop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: feedback-loop
+  template:
+    metadata:
+      labels:
+        app: feedback-loop
+    spec:
+      containers:
+        - name: feedback-loop
+          image: example/feedback-loop:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5005
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/feedback-loop-service.yaml
+++ b/infrastructure/k8s/base/feedback-loop-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feedback-loop
+spec:
+  type: ClusterIP
+  selector:
+    app: feedback-loop
+  ports:
+    - port: 80
+      targetPort: 5005

--- a/infrastructure/k8s/base/feedback-loop-servicemonitor.yaml
+++ b/infrastructure/k8s/base/feedback-loop-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: feedback-loop
+  labels:
+    app: feedback-loop
+spec:
+  selector:
+    matchLabels:
+      app: feedback-loop
+  endpoints:
+    - path: /metrics
+      targetPort: 80
+      interval: 30s

--- a/infrastructure/k8s/base/kustomization.yaml
+++ b/infrastructure/k8s/base/kustomization.yaml
@@ -11,6 +11,15 @@ resources:
   - scoring-engine-deployment.yaml
   - scoring-engine-service.yaml
   - scoring-engine-servicemonitor.yaml
+  - ai-mockup-generation-deployment.yaml
+  - ai-mockup-generation-service.yaml
+  - ai-mockup-generation-servicemonitor.yaml
+  - feedback-loop-deployment.yaml
+  - feedback-loop-service.yaml
+  - feedback-loop-servicemonitor.yaml
+  - optimization-deployment.yaml
+  - optimization-service.yaml
+  - optimization-servicemonitor.yaml
   - monitoring-deployment.yaml
   - monitoring-service.yaml
   - monitoring-servicemonitor.yaml

--- a/infrastructure/k8s/base/optimization-deployment.yaml
+++ b/infrastructure/k8s/base/optimization-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimization
+  labels:
+    app: optimization
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: optimization
+  template:
+    metadata:
+      labels:
+        app: optimization
+    spec:
+      containers:
+        - name: optimization
+          image: example/optimization:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5007
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/optimization-service.yaml
+++ b/infrastructure/k8s/base/optimization-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: optimization
+spec:
+  type: ClusterIP
+  selector:
+    app: optimization
+  ports:
+    - port: 80
+      targetPort: 5007

--- a/infrastructure/k8s/base/optimization-servicemonitor.yaml
+++ b/infrastructure/k8s/base/optimization-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: optimization
+  labels:
+    app: optimization
+spec:
+  selector:
+    matchLabels:
+      app: optimization
+  endpoints:
+    - path: /metrics
+      targetPort: 80
+      interval: 30s

--- a/infrastructure/k8s/overlays/minikube/kustomization.yaml
+++ b/infrastructure/k8s/overlays/minikube/kustomization.yaml
@@ -43,6 +43,36 @@ patches:
         type: NodePort
   - target:
       kind: Service
+      name: ai-mockup-generation
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: ai-mockup-generation
+      spec:
+        type: NodePort
+  - target:
+      kind: Service
+      name: feedback-loop
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: feedback-loop
+      spec:
+        type: NodePort
+  - target:
+      kind: Service
+      name: optimization
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: optimization
+      spec:
+        type: NodePort
+  - target:
+      kind: Service
       name: monitoring
     patch: |-
       apiVersion: v1

--- a/infrastructure/k8s/overlays/production/resources.yaml
+++ b/infrastructure/k8s/overlays/production/resources.yaml
@@ -87,3 +87,57 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-mockup-generation
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: ai-mockup-generation
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feedback-loop
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: feedback-loop
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimization
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: optimization
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"


### PR DESCRIPTION
## Summary
- create deployments and services for ai-mockup-generation, feedback-loop and optimization
- patch kustomization to include the new manifests
- update minikube and production overlays
- document `kubectl` usage in cloud deployment guide

## Testing
- `./scripts/setup_codex.sh` *(fails: npm dependency resolution error)*
- `pytest` *(fails: multiple import and connection errors)*
- `npm test` *(fails: Jest module missing)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c77165004833189c7bcae5c9672a4