### PR TITLE
Add axe-core e2e pages checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,6 @@ Run the migration tests to verify the chain is valid:
 pytest tests/test_migrations.py tests/integration/test_alembic_heads.py
 ```
 
-
 ## Third-Party Licenses
 
 Generate the bundled `LICENSES` file with:

--- a/frontend/admin-dashboard/__tests__/localeSwitch.test.tsx
+++ b/frontend/admin-dashboard/__tests__/localeSwitch.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import Router from 'next-router-mock';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';

--- a/frontend/admin-dashboard/e2e/pages-a11y.spec.ts
+++ b/frontend/admin-dashboard/e2e/pages-a11y.spec.ts
@@ -1,0 +1,32 @@
+import { test } from '@playwright/test';
+import { checkA11y } from './a11y';
+
+const routes = [
+  '/',
+  '/dashboard',
+  '/dashboard/gallery',
+  '/dashboard/publish',
+  '/dashboard/audit-logs',
+  '/dashboard/optimizations',
+  '/dashboard/ab-tests',
+  '/dashboard/analytics',
+  '/dashboard/heatmap',
+  '/dashboard/low-performers',
+  '/dashboard/maintenance',
+  '/dashboard/metrics',
+  '/dashboard/preferences',
+  '/dashboard/roles',
+  '/dashboard/zazzle',
+  '/ideas',
+  '/metrics',
+  '/mockups',
+  '/publish',
+  '/signals',
+];
+
+for (const route of routes) {
+  test(`page ${route} has no accessibility violations`, async ({ page }) => {
+    await page.goto(route);
+    await checkA11y(page);
+  });
+}


### PR DESCRIPTION
## Summary
- add new Playwright spec to check accessibility on all pages
- fix locale switch test imports
- run Prettier on contributing docs

## Testing
- `flake8 .`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: 170 errors)*
- `pydocstyle .` *(fails: D202 for 3 functions)*
- `docformatter --check --recursive .`
- `pip-audit -r requirements.txt -r requirements-dev.txt` *(fails: could not install scikit)*
- `python -m pytest -W error -vv` *(fails: 64 errors during collection)*
- `npm test`
- `npm run test:e2e` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_b_687d8362e95483318ed2e2060c9a170e