### PR TITLE
Implement metrics dashboard

### DIFF
--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Callable, Coroutine, Iterable
 
@@ -88,9 +89,12 @@ async def overview() -> dict[str, float]:
 
 
 @app.get("/analytics")
-async def analytics() -> dict[str, int]:
-    """Return placeholder analytics dashboard data."""
-    return {"active_users": 0, "error_rate": 0}
+async def analytics() -> dict[str, float]:
+    """Return metrics derived from the TimescaleDB store."""
+    since = datetime.utcnow() - timedelta(days=1)
+    active = metrics_store.get_active_users(since)
+    error_rate = metrics_store.get_error_rate(since)
+    return {"active_users": float(active), "error_rate": error_rate}
 
 
 @app.get("/status")

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -29,3 +29,9 @@ Run:
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.tracing.yml up -d otel-collector
 ```
+
+## Grafana Dashboards
+
+Prebuilt dashboard JSON files reside in `infrastructure/grafana`.
+Import them into Grafana via **Dashboards → Import** and select the
+TimescaleDB data source when prompted.

--- a/infrastructure/grafana/latency_overview.json
+++ b/infrastructure/grafana/latency_overview.json
@@ -1,0 +1,29 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "TimescaleDB",
+      "type": "timeseries",
+      "title": "Average Publish Latency",
+      "targets": [
+        {
+          "rawSql": "SELECT bucket AS time, avg_latency FROM latency_hourly ORDER BY bucket",
+          "refId": "A",
+          "format": "time_series"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Latency Overview",
+  "version": 1
+}

--- a/infrastructure/grafana/scores_overview.json
+++ b/infrastructure/grafana/scores_overview.json
@@ -1,0 +1,29 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "TimescaleDB",
+      "type": "timeseries",
+      "title": "Average Score",
+      "targets": [
+        {
+          "rawSql": "SELECT time_bucket('1 hour', timestamp) AS time, AVG(score) FROM scores GROUP BY time ORDER BY time",
+          "refId": "A",
+          "format": "time_series"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Score Overview",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
- replace analytics placeholder with real metrics queries
- add helper functions in metrics store
- ship example Grafana dashboards
- document importing dashboards

## Testing
- `flake8 backend/monitoring/src/monitoring/main.py backend/monitoring/src/monitoring/metrics_store.py`
- `mypy backend/monitoring/src/monitoring/main.py backend/monitoring/src/monitoring/metrics_store.py --config-file pyproject.toml` *(fails: missing stubs)*
- `python -m pytest -W error -vv tests/test_metrics_store.py::test_metrics_insertion` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_b_687d286a9e5c833188f9fe2ead5f9cce