### PR TITLE
Add daily summary Dagster job and monitoring endpoint

### DIFF
--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -37,6 +37,7 @@ LAST_ALERT_KEY = "sla:last_alert"
 
 from .logging_config import configure_logging
 from .settings import settings
+from scripts.daily_summary import generate_daily_summary
 
 metrics_store = TimescaleMetricsStore()
 
@@ -207,6 +208,13 @@ async def latency() -> dict[str, float]:
     """Return average signal-to-publish latency without triggering alerts."""
     avg = get_average_latency()
     return {"average_seconds": avg}
+
+
+@app.get("/daily_summary")
+async def daily_summary() -> dict[str, object]:
+    """Return the daily summary generated from recent activity."""
+    summary = await generate_daily_summary()
+    return dict(summary)
 
 
 @app.get("/logs")

--- a/backend/orchestrator/README.md
+++ b/backend/orchestrator/README.md
@@ -6,6 +6,7 @@ This module contains all Dagster jobs and schedules for desAInz.
 
 - **daily_backup_schedule**: Runs `backup_job` every day at 00:00 UTC. Ensures backups are created regularly.
 - **hourly_cleanup_schedule**: Runs `cleanup_job` every hour. Removes temporary data to keep storage usage low.
+- **daily_summary_schedule**: Runs `daily_summary_job` every day at 00:05 UTC. Generates a JSON report of recent activity.
 
 Metrics for job success and failure are exported as Prometheus counters:
 `backup_job_success_total`, `backup_job_failure_total`, `cleanup_job_success_total`, and `cleanup_job_failure_total`.

--- a/backend/orchestrator/orchestrator/__init__.py
+++ b/backend/orchestrator/orchestrator/__init__.py
@@ -1,15 +1,21 @@
 """Orchestration pipelines using Dagster."""
 
-from .jobs import cleanup_job, idea_job, backup_job
-from .schedules import daily_backup_schedule, hourly_cleanup_schedule
+from .jobs import cleanup_job, idea_job, backup_job, daily_summary_job
+from .schedules import (
+    daily_backup_schedule,
+    hourly_cleanup_schedule,
+    daily_summary_schedule,
+)
 from .sensors import idea_sensor, run_failure_notifier
 
 __all__ = [
     "idea_job",
     "backup_job",
     "cleanup_job",
+    "daily_summary_job",
     "daily_backup_schedule",
     "hourly_cleanup_schedule",
+    "daily_summary_schedule",
     "idea_sensor",
     "run_failure_notifier",
 ]

