### PR TITLE
Implement feature flag API

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -50,6 +50,7 @@ tags_metadata = [
     {"name": "Models", "description": "Manage available AI models."},
     {"name": "Publish", "description": "Manage publishing tasks."},
     {"name": "Protected", "description": "Endpoints requiring authentication."},
+    {"name": "Flags", "description": "Query and modify feature flags."},
 ]
 
 SERVICE_NAME = os.getenv("SERVICE_NAME", "api-gateway")

--- a/backend/api-gateway/src/api_gateway/models.py
+++ b/backend/api-gateway/src/api_gateway/models.py
@@ -23,3 +23,9 @@ class MetadataPatch(BaseModel):
     """Arbitrary metadata payload."""
 
     model_config = ConfigDict(extra="allow")
+
+
+class FlagState(BaseModel):
+    """Desired state for a feature flag."""
+
+    enabled: bool

--- a/backend/api-gateway/tests/test_feature_flags.py
+++ b/backend/api-gateway/tests/test_feature_flags.py
@@ -1,0 +1,41 @@
+import sys
+import os
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+import importlib  # noqa: E402
+import fakeredis.aioredis  # noqa: E402
+
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared import feature_flags  # noqa: E402
+
+
+def setup_module(module: object) -> None:
+    os.environ["REDIS_URL"] = "redis://localhost:6379/0"
+    feature_flags.redis.Redis = lambda *a, **k: fakeredis.aioredis.FakeRedis(
+        decode_responses=True
+    )
+    import api_gateway.routes as routes
+    routes.get_async_client = lambda: fakeredis.aioredis.FakeRedis()
+    import api_gateway.main as main_module
+    importlib.reload(main_module)
+    importlib.reload(feature_flags)
+    feature_flags.initialize()
+    global client
+    client = TestClient(main_module.app)
+
+
+def test_toggle_flag() -> None:
+    token = create_access_token({"sub": "admin"})
+    resp = client.post(
+        "/feature-flags/demo",
+        json={"enabled": True},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    resp = client.get("/feature-flags", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json().get("demo") is True
+

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -19,3 +19,16 @@ accept requests targeting the `society6` marketplace. When disabled, such
 requests return HTTP 403.
 Similarly, the `zazzle_integration` flag controls access to the Zazzle publisher
 API and gated UI links.
+
+## API Management
+
+Feature flags can be managed through the API Gateway. The following endpoints
+require an authenticated user with the ``admin`` role:
+
+* ``GET /feature-flags`` – list all known flags and their current values.
+* ``POST /feature-flags/{name}`` – set the provided flag to the ``enabled``
+  state in the request body.
+
+The admin dashboard provides a simple interface built from the components in
+``frontend/admin-dashboard/src/components/FeatureFlags`` which consume these
+endpoints.

--- a/frontend/admin-dashboard/__tests__/featureFlags.test.tsx
+++ b/frontend/admin-dashboard/__tests__/featureFlags.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeatureFlagsList } from '../src/components/FeatureFlags/FeatureFlagsList';
+
+beforeEach(() => {
+  global.fetch = jest.fn((url: RequestInfo, init?: RequestInit) => {
+    if (typeof url === 'string' && url.endsWith('/feature-flags')) {
+      if (!init || init.method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ demo: false }),
+        }) as unknown as Response;
+      }
+      return Promise.resolve({ ok: true }) as unknown as Response;
+    }
+    return Promise.resolve({ ok: true }) as unknown as Response;
+  });
+});
+
+afterEach(() => {
+  (global.fetch as jest.Mock).mockRestore();
+});
+
+test('lists and toggles flags', async () => {
+  render(<FeatureFlagsList />);
+  await waitFor(() => screen.getByLabelText('Feature flags'));
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).not.toBeChecked();
+  await userEvent.click(checkbox);
+  expect(global.fetch).toHaveBeenLastCalledWith(
+    '/feature-flags/demo',
+    expect.objectContaining({ method: 'POST' })
+  );
+});

--- a/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagToggle.tsx
+++ b/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagToggle.tsx
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react';
+
+interface Props {
+  name: string;
+  enabled: boolean;
+  onToggle: (value: boolean) => void;
+}
+
+export function FeatureFlagToggle({ name, enabled, onToggle }: Props) {
+  return (
+    <label>
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={(e) => onToggle(e.target.checked)}
+      />
+      {name}
+    </label>
+  );
+}

--- a/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagsList.tsx
+++ b/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagsList.tsx
@@ -1,0 +1,44 @@
+// @flow
+import React, { useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../hooks/useAuthFetch';
+
+export function FeatureFlagsList() {
+  const [flags, setFlags] = useState<Record<string, boolean>>({});
+  useEffect(() => {
+    async function load() {
+      const res = await fetchWithAuth('/feature-flags');
+      if (res.ok) {
+        setFlags(await res.json());
+      }
+    }
+    void load();
+  }, []);
+
+  async function toggle(name: string, value: boolean) {
+    const res = await fetchWithAuth(`/feature-flags/${encodeURIComponent(name)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: value }),
+    });
+    if (res.ok) {
+      setFlags((f) => ({ ...f, [name]: value }));
+    }
+  }
+
+  return (
+    <ul aria-label="Feature flags">
+      {Object.entries(flags).map(([name, enabled]) => (
+        <li key={name}>
+          <label>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => toggle(name, e.target.checked)}
+            />
+            {name}
+          </label>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add functions for listing and toggling flags
- expose feature flag endpoints in API gateway
- create React components for flag toggles
- document managing flags via API
- tests for feature flag API and React components

## Testing
- `pre-commit run --files backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/models.py backend/api-gateway/src/api_gateway/routes.py backend/shared/feature_flags.py docs/feature-flags.md backend/api-gateway/tests/test_feature_flags.py frontend/admin-dashboard/__tests__/featureFlags.test.tsx frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagsList.tsx frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagToggle.tsx` *(fails: authentication to github.com)*
- `SKIP_HEAVY_DEPS=1 pytest backend/api-gateway/tests/test_feature_flags.py -q` *(fails: ModuleNotFoundError: 'RedisDsn' decode)*
- `npm test` *(fails: Cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_b_687e5479d4d88331a87a35113a83748a