### PR TITLE
Add changelog updater for OpenAPI specs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ The `blueprints` folder contains the full system blueprint.
 - [GPU Mockup Generation](mockup_generation.md)
 - Kafka schemas under `schemas/` are loaded into the registry configured by `SCHEMA_REGISTRY_URL`.
 - OpenAPI schemas under `openapi/` can be regenerated with `python scripts/generate_openapi.py`.
+  Run `python scripts/update_openapi_changelog.py` afterwards to include version
+  hashes and update the changelog automatically.
 
 The `scripts` directory provides helper scripts for setting up storage and CDN resources:
 

--- a/openapi/analytics.json
+++ b/openapi/analytics.json
@@ -181,7 +181,11 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {"type": "integer", "title": "Limit", "default": 10}
+            "schema": {
+              "type": "integer",
+              "title": "Limit",
+              "default": 10
+            }
           }
         ],
         "responses": {
@@ -190,7 +194,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {"$ref": "#/components/schemas/LowPerformer"},
+                  "items": {
+                    "$ref": "#/components/schemas/LowPerformer"
+                  },
                   "type": "array",
                   "title": "Response Low Performers Low Performers Get"
                 }
@@ -201,7 +207,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -325,11 +333,20 @@
       },
       "LowPerformer": {
         "properties": {
-          "listing_id": {"type": "integer", "title": "Listing Id"},
-          "revenue": {"type": "number", "title": "Revenue"}
+          "listing_id": {
+            "type": "integer",
+            "title": "Listing Id"
+          },
+          "revenue": {
+            "type": "number",
+            "title": "Revenue"
+          }
         },
         "type": "object",
-        "required": ["listing_id", "revenue"],
+        "required": [
+          "listing_id",
+          "revenue"
+        ],
         "title": "LowPerformer",
         "description": "Listing with the lowest revenue."
       },
@@ -373,5 +390,6 @@
         "scheme": "bearer"
       }
     }
-  }
+  },
+  "x-spec-version": "f58f45c2f5a81524937d4df9b2c4931b88c96589159210eda06a7eddb46642cd"
 }

--- a/openapi/api-gateway.json
+++ b/openapi/api-gateway.json
@@ -174,7 +174,9 @@
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": { "type": "string" },
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "type": "object",
                 "title": "Body"
               }
@@ -188,14 +190,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "type": "object",
                   "title": "Response Refresh Auth Token Auth Refresh Post"
                 }
               }
             }
           },
-          "401": { "description": "Unauthorized" }
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -742,5 +748,6 @@
         "scheme": "bearer"
       }
     }
-  }
+  },
+  "x-spec-version": "911868d0c2ed2aea39ba5075d87135ced55c92685fc816643d3d34a4089ee883"
 }

--- a/openapi/feedback-loop.json
+++ b/openapi/feedback-loop.json
@@ -303,5 +303,6 @@
         "title": "ValidationError"
       }
     }
-  }
+  },
+  "x-spec-version": "e3dd89f2ca2db946efd7f9566e503212dde73d37edaa7a63ff4c1e66a897dab7"
 }

