### PR TITLE
Add Python replacements for shell utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,19 @@ The `docker-compose.prod.yml` file uses prebuilt images and is intended for use 
 ## Implementation Plan
 
 See [docs/implementation_plan.md](docs/implementation_plan.md) for the milestone roadmap derived from the [Design Idea Engine Complete Blueprint](docs/blueprints/DesignIdeaEngineCompleteBlueprint.md).
+
+## Running on Windows
+
+Most helper scripts in `scripts/` are written for a POSIX shell. Python equivalents
+are provided for common tasks so Windows users can run them without WSL:
+
+```bash
+python scripts/setup_codex.py           # install dependencies and build docs
+python scripts/run_integration_tests.py # run integration tests
+python scripts/run_dagster_webserver.py # start the Dagster web UI
+python scripts/rotate_logs.py           # archive and prune logs
+python scripts/wait_for_services.py     # block until local services respond
+```
+
+Other scripts depend on tools like Docker, kubectl or AWS CLI and therefore
+still require a POSIX environment (WSL or Git Bash).

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -2,5 +2,19 @@
 
 from . import maintenance
 from .rotate_secrets import rotate, main as rotate_secrets_main
+from .run_integration_tests import main as run_integration_tests
+from .run_dagster_webserver import main as run_dagster_webserver
+from .rotate_logs import main as rotate_logs
+from .wait_for_services import main as wait_for_services
+from .setup_codex import main as setup_codex
 
-__all__ = ["maintenance", "rotate", "rotate_secrets_main"]
+__all__ = [
+    "maintenance",
+    "rotate",
+    "rotate_secrets_main",
+    "run_integration_tests",
+    "run_dagster_webserver",
+    "rotate_logs",
+    "wait_for_services",
+    "setup_codex",
+]

--- a/scripts/rotate_logs.py
+++ b/scripts/rotate_logs.py
@@ -1,0 +1,31 @@
+"""Rotate log files daily by archiving and pruning old files."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+LOG_DIR = Path(os.environ.get("LOG_DIR", "logs"))
+RETENTION_DAYS = int(os.environ.get("RETENTION_DAYS", "7"))
+
+
+def main() -> None:
+    """Archive current logs and delete archives older than ``RETENTION_DAYS``."""
+    archive = LOG_DIR / "archive"
+    archive.mkdir(parents=True, exist_ok=True)
+    timestamp = time.strftime("%Y%m%d%H%M%S")
+
+    for log_file in LOG_DIR.glob("*.log"):
+        dest = archive / f"{log_file.name}.{timestamp}"
+        log_file.rename(dest)
+        log_file.touch()
+
+    cutoff = time.time() - RETENTION_DAYS * 86400
+    for path in archive.iterdir():
+        if path.is_file() and path.stat().st_mtime < cutoff:
+            path.unlink()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/run_dagster_webserver.py
+++ b/scripts/run_dagster_webserver.py
@@ -1,0 +1,33 @@
+"""Start the Dagster webserver for the orchestrator."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    """Launch ``dagster-webserver`` with the standard configuration."""
+    root_dir = Path(__file__).resolve().parents[1]
+    os.chdir(root_dir)
+    dagster_home = os.environ.get(
+        "DAGSTER_HOME", str(root_dir / "backend" / "orchestrator")
+    )
+    os.environ["DAGSTER_HOME"] = dagster_home
+    subprocess.run(
+        [
+            "dagster-webserver",
+            "-w",
+            "backend/orchestrator/workspace.yaml",
+            "-h",
+            "0.0.0.0",
+            "-p",
+            "3000",
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/run_integration_tests.py
+++ b/scripts/run_integration_tests.py
@@ -1,0 +1,17 @@
+"""Run integration tests with strict settings."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Execute pytest raising on warnings."""
+    args = argv or sys.argv[1:]
+    cmd = ["pytest", "-W", "error", "tests/integration", *args]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/setup_codex.py
+++ b/scripts/setup_codex.py
@@ -1,0 +1,53 @@
+"""Prepare the desAInz environment when running in Codex."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    """Install dependencies and build the documentation."""
+    root_dir = Path(__file__).resolve().parents[1]
+    subprocess.run(["python", "-m", "pip", "install", "--upgrade", "pip"], check=True)
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            str(root_dir / "requirements.txt"),
+            "-r",
+            str(root_dir / "requirements-dev.txt"),
+        ],
+        check=True,
+    )
+    if shutil.which("npm"):
+        subprocess.run(["npm", "ci", "--legacy-peer-deps"], check=True)
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "pip",
+            "install",
+            "sphinx",
+            "myst-parser",
+            "sphinxcontrib-mermaid",
+        ],
+        check=True,
+    )
+    env = os.environ.copy()
+    env.setdefault("SKIP_APIDOC", "1")
+    env.setdefault("SKIP_OPENAPI", "1")
+    subprocess.run(
+        ["python", "-m", "sphinx", "-W", "-b", "html", "docs", "docs/_build/html"],
+        check=True,
+        env=env,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/wait_for_services.py
+++ b/scripts/wait_for_services.py
@@ -1,0 +1,35 @@
+"""Block until required services respond on their ports."""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+
+SERVICES = [
+    ("postgres", 5432),
+    ("redis", 6379),
+    ("kafka", 9092),
+    ("minio", 9000),
+]
+
+
+def _wait(host: str, port: int) -> None:
+    while True:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except OSError:
+            time.sleep(1)
+
+
+def main() -> None:
+    """Wait for all services to become available."""
+    for host, port in SERVICES:
+        print(f"Waiting for {host}:{port} ...")
+        _wait(host, port)
+        print(f"{host}:{port} is up")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add Python scripts for core helper commands
- note Windows options in README
- expose Python utilities in `scripts.__init__`

## Testing
- `flake8 scripts/run_integration_tests.py scripts/wait_for_services.py scripts/rotate_logs.py scripts/run_dagster_webserver.py scripts/setup_codex.py scripts/__init__.py`
- `mypy scripts/run_integration_tests.py scripts/wait_for_services.py scripts/rotate_logs.py scripts/run_dagster_webserver.py scripts/setup_codex.py scripts/__init__.py`
- `pydocstyle scripts/run_integration_tests.py scripts/wait_for_services.py scripts/rotate_logs.py scripts/run_dagster_webserver.py scripts/setup_codex.py scripts/__init__.py`
- `pytest tests/test_api.py::test_api_root -W error` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_b_687d99dd20b883319cb6e65c2db599dd