### PR TITLE
Fix docstrings for backend code

### DIFF
--- a/backend/analytics/auth.py
+++ b/backend/analytics/auth.py
@@ -23,7 +23,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES = shared_jwt.ACCESS_TOKEN_EXPIRE_MINUTES
 
 
 def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
-    """Return dependency validating the authenticated user has ``required_role``."""
+    """Return a dependency that checks the user has ``required_role``."""
 
     def _checker(payload: Dict[str, Any] = Depends(verify_token)) -> Dict[str, Any]:
         username = cast(str | None, payload.get("sub"))

--- a/backend/api-gateway/src/api_gateway/rate_limiter.py
+++ b/backend/api-gateway/src/api_gateway/rate_limiter.py
@@ -11,7 +11,7 @@ class UserRateLimiter:
     """Manage request quotas for individual users."""
 
     def __init__(self, redis: AsyncRedis, limit: int, window: int) -> None:
-        """Instantiate the limiter with ``limit`` tokens per ``window`` seconds."""
+        """Instantiate limiter with ``limit`` tokens per ``window`` seconds."""
         self._redis = redis
         self._limit = limit
         self._window = window

--- a/backend/marketplace-publisher/src/marketplace_publisher/rules.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rules.py
@@ -79,7 +79,7 @@ def stop_watching_rules() -> None:
 
 
 def load_rules(path: Path, watch: bool = False) -> None:
-    """Load marketplace rules from ``path`` and optionally watch for changes."""
+    """Load rules from ``path`` and optionally watch for changes."""
 
     global _rules_path, _observer
     _rules_path = path

--- a/backend/shared/kafka/schema_registry.py
+++ b/backend/shared/kafka/schema_registry.py
@@ -20,7 +20,7 @@ class SchemaRegistryClient:
     """Simple client for interacting with a schema registry."""
 
     def __init__(self, url: str, token: str | None = None) -> None:
-        """Initialize the client with the registry ``url`` and optional ``token``."""
+        """Initialize client with registry ``url`` and optional ``token``."""
         self._url = url.rstrip("/")
         self._token = token or os.getenv("SCHEMA_REGISTRY_TOKEN")
 

--- a/tests/test_pagerduty.py
+++ b/tests/test_pagerduty.py
@@ -32,7 +32,7 @@ def test_trigger_sla_violation_sends_request(
 def test_notify_listing_issue_sends_request(
     requests_mock: Any, monkeypatch: Any
 ) -> None:
-    """notify_listing_issue should POST listing alert when routing key present."""
+    """POST listing alert when routing key is present."""
     monkeypatch.setenv("PAGERDUTY_ROUTING_KEY", "key")
     requests_mock.post(PAGERDUTY_URL, status_code=202)
     pagerduty.notify_listing_issue(123, "removed")


### PR DESCRIPTION
## Summary
- refine docstrings under backend and tests

## Testing
- `flake8 backend tests`
- `mypy backend --exclude 'tests'` *(fails: Library stubs not installed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_b_687c7726c7e48331a5dd5b65c3943ec5