--- a/openapi/marketplace-publisher.json
+++ b/openapi/marketplace-publisher.json
@@ -1,275 +1,341 @@
 {
-    "openapi": "3.1.0",
-    "info": {"title": "marketplace-publisher", "version": "0.1.0"},
-    "paths": {
-        "/publish": {
-            "post": {
-                "summary": "Publish",
-                "description": "Create a publish task and run it in the background.",
-                "operationId": "publish_publish_post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/PublishRequest"}
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {"type": "integer"},
-                                    "type": "object",
-                                    "title": "Response Publish Publish Post",
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
+  "openapi": "3.1.0",
+  "info": {
+    "title": "marketplace-publisher",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/publish": {
+      "post": {
+        "summary": "Publish",
+        "description": "Create a publish task and run it in the background.",
+        "operationId": "publish_publish_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishRequest"
+              }
             }
+          },
+          "required": true
         },
-        "/tasks/{task_id}": {
-            "get": {
-                "summary": "Get Task Status",
-                "description": "Return current status of a publish task.",
-                "operationId": "get_task_status_tasks__task_id__get",
-                "parameters": [
-                    {
-                        "name": "task_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {"type": "integer", "title": "Task Id"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "title": "Response Get Task Status Tasks  Task Id  Get",
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "type": "object",
+                  "title": "Response Publish Publish Post"
+                }
+              }
             }
-        },
-        "/tasks/{task_id}/retry": {
-            "post": {
-                "summary": "Retry Task",
-                "description": "Re-trigger publishing for a task.",
-                "operationId": "retry_task_tasks__task_id__retry_post",
-                "parameters": [
-                    {
-                        "name": "task_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {"type": "integer", "title": "Task Id"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {"type": "string"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
             }
-        },
-        "/health": {
-            "get": {
-                "summary": "Health",
-                "description": "Return service liveness.",
-                "operationId": "health_health_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {"type": "string"},
-                                    "type": "object",
-                                    "title": "Response Health Health Get",
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/ready": {
-            "get": {
-                "summary": "Ready",
-                "description": "Return service readiness.",
-                "operationId": "ready_ready_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {"type": "string"},
-                                    "type": "object",
-                                    "title": "Response Ready Ready Get",
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/webhooks/{marketplace}": {
-            "post": {
-                "summary": "Webhook",
-                "description": "Receive status callbacks from marketplaces.",
-                "operationId": "webhook_webhooks__marketplace__post",
-                "parameters": [
-                    {
-                        "name": "marketplace",
-                        "in": "path",
-                        "required": true,
-                        "schema": {"$ref": "#/components/schemas/Marketplace"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/WebhookPayload"}
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {"type": "string"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "properties": {
-                    "detail": {
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                        "type": "array",
-                        "title": "Detail",
-                    }
-                },
-                "type": "object",
-                "title": "HTTPValidationError",
-            },
-            "Marketplace": {
-                "type": "string",
-                "enum": ["redbubble", "amazon_merch", "etsy", "society6"],
-                "title": "Marketplace",
-                "description": "Supported marketplaces.",
-            },
-            "PublishRequest": {
-                "properties": {
-                    "marketplace": {"$ref": "#/components/schemas/Marketplace"},
-                    "design_path": {
-                        "type": "string",
-                        "format": "path",
-                        "title": "Design Path",
-                    },
-                    "metadata": {
-                        "additionalProperties": true,
-                        "type": "object",
-                        "title": "Metadata",
-                        "default": {},
-                    },
-                },
-                "type": "object",
-                "required": ["marketplace", "design_path"],
-                "title": "PublishRequest",
-                "description": "Request body for initiating a publish task.",
-            },
-            "ValidationError": {
-                "properties": {
-                    "loc": {
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                        "type": "array",
-                        "title": "Location",
-                    },
-                    "msg": {"type": "string", "title": "Message"},
-                    "type": {"type": "string", "title": "Error Type"},
-                },
-                "type": "object",
-                "required": ["loc", "msg", "type"],
-                "title": "ValidationError",
-            },
-            "WebhookPayload": {
-                "type": "object",
-                "properties": {
-                    "task_id": {"type": "integer", "title": "Task Id"},
-                    "status": {"type": "string", "title": "Status"},
-                },
-                "required": ["task_id", "status"],
-                "title": "WebhookPayload",
-                "description": "Webhook callback payload.",
-            },
+          }
         }
+      }
     },
+    "/tasks/{task_id}": {
+      "get": {
+        "summary": "Get Task Status",
+        "description": "Return current status of a publish task.",
+        "operationId": "get_task_status_tasks__task_id__get",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Task Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Task Status Tasks  Task Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tasks/{task_id}/retry": {
+      "post": {
+        "summary": "Retry Task",
+        "description": "Re-trigger publishing for a task.",
+        "operationId": "retry_task_tasks__task_id__retry_post",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Task Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks/{marketplace}": {
+      "post": {
+        "summary": "Webhook",
+        "description": "Receive status callbacks from marketplaces.",
+        "operationId": "webhook_webhooks__marketplace__post",
+        "parameters": [
+          {
+            "name": "marketplace",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Marketplace"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Marketplace": {
+        "type": "string",
+        "enum": [
+          "redbubble",
+          "amazon_merch",
+          "etsy",
+          "society6"
+        ],
+        "title": "Marketplace",
+        "description": "Supported marketplaces."
+      },
+      "PublishRequest": {
+        "properties": {
+          "marketplace": {
+            "$ref": "#/components/schemas/Marketplace"
+          },
+          "design_path": {
+            "type": "string",
+            "format": "path",
+            "title": "Design Path"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": [
+          "marketplace",
+          "design_path"
+        ],
+        "title": "PublishRequest",
+        "description": "Request body for initiating a publish task."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WebhookPayload": {
+        "type": "object",
+        "properties": {
+          "task_id": {
+            "type": "integer",
+            "title": "Task Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "required": [
+          "task_id",
+          "status"
+        ],
+        "title": "WebhookPayload",
+        "description": "Webhook callback payload."
+      }
+    }
+  },
+  "x-spec-version": "da4434e0f6994d4bb13d7176c0c8b2839b35df7082e770432f09a9bb58daa88d"
 }

--- a/openapi/mockup-generation.json
+++ b/openapi/mockup-generation.json
@@ -338,5 +338,6 @@
         "title": "ValidationError"
       }
     }
-  }
+  },
+  "x-spec-version": "d65fe525055166e01a2bfd474c540866539dbfc6d2bb85653451a6a095ca66b4"
 }

--- a/openapi/monitoring.json
+++ b/openapi/monitoring.json
@@ -206,5 +206,6 @@
         }
       }
     }
-  }
+  },
+  "x-spec-version": "597597fa86264ad0b9dce1f28ac5bdd7ece024b0b108a35731a81f04a4314b62"
 }

