### PR TITLE
Add compose smoke test script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,8 @@ jobs:
           python -m pip install -e .
       - name: Run tests
         run: make test
+      - name: Smoke test docker compose services
+        run: ./scripts/smoke_compose.sh
 
   publish:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/scripts/smoke_compose.sh
+++ b/scripts/smoke_compose.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run a smoke test on core services defined in docker-compose.test.yml.
+
+set -euo pipefail
+
+COMPOSE_FILES="-f docker-compose.dev.yml -f docker-compose.test.yml"
+SERVICES=(api-gateway scoring-engine marketplace-publisher signal-ingestion feedback-loop)
+
+cleanup() {
+  docker compose $COMPOSE_FILES down
+}
+trap cleanup EXIT
+
+docker compose $COMPOSE_FILES up -d "${SERVICES[@]}"
+
+declare -A PORTS=([
+  api-gateway]=8001
+  [scoring-engine]=5002
+  [marketplace-publisher]=8003
+  [signal-ingestion]=8004
+  [feedback-loop]=8005
+)
+
+for svc in "${SERVICES[@]}"; do
+  port="${PORTS[$svc]}"
+  echo "Waiting for $svc on port $port ..."
+  until curl -fsS "http://localhost:${port}/ready" >/dev/null; do
+    sleep 1
+  done
+  echo "$svc is ready"
+done
+
+echo "All services are ready."
+


### PR DESCRIPTION
## Summary
- add `scripts/smoke_compose.sh` to spin up core services and poll `/ready`
- call the smoke test script in `tests.yml` after unit tests

## Testing
- `pip install scikit-learn pytest sqlalchemy` *(fails: pip resolver errors)*
- `pytest tests/test_api.py -k test_health_ready -W error -vv` *(fails: DeprecationWarning during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687dab549bf083318d35fc5a8631ab3f