### PR TITLE
Add S3 cleanup maintenance task

### DIFF
--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -203,6 +203,7 @@ def cleanup_data(  # type: ignore[no-untyped-def]
     context.log.info("running cleanup")
     maintenance.archive_old_mockups()
     maintenance.purge_stale_records()
+    maintenance.purge_old_s3_objects()
 
 
 @op  # type: ignore[misc]

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -9,6 +9,8 @@ the following actions:
   are removed.
 - **Purge stale signals and logs**: any signal entries older than thirty days
   are deleted along with log files under the directory specified by `LOG_DIR`.
+- **Delete old S3 objects**: objects older than the configured retention period
+  are removed from the bucket defined by `S3_BUCKET`.
 - **Remove audit log entries**: records older than eighteen months are purged to
   keep the audit table compact.
 
@@ -27,6 +29,8 @@ Environment variables can override the storage paths:
 
 - `COLD_STORAGE_PATH` – directory for archived mockups (defaults to `cold_storage`)
 - `LOG_DIR` – directory containing log files (defaults to `logs`)
+- `S3_BUCKET` – target bucket for object cleanup
+- `S3_RETENTION_DAYS` – optional retention period in days (defaults to 90)
 
 ## Log Rotation
 

--- a/tests/test_maintenance_s3.py
+++ b/tests/test_maintenance_s3.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from scripts import maintenance
+from backend.shared import config
+import warnings
+
+
+@mock_aws
+def test_purge_old_s3_objects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Objects older than the retention period are removed."""
+    s3 = boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    bucket = "test-bucket"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_object(Bucket=bucket, Key="old.txt", Body=b"x")
+
+    monkeypatch.setattr(
+        maintenance,
+        "datetime",
+        type("T", (datetime,), {"utcnow": classmethod(lambda cls: datetime.utcnow() + timedelta(days=91))}),
+    )
+    monkeypatch.setattr(config.settings, "s3_bucket", bucket, raising=False)
+    monkeypatch.setattr(config.settings, "s3_endpoint", None, raising=False)
+    monkeypatch.setattr(config.settings, "s3_access_key", None, raising=False)
+    monkeypatch.setattr(config.settings, "s3_secret_key", None, raising=False)
+
+    maintenance.purge_old_s3_objects()
+
+    remaining = s3.list_objects_v2(Bucket=bucket)
+    assert "Contents" not in remaining


### PR DESCRIPTION
## Summary
- purge old objects in S3 via new maintenance task
- trigger purge from Dagster cleanup op
- document S3 cleanup configuration
- test S3 purge using Moto

## Testing
- `flake8 scripts/maintenance.py backend/orchestrator/orchestrator/ops.py tests/test_maintenance_s3.py`
- `pydocstyle scripts/maintenance.py tests/test_maintenance_s3.py backend/orchestrator/orchestrator/ops.py`
- `docformatter --check scripts/maintenance.py tests/test_maintenance_s3.py backend/orchestrator/orchestrator/ops.py`
- `mypy scripts/maintenance.py tests/test_maintenance_s3.py backend/orchestrator/orchestrator/ops.py` *(fails: Library stubs not installed for "requests")*
- `pytest tests/test_maintenance_s3.py`

------
https://chatgpt.com/codex/tasks/task_b_687d5a6f6ecc833191ce159c13ff3584