--- a/openapi/optimization.json
+++ b/openapi/optimization.json
@@ -215,5 +215,6 @@
         "title": "ValidationError"
       }
     }
-  }
+  },
+  "x-spec-version": "9f54f5b995a8c98adc6a2bea4718614d955cc0ab5e074669928fab40e858d087"
 }

--- a/openapi/scoring-engine.json
+++ b/openapi/scoring-engine.json
@@ -1,151 +1,269 @@
 {
-    "openapi": "3.0.2",
-    "info": {"title": "Scoring Engine", "version": "1.0.0"},
-    "paths": {
-        "/weights": {
-            "get": {"responses": {"200": {"description": "OK"}}},
-            "put": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/WeightsUpdate"}
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {"200": {"description": "OK"}},
-            },
-        },
-        "/score": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ScoreRequest"}
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {"200": {"description": "OK"}},
-            }
-        },
-        "/search": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/SearchRequest"}
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {"200": {"description": "OK"}},
-            }
-        },
-        "/centroid/{source}": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "source",
-                        "in": "path",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {"200": {"description": "OK"}},
-            }
-        },
-        "/health": {"get": {"responses": {"200": {"description": "OK"}}}},
-        "/ready": {"get": {"responses": {"200": {"description": "Ready"}}}},
-        "/metrics": {"get": {"responses": {"200": {"description": "OK"}}}},
-    },
-    "components": {
-        "schemas": {
-            "WeightsUpdate": {
-                "description": "Request payload for updating weight parameters.",
-                "properties": {
-                    "freshness": {"title": "Freshness", "type": "number"},
-                    "engagement": {"title": "Engagement", "type": "number"},
-                    "novelty": {"title": "Novelty", "type": "number"},
-                    "community_fit": {"title": "Community Fit", "type": "number"},
-                    "seasonality": {"title": "Seasonality", "type": "number"},
-                },
-                "required": [
-                    "freshness",
-                    "engagement",
-                    "novelty",
-                    "community_fit",
-                    "seasonality",
-                ],
-                "title": "WeightsUpdate",
-                "type": "object",
-            },
-            "ScoreRequest": {
-                "description": "Request payload for scoring a signal.",
-                "properties": {
-                    "timestamp": {
-                        "format": "date-time",
-                        "title": "Timestamp",
-                        "type": "string",
-                    },
-                    "engagement_rate": {"title": "Engagement Rate", "type": "number"},
-                    "embedding": {
-                        "items": {"type": "number"},
-                        "title": "Embedding",
-                        "type": "array",
-                    },
-                    "metadata": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": {"type": "number"},
-                                "type": "object",
-                            },
-                            {"type": "null"},
-                        ],
-                        "default": null,
-                        "title": "Metadata",
-                    },
-                    "centroid": {
-                        "anyOf": [
-                            {"items": {"type": "number"}, "type": "array"},
-                            {"type": "null"},
-                        ],
-                        "default": null,
-                        "title": "Centroid",
-                    },
-                    "median_engagement": {
-                        "anyOf": [{"type": "number"}, {"type": "null"}],
-                        "default": null,
-                        "title": "Median Engagement",
-                    },
-                    "topics": {
-                        "anyOf": [
-                            {"items": {"type": "string"}, "type": "array"},
-                            {"type": "null"},
-                        ],
-                        "default": null,
-                        "title": "Topics",
-                    },
-                },
-                "required": ["timestamp", "engagement_rate", "embedding"],
-                "title": "ScoreRequest",
-                "type": "object",
-            },
-            "SearchRequest": {
-                "description": "Embedding search request.",
-                "properties": {
-                    "embedding": {
-                        "items": {"type": "number"},
-                        "title": "Embedding",
-                        "type": "array",
-                    },
-                    "limit": {"title": "Limit", "type": "integer", "default": 5},
-                    "source": {"title": "Source", "type": "string"},
-                },
-                "required": ["embedding"],
-                "title": "SearchRequest",
-                "type": "object",
-            },
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Scoring Engine",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/weights": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WeightsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     },
+    "/score": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/search": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/centroid/{source}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Ready"
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "WeightsUpdate": {
+        "description": "Request payload for updating weight parameters.",
+        "properties": {
+          "freshness": {
+            "title": "Freshness",
+            "type": "number"
+          },
+          "engagement": {
+            "title": "Engagement",
+            "type": "number"
+          },
+          "novelty": {
+            "title": "Novelty",
+            "type": "number"
+          },
+          "community_fit": {
+            "title": "Community Fit",
+            "type": "number"
+          },
+          "seasonality": {
+            "title": "Seasonality",
+            "type": "number"
+          }
+        },
+        "required": [
+          "freshness",
+          "engagement",
+          "novelty",
+          "community_fit",
+          "seasonality"
+        ],
+        "title": "WeightsUpdate",
+        "type": "object"
+      },
+      "ScoreRequest": {
+        "description": "Request payload for scoring a signal.",
+        "properties": {
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "engagement_rate": {
+            "title": "Engagement Rate",
+            "type": "number"
+          },
+          "embedding": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Embedding",
+            "type": "array"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Metadata"
+          },
+          "centroid": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Centroid"
+          },
+          "median_engagement": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Median Engagement"
+          },
+          "topics": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Topics"
+          }
+        },
+        "required": [
+          "timestamp",
+          "engagement_rate",
+          "embedding"
+        ],
+        "title": "ScoreRequest",
+        "type": "object"
+      },
+      "SearchRequest": {
+        "description": "Embedding search request.",
+        "properties": {
+          "embedding": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Embedding",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer",
+            "default": 5
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "embedding"
+        ],
+        "title": "SearchRequest",
+        "type": "object"
+      }
+    }
+  },
+  "x-spec-version": "9bf5e18aa31693e40717ce637982b5f239e5d979a908d5e561b300e6d2937bbc"
 }

