### PR TITLE
Add automated secret rotation

### DIFF
--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -11,6 +11,7 @@ from .ops import (
     backup_data,
     cleanup_data,
     analyze_query_plans_op,
+    rotate_k8s_secrets_op,
     run_daily_summary,
     generate_content,
     ingest_signals,
@@ -52,3 +53,10 @@ def analyze_query_plans_job() -> None:
 def daily_summary_job() -> None:
     """Job generating the daily activity summary."""
     run_daily_summary()
+
+
+@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+def rotate_secrets_job() -> None:
+    """Job rotating API tokens and updating Kubernetes secrets."""
+
+    rotate_k8s_secrets_op()

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -229,3 +229,15 @@ def run_daily_summary(  # type: ignore[no-untyped-def]
 
     summary = asyncio.run(generate_daily_summary())
     context.log.debug("summary: %s", summary)
+
+
+@op(retry_policy=RetryPolicy(max_retries=3, delay=1))  # type: ignore[misc]
+def rotate_k8s_secrets_op(  # type: ignore[no-untyped-def]
+    context,
+) -> None:
+    """Rotate Kubernetes secrets via :mod:`scripts.rotate_secrets`."""
+
+    context.log.info("rotating Kubernetes secrets")
+    from scripts.rotate_secrets import rotate
+
+    rotate()

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -7,6 +7,7 @@ from .jobs import (
     backup_job,
     cleanup_job,
     idea_job,
+    rotate_secrets_job,
     daily_summary_job,
 )
 from .schedules import (
@@ -14,6 +15,7 @@ from .schedules import (
     hourly_cleanup_schedule,
     daily_query_plan_schedule,
     daily_summary_schedule,
+    monthly_secret_rotation_schedule,
 )
 from .sensors import idea_sensor, run_failure_notifier
 
@@ -25,12 +27,14 @@ defs = Definitions(
         cleanup_job,
         analyze_query_plans_job,
         daily_summary_job,
+        rotate_secrets_job,
     ],
     schedules=[
         daily_backup_schedule,
         hourly_cleanup_schedule,
         daily_query_plan_schedule,
         daily_summary_schedule,
+        monthly_secret_rotation_schedule,
     ],
     sensors=[idea_sensor, run_failure_notifier],
 )

--- a/backend/orchestrator/orchestrator/schedules.py
+++ b/backend/orchestrator/orchestrator/schedules.py
@@ -7,6 +7,7 @@ from .jobs import (
     cleanup_job,
     analyze_query_plans_job,
     daily_summary_job,
+    rotate_secrets_job,
 )
 
 
@@ -33,4 +34,10 @@ def daily_query_plan_schedule(_context: ScheduleEvaluationContext) -> dict[str, 
 @schedule(cron_schedule="5 0 * * *", job=daily_summary_job, execution_timezone="UTC")
 def daily_summary_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
     """Trigger ``daily_summary_job`` every day."""
+    return {}
+
+
+@schedule(cron_schedule="0 0 1 * *", job=rotate_secrets_job, execution_timezone="UTC")
+def monthly_secret_rotation_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
+    """Rotate secrets on the first day of each month."""
     return {}

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,3 +36,11 @@ production. To rotate it safely:
    credentials are rejected.
 3. Redeploy the services to pick up the new secret and remove the old one when
    all clients have refreshed their tokens.
+
+### Automated rotation
+
+The ``scripts/rotate_secrets.py`` helper generates new random tokens and patches
+the corresponding Kubernetes secrets using ``kubectl``. A Dagster job executes
+this script once per month. The ``monthly_secret_rotation_schedule`` defined in
+``backend.orchestrator.orchestrator.schedules`` triggers the job on the first
+day of every month at midnight UTC.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,6 @@
 """Utility scripts."""
+
+from . import maintenance
+from .rotate_secrets import rotate, main as rotate_secrets_main
+
+__all__ = ["maintenance", "rotate", "rotate_secrets_main"]

--- a/scripts/rotate_secrets.py
+++ b/scripts/rotate_secrets.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""Rotate service tokens and update Kubernetes secrets."""
+
+from __future__ import annotations
+
+import base64
+import secrets
+import subprocess
+from typing import Iterable
+
+
+SECRET_NAMES: list[str] = [
+    "api-gateway",
+    "marketplace-publisher",
+    "scoring-engine",
+]
+
+
+def _generate_token(length: int = 32) -> str:
+    """Return a secure random token."""
+    return secrets.token_urlsafe(length)
+
+
+def _kubectl_patch(secret_name: str, token: str) -> None:
+    """Patch ``secret_name`` with the new ``token`` using ``kubectl``."""
+    data = base64.b64encode(token.encode()).decode()
+    subprocess.run(
+        [
+            "kubectl",
+            "patch",
+            "secret",
+            secret_name,
+            "--type=merge",
+            "-p",
+            f'{{"data": {{"SERVICE_TOKEN": "{data}"}}}}',
+        ],
+        check=True,
+    )
+
+
+def rotate(secrets_to_rotate: Iterable[str] | None = None) -> None:
+    """Rotate the given secrets."""
+    names = secrets_to_rotate or SECRET_NAMES
+    for name in names:
+        token = _generate_token()
+        _kubectl_patch(f"{name}-secret", token)
+
+
+def main() -> None:
+    """Entry point for script execution."""
+    rotate()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- document monthly secret rotation steps
- add helper script to rotate Kubernetes secrets
- schedule rotation in Dagster via new job

## Testing
- `flake8 scripts/rotate_secrets.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/schedules.py scripts/__init__.py`
- `docformatter --check --recursive scripts/rotate_secrets.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/schedules.py scripts/__init__.py docs/security.md`
- `mypy backend/orchestrator/orchestrator` *(fails: missing stubs, etc.)*
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pre-commit run --files backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/schedules.py scripts/rotate_secrets.py scripts/__init__.py docs/security.md` *(failed: required GitHub access)*

------
https://chatgpt.com/codex/tasks/task_b_687d815b87448331afabaa0485077b92