### PR TITLE
Add listing sync Dagster op and schedule

### DIFF
--- a/backend/orchestrator/__init__.py
+++ b/backend/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+"""Orchestrator service package."""

--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -22,7 +22,7 @@ from .ops import (
 from .hooks import record_failure, record_success
 
 
-@job(retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+@job(op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def idea_job() -> None:
     """Pipeline from ingestion to publishing."""
     signals = ingest_signals()
@@ -32,37 +32,37 @@ def idea_job() -> None:
     publish_content(items)
 
 
-@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def backup_job() -> None:
     """Job running the backup operation."""
     backup_data()
 
 
-@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def cleanup_job() -> None:
     """Job running periodic cleanup."""
     cleanup_data()
 
 
-@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def analyze_query_plans_job() -> None:
     """Job collecting EXPLAIN plans for slow queries."""
     analyze_query_plans_op()
 
 
-@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def daily_summary_job() -> None:
     """Job generating the daily activity summary."""
     run_daily_summary()
 
 
-@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def rotate_secrets_job() -> None:
     """Job rotating API tokens and updating Kubernetes secrets."""
     rotate_k8s_secrets_op()
 
 
-@job(hooks={record_success, record_failure}, retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def sync_listings_job() -> None:
     """Job synchronizing marketplace listing states."""
     sync_listing_states_op()

--- a/backend/orchestrator/tests/test_jobs.py
+++ b/backend/orchestrator/tests/test_jobs.py
@@ -6,7 +6,10 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
-sys.path.append(str(ROOT))  # noqa: E402
+ORCHESTRATOR_PATH = ROOT / "backend" / "orchestrator"
+sys.path.append(str(ORCHESTRATOR_PATH))  # noqa: E402
+MONITORING_SRC = ROOT / "backend" / "monitoring" / "src"
+sys.path.append(str(MONITORING_SRC))  # noqa: E402
 
 from orchestrator.jobs import (  # noqa: E402
     backup_job,

--- a/backend/orchestrator/tests/test_listings_job.py
+++ b/backend/orchestrator/tests/test_listings_job.py
@@ -1,3 +1,5 @@
+"""Tests for the listings synchronization job."""
+
 from __future__ import annotations
 
 import sys
@@ -7,7 +9,10 @@ import pytest
 from dagster import DagsterInstance
 
 ROOT = Path(__file__).resolve().parents[3]
-sys.path.append(str(ROOT))  # noqa: E402
+ORCHESTRATOR_PATH = ROOT / "backend" / "orchestrator"
+sys.path.append(str(ORCHESTRATOR_PATH))  # noqa: E402
+MONITORING_SRC = ROOT / "backend" / "monitoring" / "src"
+sys.path.append(str(MONITORING_SRC))  # noqa: E402
 
 from orchestrator.jobs import sync_listings_job  # noqa: E402
 from orchestrator.schedules import daily_listing_sync_schedule  # noqa: E402


### PR DESCRIPTION
## Summary
- ensure orchestrator package is importable by tests
- adjust jobs to use `op_retry_policy` for Dagster 1.11
- update tests to reference orchestrator package correctly

## Testing
- `flake8 backend/orchestrator/orchestrator backend/orchestrator/tests/test_jobs.py backend/orchestrator/tests/test_listings_job.py`
- `pytest backend/orchestrator/tests/test_listings_job.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687e4e9b4d3883319f5d5073d7a65771