### PR TITLE
Add Next.js frontend docs

### DIFF
--- a/docs/frontend/api_calls.rst
+++ b/docs/frontend/api_calls.rst
@@ -1,0 +1,7 @@
+API Calls
+=========
+
+The dashboard communicates with backend services through the API Gateway. The following OpenAPI spec shows the available routes.
+
+.. openapi:: ../../openapi/api-gateway.json
+   :encoding: utf-8

--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -1,0 +1,8 @@
+Next.js Frontend
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   nextjs_setup
+   api_calls

--- a/docs/frontend/nextjs_setup.rst
+++ b/docs/frontend/nextjs_setup.rst
@@ -1,0 +1,19 @@
+Next.js Setup
+=============
+
+This page explains how the admin dashboard's Next.js project is structured and how to run it locally.
+
+Project Structure
+-----------------
+The dashboard lives in ``frontend/admin-dashboard``. It uses **TypeScript** with **tRPC** for API calls and **Tailwind CSS** for styling.
+
+Local Development
+-----------------
+Install dependencies with ``npm install --legacy-peer-deps`` and start the dev server:
+
+.. code-block:: bash
+
+   cd frontend/admin-dashboard
+   npm run dev
+
+Environment variables are loaded from ``.env.local``. See ``frontend/admin-dashboard/README.md`` for details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to desAInz's documentation!
    blueprints/DesignIdeaEngineCompleteBlueprint
    implementation_plan
    admin_dashboard_trpc
+   frontend/index
    staging_manual_qa
    migrations
    privacy


### PR DESCRIPTION
## Summary
- add `docs/frontend` section for Next.js
- provide example API call docs using existing OpenAPI spec
- link new docs from index

## Testing
- `docformatter --in-place --recursive docs/frontend docs/index.rst`
- `flake8 --select=D docs/frontend docs/index.rst`
- `SKIP_OPENAPI=1 sphinx-build -b html docs docs/_build/html`
- `flake8`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: many errors)*
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_687d522b83088331a210e0b567d8e610