### PR TITLE
Add VCR tests for marketplace publisher

### DIFF
--- a/backend/marketplace-publisher/pyproject.toml
+++ b/backend/marketplace-publisher/pyproject.toml
@@ -29,6 +29,7 @@ docformatter = "*"
 pydocstyle = "*"
 mypy = "*"
 pytest = "*"
+pytest-recording = "*"
 pytest-asyncio = "*"
 httpx = "*"
 

--- a/backend/marketplace-publisher/tests/vcr/cassettes/test_httpbin/test_httpbin.yaml
+++ b/backend/marketplace-publisher/tests/vcr/cassettes/test_httpbin/test_httpbin.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: https://proxy:8080/get
+  response:
+    body:
+      string: "{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n
+        \   \"Accept-Encoding\": \"gzip, deflate\", \n    \"Host\": \"httpbin.org\",
+        \n    \"User-Agent\": \"python-requests/2.32.4\", \n    \"X-Amzn-Trace-Id\":
+        \"Root=1-687d8389-7f366a364e35fcf3164ae86c\", \n    \"X-Envoy-Expected-Rq-Timeout-Ms\":
+        \"900000\", \n    \"X-No-Mitm\": \"False\"\n  }, \n  \"origin\": \"52.176.140.121\",
+        \n  \"url\": \"https://httpbin.org/get\"\n}\n"
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-origin:
+      - '*'
+      content-length:
+      - '384'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Jul 2025 00:02:17 GMT
+      server:
+      - envoy
+      x-envoy-upstream-service-time:
+      - '138'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/backend/marketplace-publisher/tests/vcr/test_httpbin.py
+++ b/backend/marketplace-publisher/tests/vcr/test_httpbin.py
@@ -1,0 +1,15 @@
+"""VCR tests for HTTP interactions."""
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+
+@pytest.mark.vcr()
+def test_httpbin() -> None:
+    """Record GET request to httpbin and assert response."""
+    response = requests.get("https://httpbin.org/get", timeout=5)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["url"] == "https://httpbin.org/get"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,3 +33,4 @@ sphinxcontrib - mermaid
 openapi - schema - validator
 opentelemetry - exporter - otlp
 python - jose[cryptography]
+pytest-recording


### PR DESCRIPTION
## Summary
- add pytest-recording to marketplace-publisher dev deps
- record http interactions with pytest-recording
- keep cassette for httpbin GET request
- update dev requirements

## Testing
- `PYTHONPATH=. pytest backend/marketplace-publisher/tests/vcr/test_httpbin.py --import-mode=importlib --record-mode=none -vv`

------
https://chatgpt.com/codex/tasks/task_b_687d814e3f308331aa3fab13236282f0