--- a/openapi/signal-ingestion.json
+++ b/openapi/signal-ingestion.json
@@ -1,98 +1,112 @@
 {
-    "openapi": "3.1.0",
-    "info": {"title": "signal-ingestion", "version": "0.1.0"},
-    "paths": {
-        "/health": {
-            "get": {
-                "summary": "Health",
-                "description": "Return service liveness.",
-                "operationId": "health_health_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {"type": "string"},
-                                    "type": "object",
-                                    "title": "Response Health Health Get",
-                                }
-                            }
-                        },
-                    }
-                },
+  "openapi": "3.1.0",
+  "info": {
+    "title": "signal-ingestion",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
             }
-        },
-        "/ready": {
-            "get": {
-                "summary": "Ready",
-                "description": "Return service readiness.",
-                "operationId": "ready_ready_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {"type": "string"},
-                                    "type": "object",
-                                    "title": "Response Ready Ready Get",
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/ingest": {
-            "post": {
-                "summary": "Ingest Signals",
-                "description": "Trigger signal ingestion.",
-                "operationId": "ingest_signals_ingest_post",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {"type": "string"},
-                                    "type": "object",
-                                    "title": "Response Ingest Signals Ingest Post",
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/trending": {
-            "get": {
-                "summary": "Trending",
-                "description": "Return trending keywords.",
-                "operationId": "trending_trending_get",
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "items": {"type": "string"},
-                                    "type": "array",
-                                    "title": "Response Trending Trending Get",
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
+          }
+        }
+      }
     },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingest": {
