### PR TITLE
Support GPU queues and multiple models

### DIFF
--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -131,6 +131,8 @@ class GeneratePayload(BaseModel):  # type: ignore[misc]
 
     batches: list[list[str]]
     output_dir: str
+    model: str | None = None
+    gpu_index: int | None = None
 
 
 @app.post("/generate")
@@ -140,6 +142,7 @@ async def generate(payload: GeneratePayload) -> dict[str, list[str]]:
         celery_app.send_task(
             "mockup_generation.tasks.generate_mockup",
             args=[batch, payload.output_dir],
+            kwargs={"model": payload.model, "gpu_index": payload.gpu_index},
         ).id
         for batch in payload.batches
     ]

--- a/backend/mockup-generation/mockup_generation/celery_app.py
+++ b/backend/mockup-generation/mockup_generation/celery_app.py
@@ -6,7 +6,22 @@ import os
 
 from celery import Celery
 
+from .tasks import queue_for_gpu
+
 
 CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
 app = Celery("mockup_generation", broker=CELERY_BROKER_URL)
 app.conf.result_backend = CELERY_BROKER_URL
+
+
+def _route_gpu_tasks(
+    name: str, args: tuple, kwargs: dict, options: dict, **kws
+) -> dict:
+    """Route tasks with a ``gpu_index`` kwarg to the corresponding queue."""
+    gpu = kwargs.get("gpu_index")
+    if gpu is not None:
+        options = {"queue": queue_for_gpu(int(gpu))}
+    return options
+
+
+app.conf.task_routes = (_route_gpu_tasks,)

--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -37,9 +37,9 @@ class MockupGenerator:
         self.pipeline: Optional[StableDiffusionXLPipeline] = None
         self._lock = Lock()
 
-    def load(self) -> None:
+    def load(self, model_identifier: str | None = None) -> None:
         """Load or reload the diffusion pipeline on the available device."""
-        current = get_default_model_id()
+        current = model_identifier or get_default_model_id()
         with self._lock:
             if self.pipeline is None or self.model_id != current:
                 self.model_id = current
@@ -50,7 +50,12 @@ class MockupGenerator:
                 self.pipeline.enable_attention_slicing()
 
     def generate(
-        self, prompt: str, output_path: str, *, num_inference_steps: int = 30
+        self,
+        prompt: str,
+        output_path: str,
+        *,
+        num_inference_steps: int = 30,
+        model_identifier: str | None = None,
     ) -> GenerationResult:
         """
         Generate an image.
@@ -62,13 +67,14 @@ class MockupGenerator:
             prompt: Text prompt describing the desired image.
             output_path: Filesystem path to save the resulting image.
             num_inference_steps: Number of inference steps for the model.
+            model_identifier: Optional model ID to load instead of the default.
 
         Returns:
             GenerationResult containing the image path and duration.
         """
         from time import perf_counter
 
-        self.load()
+        self.load(model_identifier)
         assert self.pipeline is not None
         start = perf_counter()
         try:

--- a/backend/mockup-generation/mockup_generation/model_repository.py
+++ b/backend/mockup-generation/mockup_generation/model_repository.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 from sqlalchemy import delete, select, update
 
@@ -85,6 +85,22 @@ def list_models() -> List[ModelInfo]:
             )
             for row in rows
         ]
+
+
+def get_model(model_id: int) -> Optional[ModelInfo]:
+    """Return a model entry by primary key."""
+    with session_scope() as session:
+        row = session.get(AIModel, model_id)
+        if row is None:
+            return None
+        return ModelInfo(
+            id=row.id,
+            name=row.name,
+            version=row.version,
+            model_id=row.model_id,
+            details=row.details,
+            is_default=row.is_default,
+        )
 
 
 def set_default(model_id: int) -> None:

--- a/backend/mockup-generation/tests/test_model_repository.py
+++ b/backend/mockup-generation/tests/test_model_repository.py
@@ -105,6 +105,8 @@ warnings.filterwarnings("ignore", category=UserWarning)
 from mockup_generation.model_repository import (  # noqa: E402
     list_generated_mockups,
     save_generated_mockup,
+    register_model,
+    get_model,
 )
 
 
@@ -127,3 +129,10 @@ def test_save_and_list_generated_mockups() -> None:
         and i.image_uri == "uri"
         for i in items
     )
+
+
+def test_register_and_get_model() -> None:
+    """Model info can be retrieved by id."""
+    model_id = register_model("n", "1", "foo")
+    info = get_model(model_id)
+    assert info is not None and info.model_id == "foo"

--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -92,6 +92,6 @@ def test_generate_mockup_upload(
     tasks.settings.s3_bucket = "b"
     tasks.settings.s3_endpoint = "http://test"  # type: ignore
 
-    res = tasks.generate_mockup.run([["kw"]], str(tmp_path))
+    res = tasks.generate_mockup.run([["kw"]], str(tmp_path), model="m", gpu_index=0)
     assert res[0]["uri"].startswith("http://test/b/generated-mockups/mockup_0.png")
     assert gen.cleaned

--- a/docs/mockup_generation.md
+++ b/docs/mockup_generation.md
@@ -2,8 +2,10 @@
 
 The mockup generation service runs inside CUDA-enabled containers. Each
 Celery worker is pinned to a specific GPU using the `GPU_WORKER_INDEX`
-environment variable. Workers listen on dedicated queues
-`gpu-<index>` so Kubernetes can scale them independently.
+environment variable. Workers listen on dedicated queues `gpu-<index>`
+so Kubernetes can scale them independently. Tasks can target a specific
+GPU by passing ``gpu_index`` to the ``/generate`` endpoint, which will
+route them to the corresponding queue.
 
 ```bash
 # build image and target the first GPU


### PR DESCRIPTION
## Summary
- extend model repository with new get_model helper
- make generator load models specified at task runtime
- allow GPU index and model parameters in tasks
- route Celery tasks to GPU queues
- update API schema and docs accordingly
- adjust tests for new parameters

## Testing
- `flake8 backend/mockup-generation/mockup_generation backend/mockup-generation/tests`
- `pydocstyle backend/mockup-generation/mockup_generation backend/mockup-generation/tests`
- `mypy backend/mockup-generation/mockup_generation/model_repository.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/mockup_generation/api.py backend/mockup-generation/mockup_generation/celery_app.py`
- `pytest backend/mockup-generation/tests -W error -vv` *(fails: ModuleNotFoundError: No module named 'pgvector')*

------
https://chatgpt.com/codex/tasks/task_b_687d01ab23608331acf3fdfa2893378d