### PR TITLE
Add AWS spot management and checkpointing

### DIFF
--- a/backend/mockup-generation/Dockerfile
+++ b/backend/mockup-generation/Dockerfile
@@ -14,4 +14,5 @@ ARG GPU_INDEX=0
 ENV GPU_WORKER_INDEX=${GPU_INDEX}
 ENV CUDA_VISIBLE_DEVICES=${GPU_INDEX}
 
-CMD ["celery", "-A", "mockup_generation.celery_app", "worker", "--loglevel=info", "-Q", "gpu-${GPU_WORKER_INDEX}", "--concurrency=1"]
+COPY start_worker.sh /usr/local/bin/start_worker.sh
+CMD ["/usr/local/bin/start_worker.sh"]

--- a/backend/mockup-generation/mockup_generation/celery_app.py
+++ b/backend/mockup-generation/mockup_generation/celery_app.py
@@ -16,6 +16,8 @@ from .tasks import queue_for_gpu
 CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
 app = Celery("mockup_generation", broker=CELERY_BROKER_URL)
 app.conf.result_backend = CELERY_BROKER_URL
+app.conf.task_acks_late = True
+app.conf.task_reject_on_worker_lost = True
 
 
 class GPUQueueCollector:

--- a/backend/mockup-generation/start_worker.sh
+++ b/backend/mockup-generation/start_worker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Start the Celery worker with task checkpointing enabled.
+set -euo pipefail
+STATE_DIR=/var/run/celery
+mkdir -p "$STATE_DIR"
+exec celery -A mockup_generation.celery_app worker \
+  --loglevel=info \
+  -Q gpu-${GPU_WORKER_INDEX} \
+  --concurrency=1 \
+  --statedb="$STATE_DIR/worker.state" \
+  --task-events
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -16,3 +16,27 @@ Open the **Approvals** page to see a list of pending Dagster run IDs.
 Click **Approve** next to a run to unblock publishing.
 The API Gateway exposes `/approvals` for fetching pending runs and
 `/approvals/{run_id}` for approving a run.
+
+## Spot Instances
+
+Use `scripts/manage_spot_instances.py` to request and release AWS spot nodes. A
+typical workflow to add a worker is:
+
+```bash
+python scripts/manage_spot_instances.py request \
+  --ami-id ami-12345678 \
+  --instance-type g4dn.xlarge \
+  --key-name kube-key \
+  --security-group sg-12345678 \
+  --subnet-id subnet-12345678
+```
+
+The script waits for the instance to become ready and labels the node so
+Kubernetes can schedule pods on it. To remove a node run:
+
+```bash
+python scripts/manage_spot_instances.py release i-0abcd1234ef567890
+```
+
+Workers will checkpoint tasks using Celery's statedb so another node can resume
+processing when a spot instance is reclaimed.

--- a/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
+++ b/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
     metadata:
       labels: {{- include "ai-mockup-generation.selectorLabels" . | nindent 8 }}
     spec:
+      tolerations:
+        - key: "node-role.kubernetes.io/spot"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/scripts/manage_spot_instances.py
+++ b/scripts/manage_spot_instances.py
@@ -1,0 +1,103 @@
+"""Manage AWS spot instances for Kubernetes nodes."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import time
+
+import boto3
+
+
+def request_instance(
+    ami_id: str,
+    instance_type: str,
+    key_name: str,
+    security_group: str,
+    subnet_id: str,
+    *,
+    label: str = "node-role.kubernetes.io/spot=yes",
+) -> str:
+    """Request a spot instance and return its ID."""
+    ec2 = boto3.client("ec2")
+    resp = ec2.run_instances(
+        ImageId=ami_id,
+        InstanceType=instance_type,
+        KeyName=key_name,
+        SecurityGroupIds=[security_group],
+        SubnetId=subnet_id,
+        InstanceMarketOptions={"MarketType": "spot"},
+        MinCount=1,
+        MaxCount=1,
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": [
+                    {"Key": label.split("=")[0], "Value": label.split("=")[1]},
+                ],
+            }
+        ],
+    )
+    return resp["Instances"][0]["InstanceId"]
+
+
+def label_node(instance_id: str, label: str) -> None:
+    """Label the Kubernetes node once it becomes available."""
+    ec2 = boto3.client("ec2")
+    while True:
+        desc = ec2.describe_instances(InstanceIds=[instance_id])
+        inst = desc["Reservations"][0]["Instances"][0]
+        if inst["State"]["Name"] == "running" and "PrivateDnsName" in inst:
+            break
+        time.sleep(5)
+    node_name = inst["PrivateDnsName"].split(".")[0]
+    subprocess.run(
+        ["kubectl", "label", "nodes", node_name, label, "--overwrite"],
+        check=True,
+    )
+
+
+def release_instance(instance_id: str) -> None:
+    """Terminate the given spot instance."""
+    ec2 = boto3.client("ec2")
+    ec2.terminate_instances(InstanceIds=[instance_id])
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    req = sub.add_parser("request")
+    req.add_argument("--ami-id", required=True)
+    req.add_argument("--instance-type", required=True)
+    req.add_argument("--key-name", required=True)
+    req.add_argument("--security-group", required=True)
+    req.add_argument("--subnet-id", required=True)
+    req.add_argument("--label", default="node-role.kubernetes.io/spot=yes")
+
+    rel = sub.add_parser("release")
+    rel.add_argument("instance_id")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point."""
+    args = parse_args()
+    if args.cmd == "request":
+        instance_id = request_instance(
+            args.ami_id,
+            args.instance_type,
+            args.key_name,
+            args.security_group,
+            args.subnet_id,
+            label=args.label,
+        )
+        label_node(instance_id, args.label)
+        print(instance_id)
+    elif args.cmd == "release":
+        release_instance(args.instance_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add manage_spot_instances script
- tolerate spot node taints in mockup generation Helm chart
- checkpoint Celery tasks and add worker script
- document spot instances in operations guide

## Testing
- `black scripts/manage_spot_instances.py`
- `flake8 scripts/manage_spot_instances.py`
- `mypy --config-file=/tmp/mypy.ini`
- `docformatter --in-place --recursive docs/operations.md scripts/manage_spot_instances.py`
- `pydocstyle docs/operations.md scripts/manage_spot_instances.py`
- `pytest tests/test_backup.py -W error`

------
https://chatgpt.com/codex/tasks/task_b_687e3d1ef04083318044766a3da0edf4