### PR TITLE
Add daily listing sync job

### DIFF
--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -17,6 +17,7 @@ from .ops import (
     ingest_signals,
     publish_content,
     score_signals,
+    sync_listing_states_op,
 )
 from .hooks import record_failure, record_success
 
@@ -58,5 +59,10 @@ def daily_summary_job() -> None:
 @job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def rotate_secrets_job() -> None:
     """Job rotating API tokens and updating Kubernetes secrets."""
-
     rotate_k8s_secrets_op()
+
+
+@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+def sync_listings_job() -> None:
+    """Job synchronizing marketplace listing states."""
+    sync_listing_states_op()

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -248,8 +248,16 @@ def rotate_k8s_secrets_op(  # type: ignore[no-untyped-def]
     context,
 ) -> None:
     """Rotate Kubernetes secrets via :mod:`scripts.rotate_secrets`."""
-
     context.log.info("rotating Kubernetes secrets")
     from scripts.rotate_secrets import rotate
 
     rotate()
+
+
+@op  # type: ignore[misc]
+def sync_listing_states_op(context) -> None:  # type: ignore[no-untyped-def]
+    """Synchronize marketplace listing states with the local database."""
+    context.log.info("synchronizing listing states")
+    from scripts import listing_sync
+
+    listing_sync.main()

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -1,5 +1,4 @@
 """Dagster definitions for the orchestrator."""
-
 from dagster import Definitions
 
 from .jobs import (
@@ -9,6 +8,7 @@ from .jobs import (
     idea_job,
     rotate_secrets_job,
     daily_summary_job,
+    sync_listings_job,
 )
 from .schedules import (
     daily_backup_schedule,
@@ -16,6 +16,7 @@ from .schedules import (
     daily_query_plan_schedule,
     daily_summary_schedule,
     monthly_secret_rotation_schedule,
+    daily_listing_sync_schedule,
 )
 from .sensors import idea_sensor, run_failure_notifier
 
@@ -28,6 +29,7 @@ defs = Definitions(
         analyze_query_plans_job,
         daily_summary_job,
         rotate_secrets_job,
+        sync_listings_job,
     ],
     schedules=[
         daily_backup_schedule,
@@ -35,6 +37,7 @@ defs = Definitions(
         daily_query_plan_schedule,
         daily_summary_schedule,
         monthly_secret_rotation_schedule,
+        daily_listing_sync_schedule,
     ],
     sensors=[idea_sensor, run_failure_notifier],
 )

--- a/backend/orchestrator/orchestrator/schedules.py
+++ b/backend/orchestrator/orchestrator/schedules.py
@@ -8,6 +8,7 @@ from .jobs import (
     analyze_query_plans_job,
     daily_summary_job,
     rotate_secrets_job,
+    sync_listings_job,
 )
 
 
@@ -38,6 +39,16 @@ def daily_summary_schedule(_context: ScheduleEvaluationContext) -> dict[str, obj
 
 
 @schedule(cron_schedule="0 0 1 * *", job=rotate_secrets_job, execution_timezone="UTC")
-def monthly_secret_rotation_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
+def monthly_secret_rotation_schedule(
+    _context: ScheduleEvaluationContext,
+) -> dict[str, object]:
     """Rotate secrets on the first day of each month."""
+    return {}
+
+
+@schedule(cron_schedule="0 2 * * *", job=sync_listings_job, execution_timezone="UTC")
+def daily_listing_sync_schedule(
+    _context: ScheduleEvaluationContext,
+) -> dict[str, object]:
+    """Trigger ``sync_listings_job`` every day."""
     return {}

--- a/backend/orchestrator/tests/test_listings_job.py
+++ b/backend/orchestrator/tests/test_listings_job.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from dagster import DagsterInstance
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))  # noqa: E402
+
+from orchestrator.jobs import sync_listings_job  # noqa: E402
+from orchestrator.schedules import daily_listing_sync_schedule  # noqa: E402
+
+
+def test_sync_listings_job_structure() -> None:
+    """Ensure the job calls the listing sync op."""
+    ops = [op.name for op in sync_listings_job.graph.node_dict.values()]
+    assert ops == ["sync_listing_states_op"]
+
+
+def test_daily_listing_sync_schedule() -> None:
+    """Schedule should run the listings sync job daily."""
+    assert daily_listing_sync_schedule.job == sync_listings_job
+    assert daily_listing_sync_schedule.cron_schedule == "0 2 * * *"
+
+
+def test_sync_listings_job_exec(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the job and ensure the sync function executes."""
+    calls: list[str] = []
+
+    def fake_main() -> None:
+        calls.append("called")
+
+    monkeypatch.setattr("scripts.listing_sync.main", fake_main)
+    instance = DagsterInstance.ephemeral()
+    result = sync_listings_job.execute_in_process(instance=instance)
+    assert result.success
+    assert calls == ["called"]

--- a/scripts/listing_sync.py
+++ b/scripts/listing_sync.py
@@ -66,6 +66,11 @@ def setup_scheduler() -> BlockingScheduler:
     return scheduler
 
 
+def main() -> None:
+    """Run a single synchronization iteration."""
+    sync_listing_states()
+
+
 if __name__ == "__main__":  # pragma: no cover
     logging.basicConfig(level=logging.INFO)
     scheduler = setup_scheduler()


### PR DESCRIPTION
## Summary
- add `sync_listing_states_op` for listing synchronization
- create `sync_listings_job`
- run job daily via `daily_listing_sync_schedule`
- expose job and schedule in Dagster repository
- add basic tests for listings job
- expose `main()` entrypoint in listing sync script

## Testing
- `flake8 backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/orchestrator/repository.py scripts/listing_sync.py backend/orchestrator/tests/test_listings_job.py`
- `pydocstyle backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/orchestrator/repository.py scripts/listing_sync.py backend/orchestrator/tests/test_listings_job.py`
- `mypy backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/orchestrator/repository.py scripts/listing_sync.py backend/orchestrator/tests/test_listings_job.py --ignore-missing-imports --explicit-package-bases` *(failed: ModuleNotFoundError)*
- `pytest backend/orchestrator/tests/test_listings_job.py -vv` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_687e4b76d5bc8331a88b70018654238d