### PR TITLE
Secure feedback routes

### DIFF
--- a/backend/feedback-loop/feedback_loop/auth.py
+++ b/backend/feedback-loop/feedback_loop/auth.py
@@ -1,0 +1,44 @@
+"""Authentication helpers for the feedback loop service."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, cast
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy import select
+
+from backend.shared.auth import jwt as shared_jwt
+from backend.shared.db import session_scope
+from backend.shared.db.models import UserRole
+
+# Re-export shared helpers for convenience
+create_access_token = shared_jwt.create_access_token
+verify_token = shared_jwt.verify_token
+revoke_token = shared_jwt.revoke_token
+auth_scheme = shared_jwt.auth_scheme
+SECRET_KEY = shared_jwt.SECRET_KEY
+ALGORITHM = shared_jwt.ALGORITHM
+ACCESS_TOKEN_EXPIRE_MINUTES = shared_jwt.ACCESS_TOKEN_EXPIRE_MINUTES
+
+
+def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """Return dependency ensuring the authenticated user has ``required_role``."""
+
+    def _checker(payload: Dict[str, Any] = Depends(verify_token)) -> Dict[str, Any]:
+        username = cast(str | None, payload.get("sub"))
+        if username is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
+            )
+        with session_scope() as session:
+            role = session.execute(
+                select(UserRole.role).where(UserRole.username == username)
+            ).scalar_one_or_none()
+        if role != required_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role",
+            )
+        return payload
+
+    return _checker

--- a/backend/feedback-loop/tests/test_main.py
+++ b/backend/feedback-loop/tests/test_main.py
@@ -8,11 +8,18 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient  # noqa: E402
 from feedback_loop import ABTestManager  # noqa: E402
 import feedback_loop.main as main  # noqa: E402
+from feedback_loop.auth import create_access_token  # noqa: E402
+from backend.shared.db import Base, SessionLocal, engine, models  # noqa: E402
 
 
 def test_impression_conversion_allocation(tmp_path) -> None:
     """Recorded events should influence allocation."""
     main.manager = ABTestManager(database_url="sqlite:///:memory:")
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    with SessionLocal() as session:
+        session.add(models.UserRole(username="admin", role="admin"))
+        session.commit()
     client = TestClient(main.app)
 
     resp = client.post("/impression", params={"variant": "A"})
@@ -22,6 +29,11 @@ def test_impression_conversion_allocation(tmp_path) -> None:
     assert resp.status_code == 200
 
     resp = client.get("/allocation", params={"total_budget": 100})
+    assert resp.status_code == 403
+
+    token = create_access_token({"sub": "admin"})
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get("/allocation", params={"total_budget": 100}, headers=headers)
     assert resp.status_code == 200
     data = resp.json()
     assert set(data) == {"variant_a", "variant_b"}
@@ -30,6 +42,11 @@ def test_impression_conversion_allocation(tmp_path) -> None:
 def test_stats_endpoint(tmp_path) -> None:
     """/stats should return conversion totals."""
     main.manager = ABTestManager(database_url="sqlite:///:memory:")
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    with SessionLocal() as session:
+        session.add(models.UserRole(username="admin", role="admin"))
+        session.commit()
     client = TestClient(main.app)
 
     for _ in range(3):
@@ -38,5 +55,9 @@ def test_stats_endpoint(tmp_path) -> None:
         client.post("/conversion", params={"variant": "B"})
 
     resp = client.get("/stats")
+    assert resp.status_code == 403
+    token = create_access_token({"sub": "admin"})
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get("/stats", headers=headers)
     assert resp.status_code == 200
     assert resp.json() == {"conversions_a": 3, "conversions_b": 2}


### PR DESCRIPTION
## Summary
- require admin role for /allocation and /stats
- test tokens for feedback loop endpoints

## Testing
- `python -m pytest backend/feedback-loop/tests/test_main.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_687d231b3eac8331a4156f5edc055d7f