### PR TITLE
Expand Redis cache helpers

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -56,9 +56,9 @@ add_error_handlers(app)
 register_metrics(app)
 
 rate_limiter = UserRateLimiter(
-    get_async_client(),
     settings.rate_limit_per_user,
     settings.rate_limit_window,
+    get_async_client(),
 )
 
 

--- a/backend/api-gateway/src/api_gateway/rate_limiter.py
+++ b/backend/api-gateway/src/api_gateway/rate_limiter.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from redis.asyncio import WatchError
-from backend.shared.cache import AsyncRedis
+from backend.shared.cache import AsyncRedis, get_async_client
 
 
 class UserRateLimiter:
     """Manage request quotas for individual users."""
 
-    def __init__(self, redis: AsyncRedis, limit: int, window: int) -> None:
+    def __init__(self, limit: int, window: int, redis: AsyncRedis | None = None) -> None:
         """Instantiate the limiter with ``limit`` tokens per ``window`` seconds."""
-        self._redis = redis
+        self._redis = redis or get_async_client()
         self._limit = limit
         self._window = window
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -72,7 +72,6 @@ def _identify_user(request: Request) -> str:
 
 
 rate_limiter = MarketplaceRateLimiter(
-    get_async_client(),
     {
         Marketplace.redbubble: settings.rate_limit_redbubble,
         Marketplace.amazon_merch: settings.rate_limit_amazon_merch,
@@ -80,6 +79,7 @@ rate_limiter = MarketplaceRateLimiter(
         Marketplace.society6: settings.rate_limit_society6,
     },
     settings.rate_limit_window,
+    None,
 )
 
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from redis.asyncio import WatchError
-from backend.shared.cache import AsyncRedis
+from backend.shared.cache import AsyncRedis, get_async_client
 
 from .db import Marketplace
 
@@ -17,19 +17,19 @@ class MarketplaceRateLimiter:
 
     def __init__(
         self,
-        redis: AsyncRedis,
         limits: Mapping[Marketplace, int],
         window: int,
+        redis: AsyncRedis | None = None,
     ) -> None:
         """
         Instantiate the rate limiter.
 
         Args:
-            redis: Redis client instance.
+            redis: Redis client instance. If ``None``, a default client is used.
             limits: Allowed requests per window for each marketplace.
             window: Window size in seconds.
         """
-        self._redis = redis
+        self._redis = redis or get_async_client()
         self._limits = limits
         self._window = window
 

--- a/tests/test_latency_cache.py
+++ b/tests/test_latency_cache.py
@@ -31,9 +31,16 @@ def _import_main(monkeypatch):
 def test_average_latency_cached(monkeypatch):
     """Average latency is cached between calls."""
     fake = fakeredis.FakeRedis()
-    monkeypatch.setattr(ms, "get_sync_client", lambda: fake)
+    monkeypatch.setattr(ms, "sync_delete", lambda key: fake.delete(key))
     main = _import_main(monkeypatch)
-    monkeypatch.setattr(main, "get_sync_client", lambda: fake)
+    monkeypatch.setattr(main, "sync_get", lambda key: fake.get(key))
+    monkeypatch.setattr(
+        main,
+        "sync_set",
+        lambda key, value, ttl=None: (
+            fake.setex(key, ttl, value) if ttl else fake.set(key, value)
+        ),
+    )
     calls: list[int] = []
 
     def fake_record() -> list[float]:
@@ -51,9 +58,16 @@ def test_average_latency_cached(monkeypatch):
 def test_cache_invalidated_on_new_metric(monkeypatch):
     """Cache is cleared when metrics are recorded."""
     fake = fakeredis.FakeRedis()
-    monkeypatch.setattr(ms, "get_sync_client", lambda: fake)
+    monkeypatch.setattr(ms, "sync_delete", lambda key: fake.delete(key))
     main = _import_main(monkeypatch)
-    monkeypatch.setattr(main, "get_sync_client", lambda: fake)
+    monkeypatch.setattr(main, "sync_get", lambda key: fake.get(key))
+    monkeypatch.setattr(
+        main,
+        "sync_set",
+        lambda key, value, ttl=None: (
+            fake.setex(key, ttl, value) if ttl else fake.set(key, value)
+        ),
+    )
     calls: list[int] = []
 
     def fake_record() -> list[float]:


### PR DESCRIPTION
## Summary
- add typed sync/async Redis helpers
- use new helpers in monitoring and service rate limiters
- adjust tests for cache helper usage

## Testing
- `flake8 .`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: Found 110 errors in 43 files)*
- `python -m pytest -W error -vv` *(fails: 50 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687c771a480083318107bdb97f74b29e