### PR TITLE
Add periodic exchange rate updates

### DIFF
--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -14,6 +14,7 @@ from .settings import settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.currency import start_rate_updater
 
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
@@ -33,6 +34,12 @@ configure_sentry(app, settings.app_name)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+
+
+@app.on_event("startup")
+async def start_rates() -> None:
+    """Start background exchange rate updates."""
+    start_rate_updater()
 
 
 def _identify_user(request: Request) -> str:

--- a/backend/shared/tests/test_currency.py
+++ b/backend/shared/tests/test_currency.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import importlib.util
+from typing import Any
+
 import fakeredis
 import pytest
-
-import importlib.util
-from pathlib import Path
+from apscheduler.schedulers.background import BackgroundScheduler
 
 spec = importlib.util.spec_from_file_location(
     "currency", Path(__file__).resolve().parents[1] / "currency.py"
@@ -22,19 +24,36 @@ def setup_module(module: object) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _mock_rates(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Mock rate fetching to provide deterministic values."""
-    rates = {"EUR": 0.8456}
-
-    def _fake_fetch(base: str = currency.BASE_CURRENCY) -> dict[str, float]:
-        return rates
-
-    monkeypatch.setattr(currency, "_fetch_rates", _fake_fetch)
+def _reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset Redis and scheduler before each test."""
     currency.redis_client.flushall()
+    if currency.scheduler.running:
+        currency.scheduler.shutdown()
+    monkeypatch.setattr(currency, "scheduler", BackgroundScheduler())
+
+
+def test_update_rates(requests_mock: Any) -> None:
+    """Fetched rates are stored in Redis."""
+    requests_mock.get(currency.EXCHANGE_API_URL, json={"rates": {"EUR": 0.84}})
     currency.update_rates()
+    assert currency.redis_client.get(currency.REDIS_KEY) == '{"EUR": 0.84}'
 
 
-def test_convert_price_rounding() -> None:
+def test_convert_price_rounding(requests_mock: Any) -> None:
     """Converted amounts are rounded using ``ROUND_HALF_UP``."""
+    requests_mock.get(currency.EXCHANGE_API_URL, json={"rates": {"EUR": 0.8456}})
+    currency.update_rates()
     result = currency.convert_price(1.0, "EUR")
     assert result == 0.85
+
+
+def test_start_rate_updater_adds_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scheduler runs periodic update job."""
+    monkeypatch.setattr(currency, "scheduler", BackgroundScheduler())
+    monkeypatch.setattr(
+        currency, "_fetch_rates", lambda base=currency.BASE_CURRENCY: {"EUR": 1.0}
+    )
+    currency.start_rate_updater()
+    jobs = currency.scheduler.get_jobs()
+    assert len(jobs) == 1
+    currency.scheduler.shutdown()


### PR DESCRIPTION
## Summary
- integrate external exchange-rate provider in `currency.py`
- start the rate updater on FastAPI startup in service template
- add tests using `requests_mock` for currency updates

## Testing
- `flake8 backend/shared/currency.py`
- `black backend/shared/currency.py --check`
- `flake8 backend/service-template/src/main.py`
- `black backend/service-template/src/main.py --check`
- `flake8 backend/shared/tests/test_currency.py`
- `black backend/shared/tests/test_currency.py --check`
- `pytest backend/shared/tests/test_currency.py -q`
- `mypy backend/shared/currency.py` *(fails: import stubs and other modules)*

------
https://chatgpt.com/codex/tasks/task_b_687d68b47fb88331afdb6afc33921e0d