### PR TITLE
Add SLA alert cooldown logic

### DIFF
--- a/backend/marketplace-publisher/tests/test_publish_metrics.py
+++ b/backend/marketplace-publisher/tests/test_publish_metrics.py
@@ -1,3 +1,5 @@
+"""Tests for metrics publication in ``marketplace_publisher``."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -13,6 +15,8 @@ from marketplace_publisher import db, main, publisher
 async def test_metrics_stored_after_publish(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Background publish should store metrics in TimescaleDB."""
+
     async_url = f"sqlite+aiosqlite:///{tmp_path}/db.sqlite"
     sync_url = f"sqlite:///{tmp_path}/db.sqlite"
 

--- a/backend/mockup-generation/tests/test_generator.py
+++ b/backend/mockup-generation/tests/test_generator.py
@@ -21,6 +21,8 @@ from mockup_generation.generator import MockupGenerator, GenerationError  # noqa
 
 
 class DummySession:
+    """HTTP client that always raises ``RequestException``."""
+
     def post(self, *a, **k):
         from requests.exceptions import RequestException
 

--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -17,10 +17,19 @@ class Settings(BaseSettings):
     SLA_THRESHOLD_HOURS: float = 2.0
     enable_pagerduty: bool = True
     ENABLE_PAGERDUTY: bool = True
+    sla_alert_cooldown_minutes: int = 60
+    SLA_ALERT_COOLDOWN_MINUTES: int = 60
 
     @field_validator("sla_threshold_hours")
     @classmethod
     def _positive(cls, value: float) -> float:
+        if value <= 0:
+            raise ValueError("must be positive")
+        return value
+
+    @field_validator("sla_alert_cooldown_minutes")
+    @classmethod
+    def _cooldown_positive(cls, value: int) -> int:
         if value <= 0:
             raise ValueError("must be positive")
         return value

--- a/backend/monitoring/tests/test_pagerduty.py
+++ b/backend/monitoring/tests/test_pagerduty.py
@@ -1,0 +1,101 @@
+"""Tests for PagerDuty utilities and SLA cooldown logic."""
+
+from __future__ import annotations
+from pathlib import Path
+import sys
+import types
+
+from typing import Any
+
+import fakeredis
+
+# Add monitoring src to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from monitoring import pagerduty  # noqa: E402
+
+
+def _import_main(monkeypatch: Any):
+    """Import ``monitoring.main`` with database connections patched."""
+    monkeypatch.setitem(
+        sys.modules,
+        "psycopg2",
+        types.SimpleNamespace(connect=lambda *a, **k: types.SimpleNamespace()),
+    )
+    from monitoring import main as main_module  # noqa: E402
+
+    return main_module
+
+
+PAGERDUTY_URL = pagerduty.PAGERDUTY_URL
+
+
+def test_trigger_sla_violation_sends_request(
+    requests_mock: Any, monkeypatch: Any
+) -> None:
+    """trigger_sla_violation should POST alert when routing key present."""
+    monkeypatch.setenv("PAGERDUTY_ROUTING_KEY", "key")
+    requests_mock.post(PAGERDUTY_URL, status_code=202)
+    pagerduty.trigger_sla_violation(2.5)
+    assert requests_mock.called
+    history = requests_mock.request_history[0]
+    assert history.json()["routing_key"] == "key"
+    assert "2.50" in history.json()["payload"]["summary"]
+
+
+def test_notify_listing_issue_sends_request(
+    requests_mock: Any, monkeypatch: Any
+) -> None:
+    """notify_listing_issue should POST listing alert when routing key present."""
+    monkeypatch.setenv("PAGERDUTY_ROUTING_KEY", "key")
+    requests_mock.post(PAGERDUTY_URL, status_code=202)
+    pagerduty.notify_listing_issue(123, "removed")
+    assert requests_mock.called
+    history = requests_mock.request_history[0]
+    assert history.json()["payload"]["summary"] == "Listing 123 is removed"
+
+
+def test_pagerduty_disabled_skips_request(requests_mock: Any, monkeypatch: Any) -> None:
+    """No request should be made when ENABLE_PAGERDUTY is false."""
+    monkeypatch.setenv("PAGERDUTY_ROUTING_KEY", "key")
+    main = _import_main(monkeypatch)
+    monkeypatch.setattr(main.settings, "enable_pagerduty", False)
+    requests_mock.post(PAGERDUTY_URL, status_code=202)
+    pagerduty.trigger_sla_violation(1.0)
+    assert not requests_mock.called
+
+
+def test_sla_alert_respects_cooldown(monkeypatch: Any) -> None:
+    """Subsequent SLA alerts are suppressed during cooldown."""
+    main = _import_main(monkeypatch)
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(main, "sync_get", lambda key: fake.get(key))
+    monkeypatch.setattr(
+        main,
+        "sync_set",
+        lambda key, value, ttl=None: (
+            fake.set(key, value) if ttl is None else fake.setex(key, ttl, value)
+        ),
+    )
+    monkeypatch.setattr(main.settings, "SLA_THRESHOLD_HOURS", 2)
+    monkeypatch.setattr(main.settings, "SLA_ALERT_COOLDOWN_MINUTES", 10)
+    monkeypatch.setattr(main, "_record_latencies", lambda: [7200.0, 10800.0])
+    times = iter([1000.0, 1000.0, 1000.0 + 601])
+
+    def fake_time() -> float:
+        try:
+            return next(times)
+        except StopIteration:  # pragma: no cover - extra calls
+            return 1000.0 + 601
+
+    monkeypatch.setattr(main.time, "time", fake_time)
+    triggered: list[float] = []
+
+    def fake_trigger(hours: float) -> None:
+        triggered.append(hours)
+
+    monkeypatch.setattr(main, "trigger_sla_violation", fake_trigger)
+    main._check_sla()
+    main._check_sla()
+    main._check_sla()
+    assert len(triggered) == 2

