### PR TITLE
Add blue/green rollout action

### DIFF
--- a/.github/actions/blue-green-rollout/action.yml
+++ b/.github/actions/blue-green-rollout/action.yml
@@ -1,0 +1,22 @@
+name: Blue Green Rollout
+inputs:
+  namespace:
+    description: "Kubernetes namespace"
+    required: true
+  services:
+    description: "Space separated list of services"
+    required: true
+  registry:
+    description: "Container registry prefix"
+    required: true
+  tag:
+    description: "Image tag"
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        for svc in ${{ inputs.services }}; do
+          ./scripts/deploy.sh "$svc" "${{ inputs.registry }}/$svc:${{ inputs.tag }}" "${{ inputs.namespace }}"
+        done

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -17,9 +17,13 @@ jobs:
       - name: Mirror secrets from production
         run: |
           ./scripts/sync_staging_secrets.sh prod staging
-      - name: Deploy services
-        run: |
-          for svc in orchestrator ai-mockup-generation data-storage signal-ingestion scoring-engine marketplace-publisher feedback-loop; do
-            ./scripts/deploy.sh "$svc" "example/$svc:main" staging
-          done
+      - name: Blue/green rollout
+        uses: ./.github/actions/blue-green-rollout
+        with:
+          namespace: staging
+          services: >-
+            orchestrator ai-mockup-generation data-storage signal-ingestion
+            scoring-engine marketplace-publisher feedback-loop
+          registry: example
+          tag: main
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,3 +86,28 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
 2. Run containers in Azure Container Instances or AKS. Mount secrets from Azure Key Vault using CSI drivers.
 
 All deployments share the same environment variables. Ensure that values for credentials, API keys and connection strings are stored securely using the secret management solution of your platform.
+
+## Rollback
+
+Blue/green deployments update services by switching the `color` selector of the
+Kubernetes `Service`. If an issue is detected after a rollout, direct traffic
+back to the previous version by patching the service to the old color. Retrieve
+the current color with:
+
+```bash
+kubectl get svc <service> -n <namespace> -o jsonpath='{.spec.selector.color}'
+```
+
+Then patch the selector to the desired color:
+
+```bash
+kubectl patch svc <service> -n <namespace> \
+  -p '{"spec":{"selector":{"app":"<service>","color":"<previous_color>"}}}'
+```
+
+Alternatively, redeploy the desired tag using the `deploy.sh` helper which will
+update the service selector and scale down the newer deployment:
+
+```bash
+./scripts/deploy.sh <service> example/<service>:<tag> <namespace>
+```


### PR DESCRIPTION
## Summary
- add custom composite action for blue/green rollouts
- use new action from `staging-deploy.yml`
- document rollback procedure

## Testing
- `docformatter --check docs/deployment.md`
- `flake8 .`
- `pytest -k '' -v` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `npx eslint .` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_687d6884de308331961c26794bd1dd5a