### PR TITLE
Switch listing generator to GPT-4

### DIFF
--- a/backend/mockup-generation/mockup_generation/listing_generator.py
+++ b/backend/mockup-generation/mockup_generation/listing_generator.py
@@ -7,6 +7,8 @@ import os
 from dataclasses import dataclass
 from typing import List
 
+from .settings import settings
+
 import requests
 
 
@@ -24,7 +26,8 @@ class ListingGenerator:
 
     def __init__(self) -> None:
         """Initialize with API credentials from the environment."""
-        self._openai_key = os.getenv("OPENAI_API_KEY")
+        self._openai_key = settings.openai_api_key or os.getenv("OPENAI_API_KEY")
+        self._openai_model = settings.openai_model
         self._claude_key = os.getenv("CLAUDE_API_KEY")
         self._session = requests.Session()
 
@@ -40,7 +43,7 @@ class ListingGenerator:
                 "https://api.openai.com/v1/chat/completions",
                 headers={"Authorization": f"Bearer {self._openai_key}"},
                 json={
-                    "model": "gpt-3.5-turbo",
+                    "model": self._openai_model,
                     "messages": [{"role": "user", "content": prompt}],
                 },
                 timeout=30,

--- a/backend/mockup-generation/mockup_generation/settings.py
+++ b/backend/mockup-generation/mockup_generation/settings.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import field_validator
 
 
-class Settings(BaseSettings):
+class Settings(BaseSettings):  # type: ignore[misc]
     """Expose API keys and provider selection."""
 
     model_config = SettingsConfigDict(
@@ -17,9 +17,10 @@ class Settings(BaseSettings):
 
     stability_ai_api_key: str | None = None
     openai_api_key: str | None = None
+    openai_model: str = "gpt-4"
     fallback_provider: Literal["stability", "openai"] = "stability"
 
-    @field_validator("fallback_provider")
+    @field_validator("fallback_provider")  # type: ignore[misc]
     @classmethod
     def _valid_provider(cls, value: str) -> str:
         if value not in {"stability", "openai"}:

--- a/backend/mockup-generation/tests/test_listing_generator.py
+++ b/backend/mockup-generation/tests/test_listing_generator.py
@@ -62,13 +62,18 @@ def test_generate_openai(monkeypatch: pytest.MonkeyPatch) -> None:
         ]
     }
 
-    def _post(url: str, **kwargs: object) -> DummyResponse:
+    calls: dict[str, object] = {}
+
+    def _post(_self: object, url: str, **kwargs: object) -> DummyResponse:
+        calls["json"] = kwargs.get("json")
         return DummyResponse(payload)
 
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     monkeypatch.setattr("requests.Session.post", _post)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
     gen = ListingGenerator()
     result = gen.generate(["cat"])
+    assert calls["json"]["model"] == "gpt-4"
     assert result.title == "T"
     assert result.description == "D"
     assert result.tags == ["a"]
@@ -90,7 +95,7 @@ def test_generate_claude(monkeypatch: pytest.MonkeyPatch) -> None:
         ]
     }
 
-    def _post(url: str, **kwargs: object) -> DummyResponse:
+    def _post(_self: object, url: str, **kwargs: object) -> DummyResponse:
         return DummyResponse(payload)
 
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/docs/mockup_generation.md
+++ b/docs/mockup_generation.md
@@ -24,3 +24,6 @@ redis-cli set gpu_slots 2
 
 An example HPA manifest lives in `infrastructure/k8s/examples/gpu-worker-hpa.yaml`
 and scales the `mockup-generation` deployment according to queue length.
+
+The metadata generation service uses OpenAI's GPT‑4 model by default. The
+model can be changed by setting the ``OPENAI_MODEL`` environment variable.


### PR DESCRIPTION
## Summary
- support selecting the OpenAI model via `OPENAI_MODEL` setting
- default to GPT-4 in listing generator
- adapt tests to mock GPT-4
- document the default model

## Testing
- `mypy backend/mockup-generation/mockup_generation/listing_generator.py backend/mockup-generation/mockup_generation/settings.py`
- `flake8 backend/mockup-generation/mockup_generation/listing_generator.py backend/mockup-generation/mockup_generation/settings.py backend/mockup-generation/tests/test_listing_generator.py`
- `pydocstyle backend/mockup-generation/mockup_generation/listing_generator.py backend/mockup-generation/mockup_generation/settings.py docs/mockup_generation.md`
- `SKIP_HEAVY_DEPS=1 pytest backend/mockup-generation/tests/test_listing_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_687dc56cc5c48331b7123d4784e9139f