### PR TITLE
Add logrotate cron integration

### DIFF
--- a/docker/logrotate/Dockerfile
+++ b/docker/logrotate/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY scripts/rotate_logs.py /app/rotate_logs.py
+COPY LICENSES /licenses/LICENSES
+CMD ["python", "/app/rotate_logs.py"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Welcome to desAInz's documentation!
    load_testing
    mocking
    maintenance
+   operations
    listing_sync
    publish_tasks
    i18n

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,10 @@
+# Operations Guide
+
+## Log Locations
+
+Application logs are written to the directory defined by the `LOG_DIR` environment variable. When unset it defaults to `logs` inside the container. Each service writes its log files with a `.log` extension under this directory.
+
+## Rotation Policy
+
+A cron job executes `scripts/rotate_logs.py` daily at 01:00. The job moves log files into `LOG_DIR/archive` with a timestamp suffix and removes archives older than seven days. The cronjob definition can be found in `infrastructure/k8s/base/cronjobs/logrotate.yaml` and the Docker image used is built from `docker/logrotate`.
+

--- a/infrastructure/helm/all-services/Chart.yaml
+++ b/infrastructure/helm/all-services/Chart.yaml
@@ -29,3 +29,6 @@ dependencies:
   - name: backup-jobs
     version: 0.1.0
     repository: "file://../backup-jobs"
+  - name: logrotate-jobs
+    version: 0.1.0
+    repository: "file://../logrotate-jobs"

--- a/infrastructure/helm/all-services/values-dev.yaml
+++ b/infrastructure/helm/all-services/values-dev.yaml
@@ -29,3 +29,7 @@ orchestrator:
 backup-jobs:
   image:
     tag: latest
+
+logrotate-jobs:
+  image:
+    tag: latest

--- a/infrastructure/helm/all-services/values-prod.yaml
+++ b/infrastructure/helm/all-services/values-prod.yaml
@@ -29,3 +29,7 @@ orchestrator:
 backup-jobs:
   image:
     tag: latest
+
+logrotate-jobs:
+  image:
+    tag: latest

--- a/infrastructure/helm/all-services/values-staging.yaml
+++ b/infrastructure/helm/all-services/values-staging.yaml
@@ -29,3 +29,7 @@ orchestrator:
 backup-jobs:
   image:
     tag: latest
+
+logrotate-jobs:
+  image:
+    tag: latest

--- a/infrastructure/helm/all-services/values.yaml
+++ b/infrastructure/helm/all-services/values.yaml
@@ -132,3 +132,11 @@ backup-jobs:
   schedule: "0 2 * * *"
   bucket: my-backup-bucket
   minioDataPath: /data
+
+logrotate-jobs:
+  image:
+    repository: example/logrotate
+    tag: latest
+    pullPolicy: IfNotPresent
+  schedule: "0 1 * * *"
+  logDir: /var/log

--- a/infrastructure/helm/logrotate-jobs/Chart.yaml
+++ b/infrastructure/helm/logrotate-jobs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: logrotate-jobs
+version: 0.1.0
+description: Helm chart for log rotation jobs
+type: application
+appVersion: "1.0"

--- a/infrastructure/helm/logrotate-jobs/templates/_helpers.tpl
+++ b/infrastructure/helm/logrotate-jobs/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "logrotate-jobs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "logrotate-jobs.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- $name = .Values.fullnameOverride -}}
+{{- end -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "logrotate-jobs.labels" -}}
+helm.sh/chart: {{ include "logrotate-jobs.chart" . }}
+{{ include "logrotate-jobs.selectorLabels" . }}
+{{- if .Chart.AppVersion -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "logrotate-jobs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "logrotate-jobs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "logrotate-jobs.chart" -}}
+{{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}

--- a/infrastructure/helm/logrotate-jobs/templates/cronjob.yaml
+++ b/infrastructure/helm/logrotate-jobs/templates/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "logrotate-jobs.fullname" . }}
+  labels: {{- include "logrotate-jobs.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: logrotate
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: LOG_DIR
+                  value: {{ .Values.logDir | quote }}
+{{- range $key, $value := .Values.extraEnv }}
+                - name: {{ $key }}
+                  value: {{ $value | quote }}
+{{- end }}
+              command: ["python", "/app/rotate_logs.py"]

--- a/infrastructure/helm/logrotate-jobs/values-dev.yaml
+++ b/infrastructure/helm/logrotate-jobs/values-dev.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: example/logrotate
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 1 * * *"
+logDir: /var/log
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/helm/logrotate-jobs/values-prod.yaml
+++ b/infrastructure/helm/logrotate-jobs/values-prod.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: example/logrotate
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 1 * * *"
+logDir: /var/log
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/helm/logrotate-jobs/values-staging.yaml
+++ b/infrastructure/helm/logrotate-jobs/values-staging.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: example/logrotate
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 1 * * *"
+logDir: /var/log
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/helm/logrotate-jobs/values.yaml
+++ b/infrastructure/helm/logrotate-jobs/values.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: example/logrotate
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 1 * * *"
+logDir: /var/log
+
+# Additional environment variables
+extraEnv: {}

--- a/infrastructure/k8s/base/cronjobs/logrotate.yaml
+++ b/infrastructure/k8s/base/cronjobs/logrotate.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: logrotate
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: logrotate
+              image: example/logrotate:latest
+              imagePullPolicy: IfNotPresent
+              command: ["python", "/app/rotate_logs.py"]

--- a/infrastructure/k8s/base/kustomization.yaml
+++ b/infrastructure/k8s/base/kustomization.yaml
@@ -35,3 +35,4 @@ resources:
   - cronjobs/orchestrator-cleanup.yaml
   - cronjobs/orchestrator-idea.yaml
   - cronjobs/orchestrator-query-plan.yaml
+  - cronjobs/logrotate.yaml


### PR DESCRIPTION
## Summary
- add Docker image for log rotation
- add Kubernetes CronJob and Helm chart for log rotation
- document log directories and rotation policy

## Testing
- `python -m pytest -k rotate -W error -vv` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_687da580841083318fb56f661a5ee829