### PR TITLE
Add docstring for logging level validator

### DIFF
--- a/backend/service-template/src/settings.py
+++ b/backend/service-template/src/settings.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     @field_validator("log_level")
     @classmethod
     def _valid_level(cls, value: str) -> str:
+        """Validate the provided logging level."""
+
         return value
 
 


### PR DESCRIPTION
## Summary
- document log level validator in `service-template` settings

## Testing
- `docformatter -i backend/service-template/src/*.py`
- `flake8 backend/service-template/src --select=D`


------
https://chatgpt.com/codex/tasks/task_b_687d68b241a48331b84c89860fe64e28