### PR TITLE
Add Dagster job retries and retry sensor

### DIFF
--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from dagster import job
+from dagster import RetryPolicy, job
+
+DEFAULT_JOB_RETRY_POLICY = RetryPolicy(max_retries=3, delay=1)
 
 from .ops import (
     await_approval,
@@ -18,7 +20,7 @@ from .ops import (
 from .hooks import record_failure, record_success
 
 
-@job
+@job(retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def idea_job() -> None:
     """Pipeline from ingestion to publishing."""
     signals = ingest_signals()
@@ -28,25 +30,25 @@ def idea_job() -> None:
     publish_content(items)
 
 
-@job(hooks={record_success, record_failure})
+@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def backup_job() -> None:
     """Job running the backup operation."""
     backup_data()
 
 
-@job(hooks={record_success, record_failure})
+@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def cleanup_job() -> None:
     """Job running periodic cleanup."""
     cleanup_data()
 
 
-@job(hooks={record_success, record_failure})
+@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def analyze_query_plans_job() -> None:
     """Job collecting EXPLAIN plans for slow queries."""
     analyze_query_plans_op()
 
 
-@job(hooks={record_success, record_failure})
+@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def daily_summary_job() -> None:
     """Job generating the daily activity summary."""
     run_daily_summary()


### PR DESCRIPTION
## Summary
- configure default retry policy for Dagster jobs
- reschedule failed runs via new Dagster sensor

## Testing
- `flake8 backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/sensors.py`
- `mypy backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/sensors.py --follow-imports=skip --ignore-missing-imports`
- `docformatter --check backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/sensors.py`
- `pytest -W error -q` *(fails: psycopg2.OperationalError, TypeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_687d7dd2d3708331ba9d31533fb619ab