### PR TITLE
Add S3 lifecycle helper

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -48,6 +48,7 @@ jobs:
           echo "BUCKET=$BUCKET" >> "$GITHUB_ENV"
           aws s3api create-bucket --bucket "$BUCKET"
           ./scripts/setup_storage.sh "$BUCKET"
+          python scripts/apply_s3_lifecycle.py "$BUCKET"
       - name: Run integration tests
         env:
           S3_BUCKET: ${{ env.BUCKET }}

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -12,6 +12,14 @@ with `pg_dump` and the AWS CLI installed.
 The script dumps the PostgreSQL database to a temporary file and uploads it to
 the S3 bucket specified by `BACKUP_BUCKET`.
 
+Use `scripts/apply_s3_lifecycle.py` to configure the bucket with a lifecycle
+policy that transitions objects to Glacier after 365 days. Run the script once
+after bucket creation:
+
+```bash
+python scripts/apply_s3_lifecycle.py <bucket>
+```
+
 ## Restoring from Backup
 
 1. Download the desired SQL dump from your backup bucket:

--- a/scripts/apply_s3_lifecycle.py
+++ b/scripts/apply_s3_lifecycle.py
@@ -1,0 +1,44 @@
+"""Configure S3 lifecycle rules using boto3."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any, Dict
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+def apply_policy(bucket: str) -> None:
+    """Apply Glacier transition after 365 days to ``bucket``."""
+    s3 = boto3.client("s3")
+    lifecycle: Dict[str, Any] = {
+        "Rules": [
+            {
+                "ID": "ArchiveAfter12Months",
+                "Filter": {"Prefix": ""},
+                "Status": "Enabled",
+                "Transitions": [{"Days": 365, "StorageClass": "GLACIER"}],
+            }
+        ]
+    }
+    s3.put_bucket_lifecycle_configuration(
+        Bucket=bucket, LifecycleConfiguration=lifecycle
+    )
+    logger.info("Applied lifecycle policy to %s", bucket)
+
+
+def main(argv: list[str]) -> int:
+    """CLI entrypoint."""
+    if len(argv) != 1:
+        print("Usage: apply_s3_lifecycle.py <bucket>", file=sys.stderr)
+        return 1
+    apply_policy(argv[0])
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/setup_storage.sh
+++ b/scripts/setup_storage.sh
@@ -2,6 +2,7 @@
 
 # Setup S3 or MinIO buckets and lifecycle policies based on the blueprint.
 # Usage: ./setup_storage.sh <bucket-name> [--minio]
+# Calls ``apply_s3_lifecycle.py`` to configure Glacier transitions on AWS.
 
 set -euo pipefail
 
@@ -50,7 +51,7 @@ create_bucket() {
     if ! aws s3api head-bucket --bucket "$BUCKET" >/dev/null 2>&1; then
       aws s3api create-bucket --bucket "$BUCKET"
     fi
-    aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" --lifecycle-configuration '{"Rules":[{"ID":"ArchiveAfter12Months","Prefix":"","Status":"Enabled","Transitions":[{"Days":365,"StorageClass":"GLACIER"}]}]}'
+    python "$(dirname "$0")/apply_s3_lifecycle.py" "$BUCKET"
   fi
 }
 

--- a/tests/test_s3_lifecycle.py
+++ b/tests/test_s3_lifecycle.py
@@ -1,0 +1,24 @@
+"""Tests for the S3 lifecycle helper."""
+
+from __future__ import annotations
+
+import boto3
+from moto import mock_aws
+
+from scripts.apply_s3_lifecycle import apply_policy
+
+
+@mock_aws
+def test_apply_policy() -> None:
+    """Lifecycle rule moves objects to Glacier after 365 days."""
+    s3 = boto3.client("s3", region_name="us-east-1")
+    bucket = "test-bucket"
+    s3.create_bucket(Bucket=bucket)
+
+    apply_policy(bucket)
+
+    config = s3.get_bucket_lifecycle_configuration(Bucket=bucket)
+    rule = config["Rules"][0]
+    transition = rule["Transitions"][0]
+    assert transition["Days"] == 365
+    assert transition["StorageClass"] == "GLACIER"


### PR DESCRIPTION
## Summary
- create `apply_s3_lifecycle.py` for setting Glacier transition
- reference helper in backup docs and storage setup script
- invoke script when provisioning CI buckets
- test policy with moto

## Testing
- `flake8 scripts/apply_s3_lifecycle.py tests/test_s3_lifecycle.py`
- `mypy scripts/apply_s3_lifecycle.py tests/test_s3_lifecycle.py --ignore-missing-imports` *(fails: found errors in unrelated modules)*
- `pytest tests/test_s3_lifecycle.py -W error` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687e606f3f448331b641abcdd5b44dc8