### PR TITLE
Add implementation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ make prod-up
 ```
 
 The `docker-compose.prod.yml` file uses prebuilt images and is intended for use on servers.
+
+## Implementation Plan
+
+See [docs/implementation_plan.md](docs/implementation_plan.md) for the milestone roadmap derived from the [Design Idea Engine Complete Blueprint](docs/blueprints/DesignIdeaEngineCompleteBlueprint.md).

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,0 +1,15 @@
+# Implementation Plan
+
+This document outlines the high-level milestones for desAInz. It references the [Design Idea Engine Complete Blueprint](blueprints/DesignIdeaEngineCompleteBlueprint.md) for additional context.
+
+## Milestones
+
+1. **Analysis & Planning** – finalize technology choices and architecture diagrams.
+2. **Core Services** – implement Signal Ingestion, Data Storage and Scoring Engine APIs.
+3. **AI Integration** – add the Prompt Builder, mock-up generation and listing draft creation.
+4. **Frontend Dashboard** – build the Next.js admin dashboard.
+5. **Marketplace Integration** – enable one-click publish and gather performance data.
+6. **Monitoring & Optimization** – add observability, auto‑scaling and brand‑safety checks.
+7. **Testing & Deployment** – run automated tests and deploy via Docker or Kubernetes.
+
+These milestones mirror the roadmap in the blueprint while providing a concise overview for contributors.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to desAInz's documentation!
    architecture
    marketplace_file_sizes
    blueprints/DesignIdeaEngineCompleteBlueprint
+   implementation_plan
    admin_dashboard_trpc
    staging_manual_qa
    migrations


### PR DESCRIPTION
## Summary
- outline milestones in docs/implementation_plan.md
- reference plan from README and docs index

## Testing
- `make lint` *(fails: mypy errors)*
- `make test` *(fails: docker not found)*
- `sphinx-build -W -b html docs docs/_build/html` *(fails: extension error)*

------
https://chatgpt.com/codex/tasks/task_b_687c77208568833180771fbba431a1e4