### PR TITLE
Expand backup restore docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ for f in backend/*/.env.example; do cp "$f" "$(dirname "$f")/.env"; done
 In production, secrets are stored in HashiCorp Vault or AWS Secrets Manager and surfaced to the containers via Docker secrets or Kubernetes Secrets. The settings modules read from `/run/secrets` if present. Do not rely on `.env` files in production.
 
 See [docs/security.md](docs/security.md) for the rotation procedure.
+See [docs/backup.md](docs/backup.md) for disaster recovery instructions.
 
 ## Release process
 


### PR DESCRIPTION
## Summary
- add detailed walkthrough for restoring the application
- reference recovery docs from the project README

## Testing
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_b_687d85b134bc833197adfe423472d1e6