### PR TITLE
Improve dashboard accessibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
+    'plugin:jsx-a11y/recommended',
     'next',
     'next/core-web-vitals',
     'standard',

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,0 +1,5 @@
+# Frontend Accessibility
+
+The admin dashboard follows WCAG guidelines. Interactive controls include `aria-label` attributes and keyboard handlers so screen reader and keyboard users can operate all features. Jest and React Testing Library verify components respond to keyboard events and remain free of accessibility violations via `jest-axe`.
+
+Key widgets like the language switcher and toggle button expose labels that describe their action. Chart range selectors provide accessible labels, and lists identify their content for assistive technologies.

--- a/frontend/admin-dashboard/__tests__/accessibility.test.tsx
+++ b/frontend/admin-dashboard/__tests__/accessibility.test.tsx
@@ -1,9 +1,20 @@
-import { render } from '@testing-library/react';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Router from 'next-router-mock';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { Button } from '../src/components/Button';
 import { ToggleButton } from '../src/components/ToggleButton';
+import { LanguageSwitcher } from '../src/components/LanguageSwitcher';
 
 expect.extend(toHaveNoViolations);
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(
+    <RouterContext.Provider value={Router}>{ui}</RouterContext.Provider>
+  );
+}
 
 describe('accessibility checks', () => {
   it('Button has no a11y violations', async () => {
@@ -16,5 +27,21 @@ describe('accessibility checks', () => {
     const { container } = render(<ToggleButton />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('ToggleButton toggles via keyboard', async () => {
+    render(<ToggleButton />);
+    const button = screen.getByTestId('toggle-button');
+    button.focus();
+    await userEvent.keyboard('{enter}');
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('LanguageSwitcher allows keyboard selection', async () => {
+    renderWithRouter(<LanguageSwitcher />);
+    const first = screen.getByTestId('lang-en');
+    first.focus();
+    await userEvent.keyboard('{enter}');
+    expect(first).toBeInTheDocument();
   });
 });

--- a/frontend/admin-dashboard/eslint.config.mjs
+++ b/frontend/admin-dashboard/eslint.config.mjs
@@ -1,6 +1,6 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,9 +10,13 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends(
+    'next/core-web-vitals',
+    'next/typescript',
+    'plugin:jsx-a11y/recommended'
+  ),
   {
-    ignores: ["coverage/**"],
+    ignores: ['coverage/**'],
   },
 ];
 

--- a/frontend/admin-dashboard/package.json
+++ b/frontend/admin-dashboard/package.json
@@ -52,6 +52,7 @@
     "babel-jest": "^30.0.4",
     "eslint": "^9",
     "eslint-config-next": "15.4.1",
+    "eslint-plugin-jsx-a11y": "^6.10.0",
     "flow-bin": "^0.275.0",
     "jest": "^30.0.4",
     "jest-axe": "^10.0.0",

--- a/frontend/admin-dashboard/src/components/AnalyticsChart.tsx
+++ b/frontend/admin-dashboard/src/components/AnalyticsChart.tsx
@@ -42,6 +42,7 @@ export function AnalyticsChart() {
       </label>
       <select
         id="analytics-range"
+        aria-label="Analytics range"
         onChange={(e) => setRange(e.target.value)}
         value={range}
       >

--- a/frontend/admin-dashboard/src/components/AuthButton.tsx
+++ b/frontend/admin-dashboard/src/components/AuthButton.tsx
@@ -19,14 +19,24 @@ export default function AuthButton() {
 
   if (session) {
     return (
-      <button onClick={() => signOut()} className="ml-auto">
+      <button
+        type="button"
+        aria-label={t('logout')}
+        onClick={() => signOut()}
+        className="ml-auto"
+      >
         {t('logout')}
       </button>
     );
   }
 
   return (
-    <button onClick={() => signIn()} className="ml-auto">
+    <button
+      type="button"
+      aria-label={t('login')}
+      onClick={() => signIn()}
+      className="ml-auto"
+    >
       {t('login')}
     </button>
   );

--- a/frontend/admin-dashboard/src/components/LanguageSwitcher.tsx
+++ b/frontend/admin-dashboard/src/components/LanguageSwitcher.tsx
@@ -12,6 +12,7 @@ export function LanguageSwitcher() {
         <button
           key={lng}
           type="button"
+          aria-label={`Switch to ${lng === 'en' ? 'English' : 'Spanish'}`}
           onClick={() => {
             void changeLanguage(lng);
             void router.push(router.asPath, undefined, { locale: lng });

--- a/frontend/admin-dashboard/src/components/LatencyChart.tsx
+++ b/frontend/admin-dashboard/src/components/LatencyChart.tsx
@@ -42,6 +42,7 @@ export function LatencyChart() {
       </label>
       <select
         id="latency-range"
+        aria-label="Latency range"
         onChange={(e) => setRange(e.target.value)}
         value={range}
       >

--- a/frontend/admin-dashboard/src/components/RolesList.tsx
+++ b/frontend/admin-dashboard/src/components/RolesList.tsx
@@ -18,7 +18,7 @@ export function RolesList() {
     void load();
   }, []);
   return (
-    <ul>
+    <ul aria-label="User roles">
       {roles.map((r) => (
         <li key={r.username}>
           {r.username}: {r.role}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-n": "^17.21.0",
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-jsx-a11y": "^6.10.0",
     "flow-bin": "^0.275.0",
     "next": "15.4.1",
     "prettier": "^3.6.2",


### PR DESCRIPTION
## Summary
- add aria-labels on dashboard UI components
- ensure eslint checks for a11y with jsx-a11y plugin
- add keyboard navigation tests
- document accessibility features

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_687e437dc9608331bb5f5168812a6dd9