+      "post": {
+        "summary": "Ingest Signals",
+        "description": "Trigger signal ingestion.",
+        "operationId": "ingest_signals_ingest_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ingest Signals Ingest Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/trending": {
+      "get": {
+        "summary": "Trending",
+        "description": "Return trending keywords.",
+        "operationId": "trending_trending_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response Trending Trending Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-spec-version": "60f75cf80d2859d134e0ba005249d8721a8bfb68cae2314e9aa31f88608e5daf"
 }

--- a/scripts/update_openapi_changelog.py
+++ b/scripts/update_openapi_changelog.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Update changelog when OpenAPI specs change.
+
+This script computes a stable hash for each JSON specification under the
+``openapi`` directory. The hash ignores the ``x-spec-version`` field so that it
+represents the actual specification content. When the current hash differs from
+that of the same file in the previous commit, the changelog is updated with a
+short entry and the ``x-spec-version`` field in the JSON file is set to the new
+hash.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import pyjson5
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+OPENAPI_DIR = PROJECT_ROOT / "openapi"
+CHANGELOG = PROJECT_ROOT / "CHANGELOG.md"
+
+
+def _spec_hash(data: dict) -> str:
+    """Return stable hash for ``data`` ignoring ``x-spec-version``."""
+    stripped = dict(data)
+    stripped.pop("x-spec-version", None)
+    serialized = json.dumps(stripped, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _hash_from_git(path: Path) -> str | None:
+    """Return spec hash for ``path`` from previous commit or ``None``."""
+    rel_path = path
+    if rel_path.is_absolute():
+        rel_path = rel_path.relative_to(PROJECT_ROOT)
+    rel = rel_path.as_posix()
+    try:
+        content = subprocess.check_output(["git", "show", f"HEAD:{rel}"], text=True)
+    except subprocess.CalledProcessError:
+        return None
+    return _spec_hash(pyjson5.decode(content))
+
+
+def _update_changelog(services: list[str]) -> None:
+    """Insert changelog entries for ``services``."""
+    if not CHANGELOG.exists():
+        return
+    lines = CHANGELOG.read_text(encoding="utf-8").splitlines()
+    try:
+        idx = lines.index("### ⚙️ Miscellaneous Tasks")
+    except ValueError:
+        return
+    insert_at = idx + 1
+    for service in services:
+        entry = f"- *(openapi)* Update {service} spec"
+        if entry not in lines:
+            lines.insert(insert_at, entry)
+            insert_at += 1
+    CHANGELOG.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    """Update spec hashes and changelog."""
+    changed: list[str] = []
+    for path in sorted(OPENAPI_DIR.glob("*.json")):
+        data = pyjson5.decode(path.read_text(encoding="utf-8"))
+        current_hash = _spec_hash(data)
+        data["x-spec-version"] = current_hash
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        previous_hash = _hash_from_git(path)
+        if current_hash != previous_hash:
+            changed.append(path.stem)
+    if changed:
+        _update_changelog(changed)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `update_openapi_changelog.py` to track spec hashes
- record version hash in each OpenAPI json file
- mention the new script in the docs
- compute spec hash during generation

## Testing
- `make lint` *(fails: flake8 issues in tests)*
- `pytest -W error -vv` *(fails: database connection errors)*
- `npm test` *(fails: missing Jest module)*

------
https://chatgpt.com/codex/tasks/task_b_687dab559d90833181c988b985ca0c98