### PR TITLE
Add env examples for backend services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ flow-typed/
 .env
 .env.*
 !.env.*.example
+!.env.example
 docs/sphinx/api/

--- a/backend/api-gateway/.env.example
+++ b/backend/api-gateway/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/api-gateway/README.md
+++ b/backend/api-gateway/README.md
@@ -1,3 +1,7 @@
 # API Gateway
 
 This microservice exposes REST and tRPC-compatible endpoints and uses JWT authentication.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values.

--- a/backend/feedback-loop/.env.example
+++ b/backend/feedback-loop/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/feedback-loop/README.md
+++ b/backend/feedback-loop/README.md
@@ -1,0 +1,7 @@
+# Feedback Loop Service
+
+This service manages user feedback processing and periodic weight updates.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values for your environment.

--- a/backend/marketplace-publisher/.env.example
+++ b/backend/marketplace-publisher/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/marketplace-publisher/README.md
+++ b/backend/marketplace-publisher/README.md
@@ -1,0 +1,7 @@
+# Marketplace Publisher Service
+
+Publishes generated assets to the marketplace platform.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and set the credentials for your deployment.

--- a/backend/mockup-generation/.env.example
+++ b/backend/mockup-generation/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/mockup-generation/README.md
+++ b/backend/mockup-generation/README.md
@@ -1,3 +1,7 @@
 # Mockup Generation Service
 
 This service generates design mockups using Stable Diffusion XL. It exposes Celery tasks for asynchronous generation and provides a post-processing pipeline.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values.

--- a/backend/monitoring/.env.example
+++ b/backend/monitoring/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/monitoring/README.md
+++ b/backend/monitoring/README.md
@@ -1,0 +1,7 @@
+# Monitoring Service
+
+Collects metrics and exposes health endpoints for desAInz.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and configure as needed.

--- a/backend/orchestrator/.env.example
+++ b/backend/orchestrator/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/orchestrator/README.md
+++ b/backend/orchestrator/README.md
@@ -22,3 +22,7 @@ Start the Dagster webserver to inspect pipeline status and logs:
 Then open http://localhost:3000 in your browser. The server loads
 `backend/orchestrator/workspace.yaml` and `backend/orchestrator/dagster.yaml`
 for configuration.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values.

--- a/backend/scoring-engine/.env.example
+++ b/backend/scoring-engine/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/scoring-engine/README.md
+++ b/backend/scoring-engine/README.md
@@ -4,3 +4,7 @@ This microservice calculates scores for design ideas using multiple factors:
 freshness, engagement, novelty, community fit and seasonality. Weighting
 parameters are stored in the database and can be updated via the REST API.
 Scores are cached in Redis for performance.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values.

--- a/backend/signal-ingestion/.env.example
+++ b/backend/signal-ingestion/.env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+REDIS_URL=redis://localhost:6379
+
+# AI Services
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+
+# Storage
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=design-idea-engine
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/backend/signal-ingestion/README.md
+++ b/backend/signal-ingestion/README.md
@@ -1,0 +1,7 @@
+# Signal Ingestion Service
+
+Ingests external signals and prepares them for scoring.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust to match your environment.


### PR DESCRIPTION
## Summary
- add `.env.example` to each backend service
- link the new files in each service README
- keep `.env.example` files tracked via `.gitignore`

## Testing
- `./scripts/setup_codex.sh`
- `make lint` *(fails: mypy found 110 errors)*
- `make test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c7affa2148331ad1f7f112aa610a0