### PR TITLE
Implement OAuth token persistence

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -366,6 +366,22 @@ async def ready() -> dict[str, str]:
     return {"status": "ready"}
 
 
+@app.get("/oauth/{marketplace}")
+async def oauth_login(marketplace: Marketplace) -> dict[str, str]:
+    """Return the authorization URL for ``marketplace``."""
+    client = publisher.CLIENTS[marketplace]
+    url = await asyncio.to_thread(client.get_authorization_url)
+    return {"authorization_url": url}
+
+
+@app.get("/oauth/{marketplace}/callback")
+async def oauth_callback(marketplace: Marketplace, request: Request) -> dict[str, str]:
+    """Handle OAuth redirect and persist tokens."""
+    client = publisher.CLIENTS[marketplace]
+    await asyncio.to_thread(client.fetch_token, str(request.url))
+    return {"status": "authorized"}
+
+
 if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser(
         description="Run the marketplace publisher service."

--- a/backend/shared/db/migrations/marketplace_publisher/versions/e07f77a52d6e_add_oauth_token_table.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/e07f77a52d6e_add_oauth_token_table.py
@@ -1,0 +1,29 @@
+"""Add oauth_token table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "e07f77a52d6e"
+down_revision = "830537fd941a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create ``oauth_token`` table."""
+    op.create_table(
+        "oauth_token",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("marketplace", sa.String(length=50), nullable=False, unique=True),
+        sa.Column("access_token", sa.String(), nullable=True),
+        sa.Column("refresh_token", sa.String(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop ``oauth_token`` table."""
+    op.drop_table("oauth_token")


### PR DESCRIPTION
## Summary
- persist oauth tokens in DB
- add oauth login endpoints
- support token loading & refreshing
- test token persistence logic
- create migration for oauth_token table

## Testing
- `flake8 backend/marketplace-publisher/src backend/marketplace-publisher/tests`
- `mypy backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/db.py backend/marketplace-publisher/src/marketplace_publisher/main.py --strict` *(fails: Library stubs not installed for "requests")*
- `pydocstyle backend/marketplace-publisher/src backend/marketplace-publisher/tests` *(fails: D202 in rules.py)*
- `pytest backend/marketplace-publisher/tests/test_clients.py::test_tokens_persisted_and_reused -q` *(fails: ModuleNotFoundError: No module named 'tests.test_clients')*

------
https://chatgpt.com/codex/tasks/task_b_687dbe4b87b08331ab8e215e888c1f8e