--- a/docs/blueprints/DesignIdeaEngineCompleteBlueprint.md
+++ b/docs/blueprints/DesignIdeaEngineCompleteBlueprint.md
@@ -1345,8 +1345,9 @@ erDiagram
   - Contract tests for each external API; use VCR.py cassettes to keep CI fast.
 
 - **Monitoring & Alerts**:
-  - Average time from signal ingestion to publishing is tracked via the `signal_to_publish_seconds` metric and displayed in the monitoring dashboard.
-  - PagerDuty alerts trigger if this average exceeds the configured `SLA_THRESHOLD_HOURS`.
+- Average time from signal ingestion to publishing is tracked via the `signal_to_publish_seconds` metric and displayed in the monitoring dashboard.
+- PagerDuty alerts trigger if this average exceeds the configured `SLA_THRESHOLD_HOURS`.
+- Alerts are suppressed for `SLA_ALERT_COOLDOWN_MINUTES` after each incident.
 
 ### **Key Takeaways**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ application settings classes.
 | `ENABLED_ADAPTERS` | Comma separated list of ingestion adapters to run; if unset all adapters are used |
 | `PAGERDUTY_ROUTING_KEY` | Integration key for sending PagerDuty incidents |
 | `ENABLE_PAGERDUTY` | Set to `true` to enable PagerDuty notifications |
+| `SLA_ALERT_COOLDOWN_MINUTES` | Minimum minutes between SLA alerts |
 | `DEDUP_ERROR_RATE` | Probability of false positives in the Bloom filter |
 | `DEDUP_CAPACITY` | Estimated maximum number of entries in the Bloom filter |
 | `DEDUP_TTL` | Time-to-live in seconds for deduplication keys |


### PR DESCRIPTION
## Summary
- skip SLA PagerDuty alerts when within cooldown
- persist last alert timestamp in Redis
- document cooldown in blueprint and configuration
- add regression tests for PagerDuty cooldown behavior

## Testing
- `make lint` *(fails: mypy errors)*
- `python -m pytest -W error -vv backend/monitoring/tests/test_pagerduty.py tests/test_sla.py tests/test_latency_cache.py` *(fails: ModuleNotFoundError & other issues)*

------
https://chatgpt.com/codex/tasks/task_b_687d2fb060c0833189ac81c94ce0e1a8