### PR TITLE
Add indexes for marketplace publisher

### DIFF
--- a/backend/marketplace-publisher/tests/test_policy_failures.py
+++ b/backend/marketplace-publisher/tests/test_policy_failures.py
@@ -1,3 +1,5 @@
+"""Tests for publisher rejection scenarios."""
+
 from __future__ import annotations
 
 import asyncio
@@ -15,6 +17,7 @@ from marketplace_publisher.settings import settings
 async def test_publish_trademark_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Return ``nsfw`` when the design is trademarked."""
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     monkeypatch.setattr(db, "engine", engine)
@@ -51,6 +54,7 @@ async def test_publish_trademark_failure(
 async def test_publish_nsfw_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Return ``nsfw`` when the image violates policy."""
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     monkeypatch.setattr(db, "engine", engine)

--- a/backend/marketplace-publisher/tests/vcr/__init__.py
+++ b/backend/marketplace-publisher/tests/vcr/__init__.py
@@ -1,0 +1,1 @@
+"""Fixtures for VCR tests."""

--- a/backend/shared/db/migrations/marketplace_publisher/versions/830537fd941a_add_indexes_for_publish_task_and_listing.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/830537fd941a_add_indexes_for_publish_task_and_listing.py
@@ -1,0 +1,30 @@
+"""Create indexes for common queries.
+
+Revision ID: 830537fd941a
+Revises: 5130a8662f39
+Create Date: 2025-07-21 02:31:22.922915
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "830537fd941a"
+down_revision = "5130a8662f39"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create indexes on ``publish_task.status`` and ``listings.state``."""
+    op.create_index(
+        op.f("ix_publish_task_status"), "publish_task", ["status"], unique=False
+    )
+    op.create_index(op.f("ix_listings_state"), "listings", ["state"], unique=False)
+
+
+def downgrade() -> None:
+    """Drop indexes created in :func:`upgrade`."""
+    op.drop_index(op.f("ix_listings_state"), table_name="listings")
+    op.drop_index(op.f("ix_publish_task_status"), table_name="publish_task")


### PR DESCRIPTION
## Summary
- add Alembic migration to index `publish_task.status` and `listings.state`
- document marketplace publisher policy failure tests

## Testing
- `python scripts/analyze_query_plans.py` *(fails: connection refused)*
- `npm test`
- `pytest -W error -vv` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_b_687da57cc5948331a945c1db08881e13