### PR TITLE
Add GPU queue metric and HPA support

### DIFF
--- a/backend/mockup-generation/tests/test_gpu_metrics.py
+++ b/backend/mockup-generation/tests/test_gpu_metrics.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+import types
+
+import fakeredis
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))  # noqa: E402
+
+# Patch heavy deps before importing the module under test
+sys.modules.setdefault("diffusers", types.ModuleType("diffusers"))
+sys.modules["diffusers"].StableDiffusionXLPipeline = object  # type: ignore[attr-defined]
+sys.modules.setdefault("torch", types.ModuleType("torch"))
+sys.modules["torch"].cuda = types.SimpleNamespace(is_available=lambda: False)  # type: ignore[attr-defined]
+
+import redis  # noqa: E402
+
+
+@pytest.mark.usefixtures("monkeypatch")  # type: ignore[misc]
+def test_gpu_queue_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Metric reflects pending tasks in Redis."""
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(redis.Redis, "from_url", lambda *a, **k: fake)
+
+    stub_tasks = types.ModuleType("mockup_generation.tasks")
+    stub_tasks.get_gpu_slots = lambda: 1  # type: ignore[attr-defined]
+    stub_tasks.queue_for_gpu = lambda idx: f"gpu-{idx}"  # type: ignore[attr-defined]
+    sys.modules["mockup_generation.tasks"] = stub_tasks
+
+    from mockup_generation import celery_app  # noqa: E402
+
+    importlib.reload(celery_app)
+    fake.rpush(stub_tasks.queue_for_gpu(0), b"job")
+    collector = celery_app.GPUQueueCollector()
+    metric = next(iter(collector.collect()))
+    assert metric.samples[0].value == 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,6 +47,11 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
      -f infrastructure/helm/orchestrator/values-dev.yaml
    ```
 
+   The `ai-mockup-generation` chart uses the `gpu_queue_length` metric to scale
+   GPU workers. Set `hpa.enabled` to `true` and configure
+   `hpa.gpuQueueAverageValue` in `values.yaml` to enable automatic scaling based
+   on pending tasks.
+
 ## Cloud Providers
 
 ### AWS

--- a/infrastructure/helm/ai-mockup-generation/templates/hpa.yaml
+++ b/infrastructure/helm/ai-mockup-generation/templates/hpa.yaml
@@ -23,4 +23,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- if .Values.hpa.gpuQueueAverageValue }}
+    - type: External
+      external:
+        metric:
+          name: gpu_queue_length
+        target:
+          type: AverageValue
+          averageValue: "{{ .Values.hpa.gpuQueueAverageValue }}"
+{{- end }}
 {{- end }}

--- a/infrastructure/helm/ai-mockup-generation/values.yaml
+++ b/infrastructure/helm/ai-mockup-generation/values.yaml
@@ -13,8 +13,9 @@ env: {}
 
 # Horizontal pod autoscaler
 hpa:
-  enabled: false
+  enabled: true
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  gpuQueueAverageValue: 3


### PR DESCRIPTION
## Summary
- expose `gpu_queue_length` metric from Celery
- enable autoscaling via GPU metric in Helm chart
- document GPU queue based scaling
- add integration test for metric collection

## Testing
- `mypy backend/mockup-generation/mockup_generation/celery_app.py backend/mockup-generation/tests/test_gpu_metrics.py --ignore-missing-imports --follow-imports=skip`
- `flake8 backend/mockup-generation/mockup_generation/celery_app.py backend/mockup-generation/tests/test_gpu_metrics.py`
- `pydocstyle backend/mockup-generation/mockup_generation/celery_app.py backend/mockup-generation/tests/test_gpu_metrics.py`
- `pytest backend/mockup-generation/tests/test_gpu_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_b_687e28b050d8833184ff414febb4f56c