### PR TITLE
Integrate Auth0 token validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/desainz
 REDIS_URL=redis://localhost:6379/0
 SECRET_KEY=dev_secret_key
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
 OPENAI_API_KEY=your_openai_key
 STABILITY_AI_API_KEY=your_stability_key
 FALLBACK_PROVIDER=stability

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,7 @@ REDIS_URL=redis://cache:6379/0
 
 # Secret key for cryptographic signing
 SECRET_KEY=change_me
+
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id

--- a/backend/analytics/.env.example
+++ b/backend/analytics/.env.example
@@ -6,6 +6,10 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/api-gateway/.env.example
+++ b/backend/api-gateway/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/api-gateway/src/api_gateway/auth.py
+++ b/backend/api-gateway/src/api_gateway/auth.py
@@ -1,14 +1,10 @@
 """JWT authentication utilities for the API gateway."""
 
-from datetime import datetime
-from typing import Any, Dict, Callable, cast
+from typing import Any, Dict, Callable, cast, Iterable
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import select
 
 from backend.shared.auth import jwt as shared_jwt
-from backend.shared.db import session_scope
-from backend.shared.db.models import UserRole
 
 # Re-export shared constants and helpers for backward compatibility
 create_access_token = shared_jwt.create_access_token
@@ -20,20 +16,19 @@ ALGORITHM = shared_jwt.ALGORITHM
 ACCESS_TOKEN_EXPIRE_MINUTES = shared_jwt.ACCESS_TOKEN_EXPIRE_MINUTES
 
 
+def _extract_roles(payload: Dict[str, Any]) -> Iterable[str]:
+    """Return roles from ``payload`` if present."""
+    roles = payload.get("roles")
+    if isinstance(roles, list):
+        return cast(Iterable[str], roles)
+    return []
+
+
 def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     """Ensure the authenticated user has ``required_role``."""
 
     def _checker(payload: Dict[str, Any] = Depends(verify_token)) -> Dict[str, Any]:
-        username = cast(str | None, payload.get("sub"))
-        if username is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-            )
-        with session_scope() as session:
-            role = session.execute(
-                select(UserRole.role).where(UserRole.username == username)
-            ).scalar_one_or_none()
-        if role != required_role:
+        if required_role not in _extract_roles(payload):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient role"
             )

--- a/backend/feedback-loop/.env.example
+++ b/backend/feedback-loop/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/feedback-loop/feedback_loop/auth.py
+++ b/backend/feedback-loop/feedback_loop/auth.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, cast
+from typing import Any, Callable, Dict, cast, Iterable
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import select
 
 from backend.shared.auth import jwt as shared_jwt
-from backend.shared.db import session_scope
-from backend.shared.db.models import UserRole
 
 # Re-export shared helpers for convenience
 create_access_token = shared_jwt.create_access_token
@@ -24,17 +21,15 @@ ACCESS_TOKEN_EXPIRE_MINUTES = shared_jwt.ACCESS_TOKEN_EXPIRE_MINUTES
 def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     """Return dependency ensuring the authenticated user has ``required_role``."""
 
+    def _extract_roles(payload: Dict[str, Any]) -> Iterable[str]:
+        """Return roles from ``payload`` if present."""
+        roles = payload.get("roles")
+        if isinstance(roles, list):
+            return cast(Iterable[str], roles)
+        return []
+
     def _checker(payload: Dict[str, Any] = Depends(verify_token)) -> Dict[str, Any]:
-        username = cast(str | None, payload.get("sub"))
-        if username is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-            )
-        with session_scope() as session:
-            role = session.execute(
-                select(UserRole.role).where(UserRole.username == username)
-            ).scalar_one_or_none()
-        if role != required_role:
+        if required_role not in _extract_roles(payload):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Insufficient role",

--- a/backend/marketplace-publisher/.env.example
+++ b/backend/marketplace-publisher/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/mockup-generation/.env.example
+++ b/backend/mockup-generation/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/monitoring/.env.example
+++ b/backend/monitoring/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/optimization/.env.example
+++ b/backend/optimization/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/orchestrator/.env.example
+++ b/backend/orchestrator/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/scoring-engine/.env.example
+++ b/backend/scoring-engine/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/service-template/.env.example
+++ b/backend/service-template/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/shared/.env.example
+++ b/backend/shared/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/backend/shared/auth/jwt.py
+++ b/backend/shared/auth/jwt.py
@@ -1,8 +1,15 @@
-"""Shared JWT authentication utilities."""
+"""Shared JWT authentication utilities.
+
+The :func:`verify_token` helper validates credentials using Auth0 when the
+``AUTH0_DOMAIN`` and ``AUTH0_CLIENT_ID`` settings are configured. If they are
+not provided, a local secret key is used which is suitable for development and
+tests.
+"""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from functools import lru_cache
 from typing import Any, Dict, Callable, cast
 from uuid import uuid4
 
