### PR TITLE
Enable Next.js i18n routing

### DIFF
--- a/frontend/admin-dashboard/__tests__/layout.test.tsx
+++ b/frontend/admin-dashboard/__tests__/layout.test.tsx
@@ -1,13 +1,17 @@
 import { render, screen } from '@testing-library/react';
+import Router from 'next-router-mock';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import RootLayout from '../app/layout';
 
 test('renders children inside layout', () => {
   const originalError = console.error;
   console.error = jest.fn();
   render(
-    <RootLayout>
-      <div>Child</div>
-    </RootLayout>,
+    <RouterContext.Provider value={Router}>
+      <RootLayout>
+        <div>Child</div>
+      </RootLayout>
+    </RouterContext.Provider>,
     { container: document.documentElement }
   );
   expect(screen.getByText('Child')).toBeInTheDocument();

--- a/frontend/admin-dashboard/__tests__/localeSwitch.test.tsx
+++ b/frontend/admin-dashboard/__tests__/localeSwitch.test.tsx
@@ -1,16 +1,27 @@
-import { act, render, screen } from '@testing-library/react';
-import { changeLanguage } from '../src/i18n';
+import { render, screen, waitFor } from '@testing-library/react';
+import Router from 'next-router-mock';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import { ToggleButton } from '../src/components/ToggleButton';
+import { I18nProvider } from '../src/i18n';
 
-test('switches locale at runtime', async () => {
-  render(<ToggleButton />);
-  const button = screen.getByTestId('toggle-button');
-  expect(button).toHaveTextContent('Off');
-  await act(async () => {
-    await changeLanguage('es');
-  });
-  expect(button).toHaveTextContent('Apagado');
-  await act(async () => {
-    await changeLanguage('en');
-  });
+function renderWithRouter(ui: React.ReactElement) {
+  return render(
+    <RouterContext.Provider value={Router}>
+      <I18nProvider>{ui}</I18nProvider>
+    </RouterContext.Provider>
+  );
+}
+
+test('loads translations based on router locale', async () => {
+  Router.locale = 'es';
+  const { unmount } = renderWithRouter(<ToggleButton />);
+  await waitFor(() =>
+    expect(screen.getByTestId('toggle-button')).toHaveTextContent('Apagado')
+  );
+  unmount();
+  Router.locale = 'en';
+  renderWithRouter(<ToggleButton />);
+  await waitFor(() =>
+    expect(screen.getByTestId('toggle-button')).toHaveTextContent('Off')
+  );
 });

--- a/frontend/admin-dashboard/app/layout.tsx
+++ b/frontend/admin-dashboard/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import '../src/styles/globals.css';
 import { LanguageSwitcher } from '../src/components/LanguageSwitcher';
-import i18n from '../src/i18n';
+import { I18nProvider } from '../src/i18n';
 
 export const metadata: Metadata = {
   title: 'Admin Dashboard',
@@ -15,12 +15,14 @@ export default function RootLayout({
   children: ReactNode;
 }) {
   return (
-    <html lang={i18n.language}>
+    <html lang="en">
       <body>
-        <div className="p-2">
-          <LanguageSwitcher />
-        </div>
-        {children}
+        <I18nProvider>
+          <div className="p-2">
+            <LanguageSwitcher />
+          </div>
+          {children}
+        </I18nProvider>
       </body>
     </html>
   );

--- a/frontend/admin-dashboard/next.config.ts
+++ b/frontend/admin-dashboard/next.config.ts
@@ -4,6 +4,10 @@ import type { NextConfig } from 'next';
  * Next.js configuration enabling tree shaking and granular code splitting.
  */
 const nextConfig: NextConfig = {
+  i18n: {
+    locales: ['en', 'es'],
+    defaultLocale: 'en',
+  },
   async headers() {
     return [
       {

--- a/frontend/admin-dashboard/src/components/LanguageSwitcher.tsx
+++ b/frontend/admin-dashboard/src/components/LanguageSwitcher.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/router';
 import { changeLanguage, supportedLngs } from '../i18n';
 
 export function LanguageSwitcher() {
   const { t } = useTranslation();
+  const router = useRouter();
   return (
     <div className="space-x-2" data-testid="language-switcher">
       {supportedLngs.map((lng) => (
         <button
           key={lng}
           type="button"
-          onClick={() => changeLanguage(lng)}
+          onClick={() => {
+            void changeLanguage(lng);
+            void router.push(router.asPath, undefined, { locale: lng });
+          }}
           data-testid={`lang-${lng}`}
         >
           {t(lng === 'en' ? 'english' : 'spanish')}

--- a/frontend/admin-dashboard/src/i18n.tsx
+++ b/frontend/admin-dashboard/src/i18n.tsx
@@ -1,5 +1,9 @@
+'use client';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import type { ReactNode } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 export const supportedLngs = ['en', 'es'] as const;
 export type SupportedLng = (typeof supportedLngs)[number];
@@ -30,6 +34,16 @@ void loadResources('en');
 export async function changeLanguage(lng: SupportedLng) {
   await loadResources(lng);
   await i18n.changeLanguage(lng);
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const { locale } = useRouter();
+  useEffect(() => {
+    const lng =
+      supportedLngs.find((l) => l === locale) ?? 'en';
+    void changeLanguage(lng);
+  }, [locale]);
+  return <>{children}</>;
 }
 
 export default i18n;

--- a/frontend/admin-dashboard/src/pages/_app.tsx
+++ b/frontend/admin-dashboard/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import type { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import '../styles/globals.css';
 import AdminLayout from '../layouts/AdminLayout';
-import '../i18n';
+import { I18nProvider } from '../i18n';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient();
@@ -15,9 +15,11 @@ export default function MyApp({
   return (
     <SessionProvider session={pageProps.session}>
       <QueryClientProvider client={queryClient}>
-        <AdminLayout>
-          <Component {...pageProps} />
-        </AdminLayout>
+        <I18nProvider>
+          <AdminLayout>
+            <Component {...pageProps} />
+          </AdminLayout>
+        </I18nProvider>
       </QueryClientProvider>
     </SessionProvider>
   );


### PR DESCRIPTION
## Summary
- configure admin dashboard for Next.js i18n routing
- sync language with router locale and update language switcher
- wrap app with `I18nProvider`
- adjust layout to include provider
- update locale switch tests for routing
- fix layout test with router context

## Testing
- `npm test` in `frontend/admin-dashboard`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_b_687d7dd56020833180fdd2333b212751