### PR TITLE
Add Alembic heads helper and tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,27 @@ Use these prefixes so the release script can determine the next semantic version
 
 Run `./scripts/release.sh <registry>` after your changes are merged. The script updates `CHANGELOG.md`, creates a git tag, builds Docker images and pushes them with the new version number.
 
+## Database Migrations
+
+Migrations for each service live under `backend/shared/db/migrations`. After changing models, generate a new revision:
+
+```bash
+alembic -c backend/shared/db/<config>.ini revision -m "add feature" --autogenerate
+```
+
+Before merging branches ensure only one revision head exists. If multiple heads are reported by `alembic heads`, create a merge revision:
+
+```bash
+alembic -c backend/shared/db/<config>.ini merge -m "merge heads" HEADS
+```
+
+Run the migration tests to verify the chain is valid:
+
+```bash
+pytest tests/test_migrations.py tests/integration/test_alembic_heads.py
+```
+
+
 ## Third-Party Licenses
 
 Generate the bundled `LICENSES` file with:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package."""

--- a/tests/integration/test_alembic_heads.py
+++ b/tests/integration/test_alembic_heads.py
@@ -1,0 +1,27 @@
+"""Integration test ensuring each migration folder has a single head."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+from tests.utils import assert_single_head
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    [
+        "backend/shared/db/alembic_scoring_engine.ini",
+        "backend/shared/db/alembic_api_gateway.ini",
+        "backend/shared/db/alembic_marketplace_publisher.ini",
+        "backend/shared/db/alembic_signal_ingestion.ini",
+    ],
+)
+def test_alembic_heads_single(config_path: str) -> None:
+    """Run ``alembic heads`` and assert a single head exists."""
+    assert_single_head(config_path)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -13,8 +13,8 @@ sys.path.append(str(REPO_ROOT / "backend" / "signal-ingestion" / "src"))
 
 from alembic import command
 from alembic.config import Config
-from alembic.script import ScriptDirectory
 import pytest
+from tests.utils import assert_single_head
 
 
 def _run_migration(config_path: str, tmp_path: Path) -> None:
@@ -25,14 +25,6 @@ def _run_migration(config_path: str, tmp_path: Path) -> None:
 
     command.upgrade(cfg, "head")
     command.downgrade(cfg, "base")
-
-
-def _assert_single_head(config_path: str) -> None:
-    """Run ``alembic heads`` and assert a single head exists."""
-    cfg = Config(config_path)
-    script = ScriptDirectory.from_config(cfg)
-    heads = script.get_heads()
-    assert len(heads) == 1, f"{config_path} has multiple heads: {heads}"
 
 
 @pytest.mark.parametrize(
@@ -60,4 +52,4 @@ def test_migrations(config_path: str, tmp_path: Path) -> None:
 )
 def test_single_head(config_path: str) -> None:
     """Ensure each environment has a single Alembic head."""
-    _assert_single_head(config_path)
+    assert_single_head(config_path)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,14 @@
+"""Pytest utilities used across the test suite."""
+
+from __future__ import annotations
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def assert_single_head(config_path: str) -> None:
+    """Assert that ``alembic heads`` returns a single revision for ``config_path``."""
+    cfg = Config(config_path)
+    script = ScriptDirectory.from_config(cfg)
+    heads = script.get_heads()
+    assert len(heads) == 1, f"{config_path} has multiple heads: {heads}"


### PR DESCRIPTION
## Summary
- add `assert_single_head` helper for alembic
- check alembic heads in integration tests
- document migration workflow in CONTRIBUTING

## Testing
- `pytest tests/test_migrations.py tests/integration/test_alembic_heads.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_687d4b1a6a04833187cc12581cb8ba84