@@ -10,6 +17,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from sqlalchemy import select
+import httpx
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import RevokedToken
@@ -18,6 +26,9 @@ from backend.shared.config import settings as shared_settings
 SECRET_KEY = shared_settings.secret_key or "change_this"
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+AUTH0_DOMAIN = shared_settings.auth0_domain
+AUTH0_CLIENT_ID = shared_settings.auth0_client_id
 
 auth_scheme = HTTPBearer()
 
@@ -30,19 +41,57 @@ def create_access_token(data: Dict[str, Any]) -> str:
     return cast(str, jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM))
 
 
+def _jwks_url() -> str:
+    return f"https://{AUTH0_DOMAIN}/.well-known/jwks.json"
+
+
+@lru_cache(maxsize=1)
+def _jwks() -> Dict[str, Any]:
+    response = httpx.get(_jwks_url(), timeout=5)
+    response.raise_for_status()
+    return cast(Dict[str, Any], response.json())
+
+
+def _verify_auth0_token(token: str) -> Dict[str, Any]:
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError as exc:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Invalid token") from exc
+    jwks = _jwks()
+    key = next(
+        (k for k in jwks.get("keys", []) if k.get("kid") == header.get("kid")), None
+    )
+    if key is None:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Invalid token")
+    try:
+        payload = jwt.decode(
+            token,
+            key,
+            algorithms=[header.get("alg", "RS256")],
+            audience=AUTH0_CLIENT_ID,
+            issuer=f"https://{AUTH0_DOMAIN}/",
+        )
+    except JWTError as exc:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Invalid token") from exc
+    return cast(Dict[str, Any], payload)
+
+
 def verify_token(
     credentials: HTTPAuthorizationCredentials = Depends(auth_scheme),
 ) -> Dict[str, Any]:
     """Validate ``credentials`` and return the decoded payload."""
     token = credentials.credentials
-    try:
-        payload = cast(
-            Dict[str, Any], jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        )
-    except JWTError as exc:  # pragma: no cover - jose raises JWTError for any issue
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-        ) from exc
+    if AUTH0_DOMAIN and AUTH0_CLIENT_ID:
+        payload = _verify_auth0_token(token)
+    else:
+        try:
+            payload = cast(
+                Dict[str, Any], jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+            )
+        except JWTError as exc:  # pragma: no cover - jose raises JWTError for any issue
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
+            ) from exc
     jti = cast(str | None, payload.get("jti"))
     if jti is not None:
         with session_scope() as session:

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -27,6 +27,8 @@ class Settings(BaseSettings):  # type: ignore[misc]
     s3_bucket: str | None = None
     s3_base_url: str | None = None
     secret_key: str | None = None
+    auth0_domain: str | None = None
+    auth0_client_id: str | None = None
     weights_token: str | None = None
     allowed_origins: list[str] = Field(default_factory=list)
 

--- a/backend/signal-ingestion/.env.example
+++ b/backend/signal-ingestion/.env.example
@@ -6,6 +6,11 @@ REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
+# Auth0
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-client-id
+
+
 # Storage
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,8 @@ application settings classes.
 | `DATABASE_URL` | Database connection string |
 | `REDIS_URL` | Redis connection string |
 | `SECRET_KEY` | Secret key for cryptographic signing |
+| `AUTH0_DOMAIN` | Domain of the Auth0 tenant used for authentication |
+| `AUTH0_CLIENT_ID` | Client identifier issued by Auth0 |
 | `OPENAI_API_KEY` | OpenAI API authentication token used for image and listing generation |
 | `STABILITY_AI_API_KEY` | Stability AI API token |
 | `FALLBACK_PROVIDER` | `stability` or `dall-e` |

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,15 +27,10 @@ This project relies on environment variables for configuration.
 
 ### JWT secret rotation
 
-The `SECRET_KEY` used to sign JWT tokens is loaded from `/run/secrets` in
-production. To rotate it safely:
-
-1. Deploy the new secret alongside the old one and update the `secret_key`
-   environment variable.
-2. Insert all active token identifiers into the `revoked_tokens` table so old
-   credentials are rejected.
-3. Redeploy the services to pick up the new secret and remove the old one when
-   all clients have refreshed their tokens.
+Auth0 manages the signing keys for issued tokens. Rotation of these keys is
+handled automatically by Auth0 and requires no action from the services. During
+tests or local development, a static ``SECRET_KEY`` is still used and should be
+rotated periodically following the usual secret rotation procedure.
 
 ### Automated rotation
 


### PR DESCRIPTION
## Summary
- validate JWT tokens via Auth0 when configured
- map user roles from token claims in the API gateway and services
- add Auth0 domain/client ID docs and env vars
- document Auth0 token management

## Testing
- `flake8 backend/shared/auth/jwt.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py backend/feedback-loop/feedback_loop/auth.py`
- `pydocstyle backend/shared/auth/jwt.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py backend/feedback-loop/feedback_loop/auth.py`
- `mypy backend/shared/auth/jwt.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py backend/feedback-loop/feedback_loop/auth.py` *(failed: Command timed out)*
- `pytest -k 'not e2e' -q` *(failed: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687dbb126b8c8331af6b5ac45f8be6c1