### PR TITLE
Add ZAP scanning on staging

### DIFF
--- a/.github/workflows/owasp-zap.yml
+++ b/.github/workflows/owasp-zap.yml
@@ -3,30 +3,22 @@ name: OWASP ZAP Scan
 on:
   push:
     branches: [main]
-  pull_request:
 
 jobs:
   zap:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      - name: Install frontend dependencies
-        run: |
-          npm ci --prefix frontend/admin-dashboard
-      - name: Build and start app
-        run: |
-          npm run build --prefix frontend/admin-dashboard
-          npm start --prefix frontend/admin-dashboard &
-          sleep 15
       - name: OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.12.0
         with:
-          target: 'http://localhost:3000'
-          fail_action: true
-      - name: Stop server
+          target: 'https://staging.example.com'
+          fail_action: false
+          cmd_options: '-J zap_report.json'
+      - name: Fail if medium or high vulnerabilities found
         run: |
-          kill $(lsof -t -i:3000) || true
+          if jq '.site[].alerts[] | select((.riskcode|tonumber) >= 2)' zap_report.json | grep -q .; then
+            echo "Medium or high vulnerabilities detected."
+            exit 1
+          fi
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,8 @@ Third-party Python packages are scanned with `pip-audit` and Docker images are s
 
 ## Dynamic Scanning
 
-OWASP ZAP runs against the development server to find common web vulnerabilities. Failing checks will stop the CI run.
+Each push to `main` triggers an OWASP ZAP baseline scan against the staging environment (`https://staging.example.com`).
+The resulting report is parsed and the workflow fails if any medium or high vulnerabilities are found.
 
 ## Mitigation Tracking
 


### PR DESCRIPTION
## Summary
- run OWASP ZAP against staging on push to main
- update security policy with staging ZAP scan details

## Testing
- `pip install -r requirements.txt` *(fails to show full output because of environment limits)*
- `pytest -n auto -vv` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_b_687dab56ac64833196531d66cdfc43e1