### PR TITLE
Add community affinity embeddings

### DIFF
--- a/backend/scoring-engine/scoring_engine/affinity.py
+++ b/backend/scoring-engine/scoring_engine/affinity.py
@@ -1,0 +1,57 @@
+"""Community affinity utilities."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+DIMENSION = 32
+
+
+def _hash_embedding(text: str) -> NDArray[np.floating]:
+    """Return a deterministic embedding vector for ``text``."""
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    arr = np.frombuffer(digest, dtype=np.uint8).astype(float)
+    return arr[:DIMENSION] / 255.0
+
+
+def subreddit_embedding(name: str) -> NDArray[np.floating]:
+    """Return embedding for a subreddit name."""
+    return _hash_embedding(f"subreddit:{name.lower()}")
+
+
+def hashtag_embedding(tag: str) -> NDArray[np.floating]:
+    """Return embedding for a hashtag."""
+    return _hash_embedding(f"hashtag:{tag.lower()}")
+
+
+def metadata_embedding(metadata: dict[str, float]) -> NDArray[np.floating]:
+    """Aggregate embeddings for keys in ``metadata``."""
+    if not metadata:
+        return np.zeros(DIMENSION, dtype=float)
+    total = np.zeros(DIMENSION, dtype=float)
+    weight_sum = 0.0
+    for key, weight in metadata.items():
+        if key.startswith("r/"):
+            vec = subreddit_embedding(key[2:])
+        elif key.startswith("#"):
+            vec = hashtag_embedding(key[1:])
+        else:
+            vec = _hash_embedding(key)
+        total += vec * float(weight)
+        weight_sum += float(weight)
+    if weight_sum == 0.0:
+        return total
+    return total / weight_sum
+
+
+__all__ = [
+    "DIMENSION",
+    "subreddit_embedding",
+    "hashtag_embedding",
+    "metadata_embedding",
+]

--- a/backend/scoring-engine/scoring_engine/scoring.py
+++ b/backend/scoring-engine/scoring_engine/scoring.py
@@ -12,6 +12,7 @@ import numpy as np
 from sklearn.preprocessing import StandardScaler
 
 from .weight_repository import get_centroid, get_weights
+from .affinity import metadata_embedding, DIMENSION
 
 
 class Signal:
@@ -62,10 +63,12 @@ def compute_novelty(
 
 
 def compute_community_fit(metadata: dict[str, float]) -> float:
-    """Simplistic community affinity from metadata weights."""
+    """Return community affinity score based on metadata embeddings."""
     if not metadata:
         return 0.0
-    return float(sum(metadata.values()) / len(metadata))
+    vec = metadata_embedding(metadata)
+    norm = float(np.linalg.norm(vec))
+    return norm / math.sqrt(DIMENSION)
 
 
 def compute_seasonality(timestamp: datetime, topics: Iterable[str]) -> float:

--- a/backend/scoring-engine/tests/test_affinity.py
+++ b/backend/scoring-engine/tests/test_affinity.py
@@ -1,0 +1,41 @@
+"""Tests for affinity utilities."""
+
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from scoring_engine.affinity import (
+    DIMENSION,
+    hashtag_embedding,
+    metadata_embedding,
+    subreddit_embedding,
+)
+from scoring_engine.scoring import compute_community_fit
+
+
+def test_subreddit_embedding_deterministic() -> None:
+    """Subreddit embeddings should be deterministic."""
+    v1 = subreddit_embedding("Python")
+    v2 = subreddit_embedding("python")
+    assert np.array_equal(v1, v2)
+
+
+def test_metadata_embedding_weighted_average() -> None:
+    """metadata_embedding returns weighted average of components."""
+    meta = {"r/foo": 2.0, "#bar": 1.0}
+    expected = (subreddit_embedding("foo") * 2.0 + hashtag_embedding("bar")) / 3.0
+    result = metadata_embedding(meta)
+    assert np.allclose(result, expected)
+
+
+def test_compute_community_fit_uses_embeddings() -> None:
+    """compute_community_fit scales embedding norm."""
+    meta = {"r/foo": 1.0}
+    vec = subreddit_embedding("foo")
+    expected = np.linalg.norm(vec) / math.sqrt(DIMENSION)
+    result = compute_community_fit(meta)
+    assert result == expected

--- a/docs/scoring_engine/affinity.rst
+++ b/docs/scoring_engine/affinity.rst
@@ -1,0 +1,8 @@
+Affinity Utilities
+==================
+
+The :mod:`scoring_engine.affinity` module provides simple helpers for computing
+subreddit and hashtag embeddings used to determine community fit.
+
+.. automodule:: scoring_engine.affinity
+   :members:

--- a/docs/scoring_engine/index.rst
+++ b/docs/scoring_engine/index.rst
@@ -17,5 +17,6 @@ documentation for details.
    :maxdepth: 2
    :caption: Contents:
 
+   affinity
    modules
 

--- a/docs/scoring_engine/modules.rst
+++ b/docs/scoring_engine/modules.rst
@@ -4,6 +4,9 @@ API Reference
 .. automodule:: scoring_engine.scoring
    :members:
 
+.. automodule:: scoring_engine.affinity
+   :members:
+
 .. automodule:: scoring_engine.app
    :members:
 


### PR DESCRIPTION
## Summary
- compute subreddit/hashtag embeddings in `affinity.py`
- leverage embeddings in `compute_community_fit`
- document affinity helpers and expose in docs
- test affinity utilities

## Testing
- `flake8 backend/scoring-engine/scoring_engine/affinity.py backend/scoring-engine/scoring_engine/scoring.py backend/scoring-engine/tests/test_affinity.py`
- `pydocstyle backend/scoring-engine/scoring_engine/affinity.py backend/scoring-engine/scoring_engine/scoring.py backend/scoring-engine/tests/test_affinity.py`
- `docformatter --check backend/scoring-engine/scoring_engine/affinity.py backend/scoring-engine/scoring_engine/scoring.py backend/scoring-engine/tests/test_affinity.py docs/scoring_engine/affinity.rst docs/scoring_engine/index.rst docs/scoring_engine/modules.rst`
- `mypy backend/scoring-engine/scoring_engine/affinity.py backend/scoring-engine/scoring_engine/scoring.py --ignore-missing-imports` *(fails: missing stubs)*
- `pytest backend/scoring-engine/tests/test_affinity.py -W error -vv` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687e32577ad083318ccdfb2269e91dcc