### PR TITLE
Add cron backups and log rotation

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -216,6 +216,15 @@ services:
       dockerfile: backend/orchestrator/Dockerfile
     ports:
       - "3001:3000"
+
+  backup:
+    image: ghcr.io/example/backup:latest
+    environment:
+      - BACKUP_BUCKET=${BACKUP_BUCKET}
+    command: >-
+      sh -c "echo '0 0 * * * python /app/backup.py >> /var/log/backup.log 2>&1' > /etc/crontab && cron -f"
+    depends_on:
+      - postgres
 volumes:
   postgres-data:
   redis-data:

--- a/docker/backup/Dockerfile
+++ b/docker/backup/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3.11-slim
-RUN apt-get update && apt-get install -y postgresql-client awscli && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y postgresql-client awscli cron \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY scripts/backup.py /app/backup.py
 COPY LICENSES /licenses/LICENSES
-ENTRYPOINT ["python", "/app/backup.py"]
+COPY docker/backup/backup-crontab /etc/cron.d/backup
+RUN chmod 0644 /etc/cron.d/backup && crontab /etc/cron.d/backup
+CMD ["cron", "-f"]

--- a/docker/backup/backup-crontab
+++ b/docker/backup/backup-crontab
@@ -1,0 +1,2 @@
+0 0 * * * python /app/backup.py >> /var/log/backup.log 2>&1
+

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -28,6 +28,18 @@ Environment variables can override the storage paths:
 - `COLD_STORAGE_PATH` – directory for archived mockups (defaults to `cold_storage`)
 - `LOG_DIR` – directory containing log files (defaults to `logs`)
 
+## Log Rotation
+
+The `scripts/rotate_logs.sh` helper rotates application logs. It moves `*.log`
+files in `LOG_DIR` into an `archive` directory with a timestamp suffix and
+removes archives older than seven days.
+
+Run the script via cron:
+
+```bash
+0 1 * * * /app/scripts/rotate_logs.sh
+```
+
 ## Dependency Updates
 
 Dependencies for Python, JavaScript, and GitHub Actions are kept current via Dependabot.
@@ -44,3 +56,9 @@ python scripts/analyze_query_plans.py
 ```
 
 The `daily_query_plan_schedule` Dagster schedule runs the analysis once a day.
+
+## Nightly Backups
+
+In production Docker Compose deployments a `backup` service runs `scripts/backup.py`
+using cron. The container uploads a PostgreSQL dump to the bucket defined by
+`BACKUP_BUCKET` every night at midnight UTC.

--- a/scripts/rotate_logs.sh
+++ b/scripts/rotate_logs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Rotate log files daily by moving them to an archive folder and pruning old archives.
+
+set -euo pipefail
+
+LOG_DIR="${LOG_DIR:-logs}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+
+mkdir -p "${LOG_DIR}/archive"
+TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
+
+shopt -s nullglob
+for log_file in "${LOG_DIR}"/*.log; do
+    mv "$log_file" "${LOG_DIR}/archive/$(basename "$log_file").${TIMESTAMP}"
+    : > "$log_file"
+done
+shopt -u nullglob
+
+find "${LOG_DIR}/archive" -type f -mtime +"${RETENTION_DAYS}" -delete


### PR DESCRIPTION
## Summary
- create rotate_logs.sh for daily log rotation
- install cron in backup Dockerfile and add crontab
- schedule nightly backups in docker-compose.prod.yml
- document the new maintenance scripts

## Testing
- `make lint` *(fails: unused-ignore, import-untyped, etc.)*
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c7af9e03c833187a47c9e489a5835