### PR TITLE
Add live metrics WebSocket

### DIFF
--- a/backend/api-gateway/tests/test_ws_metrics.py
+++ b/backend/api-gateway/tests/test_ws_metrics.py
@@ -1,0 +1,69 @@
+"""Tests for /ws/metrics endpoint."""
+
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from typing import Any, Optional, Type
+
+import fakeredis.aioredis
+import httpx
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+sys.path.append(
+    str(Path(__file__).resolve().parents[2] / "signal-ingestion" / "src")
+)  # noqa: E402
+
+
+
+def test_metrics_ws(monkeypatch: Any) -> None:
+    """Endpoint streams combined metrics."""
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    import backend.shared.config as shared_config
+
+    shared_config.settings.redis_url = "redis://localhost:6379/0"
+    monkeypatch.setattr(
+        "backend.shared.cache.get_async_client", lambda: fakeredis.aioredis.FakeRedis()
+    )
+    import api_gateway.main as main_module
+    import api_gateway.routes as routes
+    monkeypatch.setattr(
+        "api_gateway.routes.get_async_client", lambda: fakeredis.aioredis.FakeRedis()
+    )
+    importlib.reload(main_module)
+    importlib.reload(routes)
+    main_module.rate_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.optimization_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.monitoring_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.analytics_limiter._redis = fakeredis.aioredis.FakeRedis()
+
+    class MockClient:
+        async def __aenter__(self) -> "MockClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Optional[Type[BaseException]],
+        ) -> None:
+            return None
+
+        async def get(self, url: str) -> httpx.Response:
+            if url.endswith("/overview"):
+                return httpx.Response(200, json={"cpu_percent": 1})
+            if url.endswith("/analytics"):
+                return httpx.Response(200, json={"active_users": 2})
+            return httpx.Response(404)
+
+    async def fake_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(httpx, "AsyncClient", MockClient)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    client = TestClient(main_module.app)
+    with client.websocket_connect("/ws/metrics") as ws:
+        data = ws.receive_json()
+        assert data == {"cpu_percent": 1, "active_users": 2}

--- a/frontend/admin-dashboard/src/hooks/useLiveMetrics.ts
+++ b/frontend/admin-dashboard/src/hooks/useLiveMetrics.ts
@@ -1,0 +1,34 @@
+/**
+ * React hook providing live metrics via WebSocket.
+ */
+import { useEffect, useState } from 'react';
+
+export interface LiveMetrics {
+  cpu_percent?: number;
+  memory_mb?: number;
+  active_users?: number;
+  error_rate?: number;
+}
+
+export function useLiveMetrics() {
+  const [metrics, setMetrics] = useState<LiveMetrics | null>(null);
+
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(
+      `${protocol}://${window.location.host}/ws/metrics`
+    );
+    ws.onmessage = (event) => {
+      try {
+        setMetrics(JSON.parse(event.data) as LiveMetrics);
+      } catch {
+        // ignore invalid messages
+      }
+    };
+    return () => {
+      ws.close();
+    };
+  }, []);
+
+  return metrics;
+}


### PR DESCRIPTION
## Summary
- stream metrics over WebSocket via `/ws/metrics` in API Gateway
- create React hook `useLiveMetrics` for admin dashboard
- cover new endpoint with unit test

## Testing
- `black backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_ws_metrics.py`
- `npx prettier --write frontend/admin-dashboard/src/hooks/useLiveMetrics.ts`
- `npx eslint src/hooks/useLiveMetrics.ts`
- `npm run flow`
- `flake8 backend/api-gateway/tests/test_ws_metrics.py`
- `pydocstyle backend/api-gateway/tests/test_ws_metrics.py`
- `docformatter --check backend/api-gateway/tests/test_ws_metrics.py`
- `pytest backend/api-gateway/tests/test_ws_metrics.py -q` *(failed: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_b_687d85c8ce74833188828933891924cc