### PR TITLE
Add ephemeral staging loadtest workflow

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -9,28 +9,51 @@ on:
 jobs:
   loadtest:
     runs-on: ubuntu-latest
+    env:
+      PYTHONWARNINGS: error
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
             requirements-dev.txt
-      - name: Install dependencies
+      - name: Set up Kubernetes
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.29.0'
+      - name: Set up AWS CLI
+        uses: aws-actions/setup-cli@v2
+      - name: Create staging namespace
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
-          pip install locust
-          python -m pip install -e .
-      - name: Start services
+          NS="staging-${{ github.run_id }}"
+          echo "NS=$NS" >> "$GITHUB_ENV"
+          kubectl create namespace "$NS"
+          ./scripts/sync_staging_secrets.sh prod "$NS"
+      - name: Deploy services
+        uses: ./.github/actions/blue-green-rollout
+        with:
+          namespace: ${{ env.NS }}
+          services: >-
+            orchestrator ai-mockup-generation data-storage signal-ingestion
+            scoring-engine marketplace-publisher feedback-loop
+          registry: example
+          tag: main
+      - name: Create ephemeral S3 bucket
         run: |
-          python backend/service-template/src/main.py &
-          python backend/monitoring/src/monitoring/main.py &
-          python -m uvicorn backend.optimization.api:app --port 8003 &
-          sleep 5
-      - name: Run load tests
+          BUCKET="desainz-${{ github.run_id }}"
+          echo "BUCKET=$BUCKET" >> "$GITHUB_ENV"
+          aws s3api create-bucket --bucket "$BUCKET"
+          ./scripts/setup_storage.sh "$BUCKET"
+      - name: Run integration tests
+        env:
+          S3_BUCKET: ${{ env.BUCKET }}
+        run: ./scripts/run-integration-tests.sh
+      - name: Teardown resources
+        if: always()
         run: |
-          ./scripts/run_load_tests.sh
+          aws s3 rb "s3://${{ env.BUCKET }}" --force || true
+          kubectl delete namespace "$NS" --wait || true

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,9 @@ development or via Docker/Kubernetes secrets mounted under `/run/secrets`. The
 
 Load tests use [Locust](https://locust.io/) and live in the `load_tests`
 directory. To exercise the endpoints locally, start the services you want to
-benchmark and run `scripts/run_load_tests.sh`. Continuous integration executes
-the same script via the `loadtest` workflow.
+benchmark and run `scripts/run_load_tests.sh`. Continuous integration deploys a
+temporary staging environment via the `loadtest` workflow and runs the
+integration suite against AWS resources using an ephemeral bucket.
 
 ### Expected Throughput
 

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -31,7 +31,7 @@ performance characteristics.
 
 ## Continuous Integration
 
-The `loadtest` GitHub Actions workflow runs automatically on every pull request
-and on pushes to `main`. It starts a subset of the services and executes the
-same script used locally. The workflow fails if the aggregate failure ratio
-exceeds `1%` or if the average response time is above `1000ms`.
+The `loadtest` workflow provisions a temporary staging namespace on each pull
+request and push to `main`. Services are deployed to that namespace and an
+ephemeral S3 bucket is created. The integration suite runs against these AWS
+resources and all assets are removed once the run completes.


### PR DESCRIPTION
## Summary
- run integration suite in ephemeral staging environment via GitHub Actions
- deploy services and AWS resources on the fly
- document new workflow behaviour

## Testing
- `docformatter --check docs/README.md docs/load_testing.md`
- `pydocstyle docs/README.md docs/load_testing.md`
- `flake8` *(fails: `docs/README.md:3:6: E999 SyntaxError: invalid syntax`)*
- `pytest --collect-only` *(fails: `ModuleNotFoundError: No module named 'fakeredis'`)*

------
https://chatgpt.com/codex/tasks/task_b_687d85b5f7008331a92f103396690bce