### PR TITLE
Implement PagerDuty cooldown

### DIFF
--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -15,10 +15,12 @@ class Settings(BaseSettings):
     log_file: str = "app.log"
     sla_threshold_hours: float = 2.0
     SLA_THRESHOLD_HOURS: float = 2.0
+    sla_alert_cooldown_hours: float = 1.0
+    SLA_ALERT_COOLDOWN_HOURS: float = 1.0
     enable_pagerduty: bool = True
     ENABLE_PAGERDUTY: bool = True
 
-    @field_validator("sla_threshold_hours")
+    @field_validator("sla_threshold_hours", "sla_alert_cooldown_hours")
     @classmethod
     def _positive(cls, value: float) -> float:
         if value <= 0:

--- a/backend/monitoring/tests/test_pagerduty_cooldown.py
+++ b/backend/monitoring/tests/test_pagerduty_cooldown.py
@@ -1,0 +1,51 @@
+"""Tests for PagerDuty SLA cooldown logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+from datetime import datetime, timedelta
+
+# Add monitoring src to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from monitoring import main, pagerduty  # noqa: E402
+
+
+def _use_fake_redis(fake_redis: Any, monkeypatch: Any) -> None:
+    monkeypatch.setattr(main, "sync_get", lambda k: fake_redis.get(k))
+    monkeypatch.setattr(main, "sync_set", lambda k, v, ttl=None: fake_redis.set(k, v))
+    monkeypatch.setattr(
+        pagerduty, "sync_set", lambda k, v, ttl=None: fake_redis.set(k, v)
+    )
+
+
+def test_sla_cooldown_skips_alert(monkeypatch: Any, fake_redis: Any) -> None:
+    """Alert should not fire again during the cooldown period."""
+    _use_fake_redis(fake_redis, monkeypatch)
+    monkeypatch.setattr(main, "_record_latencies", lambda: [10800.0])
+    monkeypatch.setattr(main.settings, "SLA_THRESHOLD_HOURS", 1.0)
+    monkeypatch.setattr(main.settings, "SLA_ALERT_COOLDOWN_HOURS", 1.0)
+    monkeypatch.setenv("PAGERDUTY_ROUTING_KEY", "key")
+
+    called: list[float] = []
+
+    def fake_trigger(hours: float) -> None:
+        called.append(hours)
+
+    monkeypatch.setattr(main, "trigger_sla_violation", fake_trigger)
+
+    # First call should trigger and store timestamp
+    main._check_sla()
+    assert called == [3.0]
+
+    # Set last alert timestamp to 30 minutes ago
+    fake_redis.set(
+        pagerduty.SLA_LAST_ALERT_KEY,
+        str((datetime.utcnow() - timedelta(minutes=30)).timestamp()),
+    )
+
+    called.clear()
+    main._check_sla()
+    assert called == []


### PR DESCRIPTION
## Summary
- track last PagerDuty alert timestamp in Redis
- skip SLA alert when last alert was within cooldown period
- configure SLA alert cooldown in settings
- test PagerDuty cooldown logic

## Testing
- `flake8 backend/monitoring/src/monitoring/pagerduty.py backend/monitoring/src/monitoring/main.py backend/monitoring/src/monitoring/settings.py backend/monitoring/tests/test_pagerduty_cooldown.py tests/test_pagerduty.py tests/test_sla.py`
- `pydocstyle backend/monitoring/src/monitoring/pagerduty.py backend/monitoring/src/monitoring/main.py backend/monitoring/src/monitoring/settings.py backend/monitoring/tests/test_pagerduty_cooldown.py tests/test_pagerduty.py tests/test_sla.py`
- `mypy --config-file pyproject.toml backend/monitoring/src/monitoring/pagerduty.py backend/monitoring/src/monitoring/main.py backend/monitoring/src/monitoring/settings.py backend/monitoring/tests/test_pagerduty_cooldown.py` *(fails: missing type hints in unrelated modules)*
- `METRICS_DB_URL=sqlite:// pytest backend/monitoring/tests/test_pagerduty_cooldown.py tests/test_sla.py tests/test_pagerduty.py -vv` *(fails: missing Kafka dependency)*

------
https://chatgpt.com/codex/tasks/task_b_687d286ede7883318d782352556e921b