### PR TITLE
Implement centroid scheduler

### DIFF
--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -93,7 +93,6 @@ register_metrics(app)
 REDIS_URL = settings.redis_url
 CACHE_TTL_SECONDS = settings.score_cache_ttl
 redis_client: AsyncRedis = get_async_client()
-start_centroid_scheduler()
 
 
 # Background Kafka consumer setup
@@ -144,6 +143,12 @@ async def start_consumer() -> None:
         target=consume_signals, args=(_stop_event, _consumer), daemon=True
     )
     _consumer_thread.start()
+
+
+@app.on_event("startup")
+async def start_centroids() -> None:
+    """Initialize centroid computation scheduler."""
+    start_centroid_scheduler()
 
 
 @app.on_event("shutdown")

--- a/backend/scoring-engine/scoring_engine/centroid_job.py
+++ b/backend/scoring-engine/scoring_engine/centroid_job.py
@@ -1,11 +1,13 @@
-"""Periodic job for computing embedding centroids."""
+"""Background scheduler for computing embedding centroids."""
 
 from __future__ import annotations
 
 import logging
 
 from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import select
+from datetime import datetime
 import numpy as np
 
 from backend.shared.db import session_scope
@@ -40,6 +42,7 @@ def compute_and_store_centroids() -> None:
 def start_centroid_scheduler() -> None:
     """Start background scheduler for centroid updates."""
     scheduler.add_job(
-        compute_and_store_centroids, "interval", hours=1, next_run_time=None
+        compute_and_store_centroids,
+        trigger=IntervalTrigger(hours=1, start_date=datetime.utcnow()),
     )
     scheduler.start()

--- a/backend/scoring-engine/tests/test_centroid_job.py
+++ b/backend/scoring-engine/tests/test_centroid_job.py
@@ -1,0 +1,51 @@
+"""Tests for centroid scheduler configuration and execution."""
+
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from scoring_engine.centroid_job import (
+    scheduler as module_scheduler,
+    start_centroid_scheduler,
+    compute_and_store_centroids,
+)
+from scoring_engine.weight_repository import get_centroid
+from backend.shared.db import session_scope
+from backend.shared.db.models import Embedding
+
+
+def test_scheduler_configuration(monkeypatch) -> None:
+    """Scheduler runs compute job hourly."""
+    monkeypatch.setattr("scoring_engine.centroid_job.scheduler", BackgroundScheduler())
+    start_centroid_scheduler()
+    jobs = module_scheduler.get_jobs()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert isinstance(job.trigger, IntervalTrigger)
+    assert int(job.trigger.interval.total_seconds()) == 3600
+    module_scheduler.shutdown()
+
+
+def test_centroid_job_executes(monkeypatch) -> None:
+    """Job computes centroids from stored embeddings."""
+    monkeypatch.setattr("scoring_engine.centroid_job.scheduler", BackgroundScheduler())
+    with session_scope() as session:
+        v1 = [1.0] + [0.0] * 767
+        v2 = [0.0] * 767 + [1.0]
+        session.add_all(
+            [
+                Embedding(source="src", embedding=v1),
+                Embedding(source="src", embedding=v2),
+            ]
+        )
+        session.flush()
+    start_centroid_scheduler()
+    # execute the scheduled job directly
+    job = module_scheduler.get_jobs()[0]
+    job.func()
+    module_scheduler.shutdown()
+    centroid = get_centroid("src")
+    assert centroid == [0.5] + [0.0] * 766 + [0.5]

--- a/docs/scoring_engine/modules.rst
+++ b/docs/scoring_engine/modules.rst
@@ -6,3 +6,6 @@ API Reference
 
 .. automodule:: scoring_engine.app
    :members:
+
+.. automodule:: scoring_engine.centroid_job
+   :members:


### PR DESCRIPTION
## Summary
- implement centroid background scheduler
- run the scheduler at app startup
- document module and extend docs
- test centroid scheduler configuration and execution

## Testing
- `mypy --config-file pyproject.toml backend/scoring-engine/scoring_engine/centroid_job.py backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_centroid_job.py`
- `flake8 backend/scoring-engine/scoring_engine/centroid_job.py backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_centroid_job.py`
- `pydocstyle backend/scoring-engine/scoring_engine/centroid_job.py backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_centroid_job.py`
- `docformatter --in-place --recursive backend/scoring-engine/scoring_engine/centroid_job.py backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_centroid_job.py docs/scoring_engine/modules.rst`
- `black backend/scoring-engine/scoring_engine/centroid_job.py backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_centroid_job.py`
- `pytest -k centroid_job -vv` *(fails: ModuleNotFoundError: No module named 'tests.conftest')*

------
https://chatgpt.com/codex/tasks/task_b_687cf7d868508331b14856a74cb4300a