### PR TITLE
Document dedup settings

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/dedup.py
+++ b/backend/signal-ingestion/src/signal_ingestion/dedup.py
@@ -10,13 +10,11 @@ redis_client: SyncRedis = get_sync_client()
 BLOOM_KEY = "signals:bloom"
 
 
-def initialize() -> None:
+def initialize(error_rate: float, capacity: int, ttl: int) -> None:
     """Create the bloom filter if it does not already exist."""
     if not redis_client.exists(BLOOM_KEY):
-        redis_client.bf().create(
-            BLOOM_KEY, settings.dedup_error_rate, settings.dedup_capacity
-        )
-        redis_client.expire(BLOOM_KEY, settings.dedup_ttl)
+        redis_client.bf().create(BLOOM_KEY, error_rate, capacity)
+        redis_client.expire(BLOOM_KEY, ttl)
 
 
 def is_duplicate(key: str) -> bool:
@@ -30,4 +28,4 @@ def add_key(key: str) -> None:
     redis_client.expire(BLOOM_KEY, settings.dedup_ttl)
 
 
-initialize()
+initialize(settings.dedup_error_rate, settings.dedup_capacity, settings.dedup_ttl)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,3 +31,6 @@ application settings classes.
 | `ENABLED_ADAPTERS` | Comma separated list of ingestion adapters to run; if unset all adapters are used |
 | `PAGERDUTY_ROUTING_KEY` | Integration key for sending PagerDuty incidents |
 | `ENABLE_PAGERDUTY` | Set to `true` to enable PagerDuty notifications |
+| `DEDUP_ERROR_RATE` | Probability of false positives in the Bloom filter |
+| `DEDUP_CAPACITY` | Estimated maximum number of entries in the Bloom filter |
+| `DEDUP_TTL` | Time-to-live in seconds for deduplication keys |


### PR DESCRIPTION
## Summary
- pass dedup settings explicitly when initializing bloom filter
- document deduplication environment variables

## Testing
- `black backend/signal-ingestion/src/signal_ingestion/dedup.py backend/signal-ingestion/src/signal_ingestion/settings.py --check`
- `docformatter --check docs/configuration.md`
- `pydocstyle docs/configuration.md`
- `flake8 backend/signal-ingestion/src/signal_ingestion/dedup.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/dedup.py` *(fails: Untyped decorator makes function "_record_metrics" untyped)*
- `pytest -W error -vv tests/integration/test_workflow.py::test_workflow -k 'nothing' --maxfail=1` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_b_687cf7d2d7448331af76826f3d1e4c41