### PR TITLE
Implement aggregated system health endpoint

### DIFF
--- a/frontend/admin-dashboard/src/components/StatusIndicator.tsx
+++ b/frontend/admin-dashboard/src/components/StatusIndicator.tsx
@@ -6,8 +6,7 @@ interface StatusMap {
 
 export default function StatusIndicator() {
   const [status, setStatus] = useState<StatusMap>({});
-  const url =
-    process.env.NEXT_PUBLIC_MONITORING_URL ?? 'http://localhost:8000/status';
+  const url = process.env.NEXT_PUBLIC_API_HEALTH_URL ?? '/api/health';
 
   useEffect(() => {
     async function fetchStatus() {

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -1,0 +1,68 @@
+"""Tests for aggregated system health endpoint."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any, Optional, Type
+
+import fakeredis.aioredis
+import httpx
+from fastapi.testclient import TestClient
+
+
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")
+)
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "backend" / "signal-ingestion" / "src")
+)
+
+
+def test_system_health(monkeypatch: Any) -> None:
+    """All service health checks are aggregated successfully."""
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    import backend.shared.config as shared_config
+
+    shared_config.settings.redis_url = "redis://localhost:6379/0"
+    monkeypatch.setattr(
+        "backend.shared.cache.get_async_client", lambda: fakeredis.aioredis.FakeRedis()
+    )
+    import api_gateway.main as main_module
+    import api_gateway.routes as routes
+
+    main_module.rate_limiter._redis = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(
+        "api_gateway.routes.get_async_client", lambda: fakeredis.aioredis.FakeRedis()
+    )
+    routes.optimization_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.monitoring_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.analytics_limiter._redis = fakeredis.aioredis.FakeRedis()
+
+    class MockClient:
+        async def __aenter__(self) -> "MockClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Optional[Type[BaseException]],
+        ) -> None:
+            return None
+
+        async def get(self, url: str) -> httpx.Response:
+            return httpx.Response(200, json={"status": "ok"})
+
+    monkeypatch.setattr(httpx, "AsyncClient", MockClient)
+
+    importlib.reload(main_module)
+    importlib.reload(routes)
+
+    client = TestClient(main_module.app)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    for service in routes.HEALTH_ENDPOINTS:
+        assert body[service] == "ok"


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to query health of all services
- show the system health on the dashboard
- cover endpoint with integration test

## Testing
- `flake8 backend/api-gateway/src/api_gateway/routes.py tests/test_system_health.py`
- `pydocstyle tests/test_system_health.py backend/api-gateway/src/api_gateway/routes.py`
- `docformatter --in-place tests/test_system_health.py backend/api-gateway/src/api_gateway/routes.py`
- `black tests/test_system_health.py backend/api-gateway/src/api_gateway/routes.py`
- `npm run lint:eslint`
- `npm run lint:prettier` *(fails: code style issues in many files)*
- `npm run lint:css`
- `npm run flow`
- `python -m pytest tests/test_system_health.py -W error -vv` *(fails: AttributeError during test execution)*

------
https://chatgpt.com/codex/tasks/task_b_687d9d2ebef48331a36fbcd8fe0e5291