### PR TITLE
Refactor DB modules for async sessions

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/db.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/db.py
@@ -12,9 +12,10 @@ from backend.shared.db import models as shared_models
 from sqlalchemy import DateTime
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy import ForeignKey, Integer, String, select, update
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
+from backend.shared.db import async_engine, AsyncSessionLocal
 from .settings import settings
 
 
@@ -80,8 +81,8 @@ class WebhookEvent(Base):
     task: Mapped["PublishTask"] = relationship("PublishTask", backref="events")
 
 
-engine = create_async_engine(settings.effective_database_url, future=True)
-SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+engine = async_engine
+SessionLocal = AsyncSessionLocal
 
 
 async def init_db() -> None:

--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -2,20 +2,48 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from typing import Any, Iterator
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any, Iterator, AsyncIterator
 
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from .base import Base
 from backend.shared.config import settings
 
-__all__ = ["Base", "engine", "SessionLocal", "session_scope"]
+__all__ = [
+    "Base",
+    "engine",
+    "SessionLocal",
+    "session_scope",
+    "async_engine",
+    "AsyncSessionLocal",
+    "async_session_scope",
+]
 
-DATABASE_URL = settings.effective_database_url
+DATABASE_URL = str(settings.effective_database_url)
+
+if DATABASE_URL.startswith("sqlite") and "+" not in DATABASE_URL:
+    ASYNC_DATABASE_URL = DATABASE_URL.replace("sqlite", "sqlite+aiosqlite", 1)
+elif DATABASE_URL.startswith("postgresql") and "+" not in DATABASE_URL:
+    ASYNC_DATABASE_URL = DATABASE_URL.replace(
+        "postgresql",
+        "postgresql+asyncpg",
+        1,
+    )
+else:
+    ASYNC_DATABASE_URL = DATABASE_URL
+
 engine = create_engine(DATABASE_URL, echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+async_engine = create_async_engine(ASYNC_DATABASE_URL, echo=False, future=True)
+AsyncSessionLocal = async_sessionmaker(async_engine, expire_on_commit=False)
 
 
 @contextmanager
@@ -50,3 +78,33 @@ def session_scope(username: str | None = None) -> Iterator[Session]:
         raise
     finally:
         session.close()
+
+
+@asynccontextmanager
+async def async_session_scope(
+    username: str | None = None,
+) -> AsyncIterator[AsyncSession]:
+    """Asynchronous transactional session scope."""
+    session: AsyncSession = AsyncSessionLocal()
+
+    if username is not None:
+
+        @event.listens_for(session.sync_session, "after_begin")  # type: ignore[misc]
+        def _set_username(
+            _session: Session,
+            _transaction: Any,
+            connection: Any,
+        ) -> None:
+            connection.execute(
+                text("SET LOCAL app.current_username = :user"),
+                {"user": username},
+            )
+
+    try:
+        yield session
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+    finally:
+        await session.close()


### PR DESCRIPTION
## Summary
- introduce `async_session_scope` and async engine in shared db utilities
- reuse shared async engine in marketplace-publisher

## Testing
- `flake8 backend/shared/db/__init__.py`
- `pydocstyle backend/shared/db/__init__.py`
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/db.py`
- `pydocstyle backend/marketplace-publisher/src/marketplace_publisher/db.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_687d96af735483319b48095def619dfa