### PR TITLE
Improve SeleniumFallback logging and CLI control

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import logging
+import os
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Coroutine, cast
@@ -344,6 +346,16 @@ async def ready() -> dict[str, str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    parser = argparse.ArgumentParser(
+        description="Run the marketplace publisher service."
+    )
+    parser.add_argument(
+        "--no-selenium", action="store_true", help="Disable Selenium fallback"
+    )
+    args = parser.parse_args()
+    if args.no_selenium:
+        os.environ["SELENIUM_SKIP"] = "1"
+
     import uvicorn
 
     uvicorn.run(

--- a/tests/test_selenium_e2e.py
+++ b/tests/test_selenium_e2e.py
@@ -86,3 +86,4 @@ def test_selenium_publish_failure_with_screenshot(tmp_path: Path) -> None:
     with pytest.raises(Exception):
         fallback.publish(Marketplace.redbubble, design, {"title": "t"})
     assert list(tmp_path.glob("*.png"))
+    assert list(tmp_path.glob("*.log"))


### PR DESCRIPTION
## Summary
- capture network logs & screenshots on Selenium publish failure
- add exponential backoff and max attempts
- allow disabling selenium via CLI
- test new failure logs

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/main.py tests/test_selenium_e2e.py`
- `pydocstyle backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/main.py tests/test_selenium_e2e.py`
- `docformatter --in-place backend/marketplace-publisher/src/marketplace_publisher/clients.py tests/test_selenium_e2e.py backend/marketplace-publisher/src/marketplace_publisher/main.py`
- `black --check backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/main.py tests/test_selenium_e2e.py`
- `mypy backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/main.py tests/test_selenium_e2e.py --explicit-package-bases` *(fails: library stubs not installed)*
- `pip-audit -r requirements.txt -r requirements-dev.txt` *(fails: could not install packages)*
- `npm run lint` *(fails: code style issues)*
- `npm run lint:css`
- `npm run flow`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_b_687d1a9342b48331a649e0d06a798f74