--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -9,6 +9,7 @@ from .ops import (
     backup_data,
     cleanup_data,
     analyze_query_plans_op,
+    run_daily_summary,
     generate_content,
     ingest_signals,
     publish_content,
@@ -43,3 +44,9 @@ def cleanup_job() -> None:
 def analyze_query_plans_job() -> None:
     """Job collecting EXPLAIN plans for slow queries."""
     analyze_query_plans_op()
+
+
+@job(hooks={record_success, record_failure})
+def daily_summary_job() -> None:
+    """Job generating the daily activity summary."""
+    run_daily_summary()

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -214,3 +214,17 @@ def analyze_query_plans_op(  # type: ignore[no-untyped-def]
     from scripts import analyze_query_plans
 
     analyze_query_plans.main()
+
+
+@op  # type: ignore[misc]
+def run_daily_summary(  # type: ignore[no-untyped-def]
+    context,
+) -> None:
+    """Execute the daily summary script and log the result."""
+    context.log.info("generating daily summary")
+    from scripts.daily_summary import generate_daily_summary
+
+    import asyncio
+
+    summary = asyncio.run(generate_daily_summary())
+    context.log.debug("summary: %s", summary)

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -2,21 +2,35 @@
 
 from dagster import Definitions
 
-from .jobs import analyze_query_plans_job, backup_job, cleanup_job, idea_job
+from .jobs import (
+    analyze_query_plans_job,
+    backup_job,
+    cleanup_job,
+    idea_job,
+    daily_summary_job,
+)
 from .schedules import (
     daily_backup_schedule,
     hourly_cleanup_schedule,
     daily_query_plan_schedule,
+    daily_summary_schedule,
 )
 from .sensors import idea_sensor, run_failure_notifier
 
 
 defs = Definitions(
-    jobs=[idea_job, backup_job, cleanup_job, analyze_query_plans_job],
+    jobs=[
+        idea_job,
+        backup_job,
+        cleanup_job,
+        analyze_query_plans_job,
+        daily_summary_job,
+    ],
     schedules=[
         daily_backup_schedule,
         hourly_cleanup_schedule,
         daily_query_plan_schedule,
+        daily_summary_schedule,
     ],
     sensors=[idea_sensor, run_failure_notifier],
 )

--- a/backend/orchestrator/orchestrator/schedules.py
+++ b/backend/orchestrator/orchestrator/schedules.py
@@ -2,7 +2,12 @@
 
 from dagster import ScheduleEvaluationContext, schedule
 
-from .jobs import backup_job, cleanup_job, analyze_query_plans_job
+from .jobs import (
+    backup_job,
+    cleanup_job,
+    analyze_query_plans_job,
+    daily_summary_job,
+)
 
 
 @schedule(cron_schedule="0 0 * * *", job=backup_job, execution_timezone="UTC")
@@ -22,4 +27,10 @@ def hourly_cleanup_schedule(_context: ScheduleEvaluationContext) -> dict[str, ob
 )
 def daily_query_plan_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
     """Trigger ``analyze_query_plans_job`` every morning."""
+    return {}
+
+
+@schedule(cron_schedule="5 0 * * *", job=daily_summary_job, execution_timezone="UTC")
+def daily_summary_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
+    """Trigger ``daily_summary_job`` every day."""
     return {}

--- a/backend/orchestrator/tests/test_jobs.py
+++ b/backend/orchestrator/tests/test_jobs.py
@@ -12,6 +12,7 @@ from orchestrator.jobs import (  # noqa: E402
     backup_job,
     cleanup_job,
     idea_job,
+    daily_summary_job,
 )
 import pytest  # noqa: E402
 from dagster import DagsterInstance, RunRequest, build_sensor_context  # noqa: E402
@@ -20,6 +21,7 @@ from orchestrator.schedules import (  # noqa: E402
     daily_backup_schedule,
     daily_query_plan_schedule,
     hourly_cleanup_schedule,
+    daily_summary_schedule,
 )
 from orchestrator.sensors import idea_sensor  # noqa: E402
 
@@ -53,6 +55,13 @@ def test_query_plan_schedule_definition() -> None:
 
     assert daily_query_plan_schedule.job.name == "analyze_query_plans_job"
     assert daily_query_plan_schedule.cron_schedule == "30 6 * * *"
+
+
+def test_daily_summary_schedule_definition() -> None:
+    """Daily summary schedule is correctly configured."""
+
+    assert daily_summary_schedule.job == daily_summary_job
+    assert daily_summary_schedule.cron_schedule == "5 0 * * *"
 
 
 def test_idea_job_execution(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/docs/daily_summary.md
+++ b/docs/daily_summary.md
@@ -11,3 +11,10 @@ Run the script manually or schedule it via cron:
 ```bash
 ./scripts/daily_summary.py
 ```
+
+The monitoring service exposes the same information via the
+`/daily_summary` HTTP endpoint:
+
+```bash
+curl http://monitoring:8000/daily_summary
+```

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import sys
+from typing import Any
 
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "monitoring" / "src")
@@ -38,3 +39,23 @@ def test_health_ready_endpoints() -> None:
     response = client.get("/ready")
     assert response.status_code == 200
     assert response.json() == {"status": "ready"}
+
+
+def test_daily_summary_endpoint(monkeypatch: Any) -> None:
+    """Daily summary endpoint returns generated summary."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "monitoring.main.generate_daily_summary",
+        AsyncMock(
+            return_value={
+                "ideas_generated": 1,
+                "mockup_success_rate": 1.0,
+                "marketplace_stats": {},
+            }
+        ),
+    )
+    response = client.get("/daily_summary")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ideas_generated"] == 1


### PR DESCRIPTION
## Summary
- support running daily summary script from Dagster
- expose `/daily_summary` in monitoring API
- schedule daily summary job
- test job & endpoint
- document daily summary endpoint

## Testing
- `flake8 backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/__init__.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/tests/test_jobs.py tests/test_monitoring.py`
- `pydocstyle backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/__init__.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/tests/test_jobs.py tests/test_monitoring.py`
- `docformatter --check backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/__init__.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/tests/test_jobs.py tests/test_monitoring.py`
- `mypy --install-types --non-interactive backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/__init__.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/tests/test_jobs.py tests/test_monitoring.py` *(failed: missing stubs)*
- `pytest -W error -vv` *(failed: connection refused to localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_b_687d522f96f48331aed61913e579a572