### PR TITLE
Implement cron-based ingestion scheduling

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     dedup_capacity: int = 100_000
     dedup_ttl: int = 86_400
     ingest_interval_minutes: int = 60
+    ingest_cron: str | None = None
     http_proxies: HttpUrl | None = None
     adapter_rate_limit: int = 5
     enabled_adapters: list[str] | None = None
@@ -74,6 +75,13 @@ class Settings(BaseSettings):  # type: ignore[misc]
         if not value:
             return []
         return [v.strip() for v in value.split(",") if v.strip()]
+
+    @field_validator("ingest_cron", mode="before")  # type: ignore[misc]
+    @classmethod
+    def _empty_to_none(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            return None
+        return value
 
 
 Settings.model_rebuild()

--- a/backend/signal-ingestion/tests/test_scheduler.py
+++ b/backend/signal-ingestion/tests/test_scheduler.py
@@ -48,16 +48,55 @@ import redis  # noqa: E402
 
 redis.Redis = _DummyRedis  # type: ignore[attr-defined]
 
+from types import SimpleNamespace
+import pytest
+from apscheduler.triggers.cron import CronTrigger  # noqa: E402
 from apscheduler.triggers.interval import IntervalTrigger  # noqa: E402
 
-from signal_ingestion.scheduler import create_scheduler  # noqa: E402
+sys.modules.setdefault(
+    "signal_ingestion.database",
+    SimpleNamespace(SessionLocal=lambda: None),
+)
+
+from signal_ingestion import scheduler  # noqa: E402
 from signal_ingestion.settings import settings  # noqa: E402
 
 
 def test_ingest_job_scheduled() -> None:
     """The scheduler configures the ingest job with the correct interval."""
-    scheduler = create_scheduler()
-    job = scheduler.get_job("ingest")
+    sched = scheduler.create_scheduler()
+    job = sched.get_job("ingest")
     assert job is not None
     assert isinstance(job.trigger, IntervalTrigger)
     assert job.trigger.interval.total_seconds() == settings.ingest_interval_minutes * 60
+
+
+def test_ingest_job_scheduled_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cron expression configures a ``CronTrigger`` for ingestion."""
+    monkeypatch.setattr(settings, "ingest_cron", "*/5 * * * *")
+    sched = scheduler.create_scheduler()
+    job = sched.get_job("ingest")
+    assert isinstance(job.trigger, CronTrigger)
+
+
+def test_ingest_job_enqueues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ingestion job sends tasks for each enabled adapter."""
+
+    class DummyApp:
+        def __init__(self) -> None:
+            self.sent: list[tuple[str, list[str], str | None]] = []
+
+        def send_task(
+            self, name: str, args: list[str] | None = None, queue: str | None = None
+        ) -> None:
+            self.sent.append((name, args or [], queue))
+
+    dummy = DummyApp()
+    monkeypatch.setattr(scheduler.tasks, "app", dummy)
+    monkeypatch.setattr(scheduler.tasks, "ADAPTERS", {"foo": object(), "bar": object()})
+    monkeypatch.setattr(settings, "enabled_adapters", ["foo", "bar"])
+    scheduler.ingest_job()
+    assert dummy.sent == [
+        ("signal_ingestion.ingest_adapter", ["foo"], scheduler.tasks.queue_for("foo")),
+        ("signal_ingestion.ingest_adapter", ["bar"], scheduler.tasks.queue_for("bar")),
+    ]


### PR DESCRIPTION
## Summary
- enqueue adapter ingestion directly from scheduler
- support cron expressions for ingestion interval
- test queues scheduled with cron support

## Testing
- `pytest backend/signal-ingestion/tests/test_scheduler.py -W error -q`

------
https://chatgpt.com/codex/tasks/task_b_687cfe530500833187e6188f0cf0be9b