### PR TITLE
Add size validators and rules

### DIFF
--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -22,6 +22,8 @@ from .post_processor import (
     convert_to_cmyk,
     ensure_not_nsfw,
     remove_background,
+    validate_dimensions,
+    validate_file_size,
     validate_color_space,
     validate_dpi_image,
 )
@@ -167,7 +169,11 @@ def generate_mockup(
                 raise ValueError("Invalid DPI")
             if not validate_color_space(processed):
                 raise ValueError("Invalid color space")
+            if not validate_dimensions(processed):
+                raise ValueError("Invalid dimensions")
             compress_lossless(processed, output_path)
+            if not validate_file_size(output_path):
+                raise ValueError("File size too large")
             obj_name = f"generated-mockups/{output_path.name}"
             if hasattr(client, "fput_object"):
                 client.fput_object(settings.s3_bucket, obj_name, str(output_path))

--- a/backend/mockup-generation/tests/test_post_processor_rules.py
+++ b/backend/mockup-generation/tests/test_post_processor_rules.py
@@ -1,0 +1,29 @@
+"""Tests for post-processing validation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))  # noqa: E402
+sys.path.append(str(ROOT / "backend" / "mockup-generation"))  # noqa: E402
+
+from PIL import Image
+
+from mockup_generation.post_processor import validate_dimensions, validate_file_size
+
+
+def test_validate_dimensions(tmp_path: Path) -> None:
+    """Image dimensions are validated against provided limits."""
+    img = Image.new("RGB", (100, 100))
+    assert validate_dimensions(img, max_width=150, max_height=150)
+    assert not validate_dimensions(img, max_width=50, max_height=150)
+
+
+def test_validate_file_size(tmp_path: Path) -> None:
+    """File size validation respects the configured threshold."""
+    path = tmp_path / "f"
+    path.write_bytes(b"x" * 1024)
+    assert validate_file_size(path, max_file_size_mb=1)
+    assert not validate_file_size(path, max_file_size_mb=0)

--- a/config/marketplace_rules.yaml
+++ b/config/marketplace_rules.yaml
@@ -1,0 +1,40 @@
+redbubble:
+  max_file_size_mb: 10
+  max_width: 8000
+  max_height: 8000
+  upload_limit: 50
+  selectors:
+    url: "https://www.redbubble.com/upload"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"
+amazon_merch:
+  max_file_size_mb: 25
+  max_width: 15000
+  max_height: 15000
+  upload_limit: 100
+  selectors:
+    url: "https://merch.amazon.com/create"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"
+etsy:
+  max_file_size_mb: 20
+  max_width: 10000
+  max_height: 10000
+  upload_limit: 80
+  selectors:
+    url: "https://www.etsy.com/new"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"
+society6:
+  max_file_size_mb: 15
+  max_width: 10000
+  max_height: 10000
+  upload_limit: 70
+  selectors:
+    url: "https://www.society6.com/sell"
+    upload_input: "#upload"
+    title_input: "#title"
+    submit_button: "#submit"


### PR DESCRIPTION
## Summary
- add marketplace rules to config
- extend post-processing with file size/dimension checks
- enforce new validations in Celery task
- cover validation helpers with unit tests

## Testing
- `pytest backend/mockup-generation/tests/test_post_processor_rules.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687d0df1e8c8833188174d348dbbd053