### PR TITLE
Add postgres aggregate test

### DIFF
--- a/backend/monitoring/tests/test_metrics_store.py
+++ b/backend/monitoring/tests/test_metrics_store.py
@@ -1,0 +1,27 @@
+"""Tests for TimescaleMetricsStore with PostgreSQL."""
+
+from __future__ import annotations
+
+import shutil
+
+import psycopg2
+import pytest
+from pytest_postgresql import factories
+
+from backend.monitoring.src.monitoring.metrics_store import TimescaleMetricsStore
+
+# Create PostgreSQL fixtures using pytest-postgresql factory
+postgresql_proc = factories.postgresql_proc()
+postgresql = factories.postgresql("postgresql_proc")
+
+
+@pytest.mark.skipif(shutil.which("initdb") is None, reason="initdb not available")
+def test_create_continuous_aggregate(
+    postgresql: psycopg2.extensions.connection,
+) -> None:
+    """Ensure continuous aggregate view is created on PostgreSQL."""
+    store = TimescaleMetricsStore(postgresql.info.dsn)
+    store.create_hourly_continuous_aggregate()
+    with postgresql.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_matviews WHERE matviewname='latency_hourly'")
+        assert cur.fetchone() is not None


### PR DESCRIPTION
## Summary
- add a PostgreSQL metrics store test using pytest-postgresql

## Testing
- `pytest -W error -vv backend/monitoring/tests/test_metrics_store.py`

------
https://chatgpt.com/codex/tasks/task_b_687d68b2c0088331a39adc6d82f33ef4