### PR TITLE
Add HTTP retry helper

### DIFF
--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Iterable, Mapping
 
 import requests
+from backend.shared.http import request_with_retry
 import asyncio
 from apscheduler.job import Job
 from apscheduler.schedulers.base import BaseScheduler
@@ -40,8 +41,9 @@ def fetch_marketplace_metrics(
     results: list[dict[str, float]] = []
     for listing_id in listing_ids:
         try:
-            resp = requests.get(f"{api_url}/listings/{listing_id}/metrics", timeout=5)
-            resp.raise_for_status()
+            resp = request_with_retry(
+                "GET", f"{api_url}/listings/{listing_id}/metrics", timeout=5
+            )
             data = resp.json()
             results.append(
                 {

--- a/backend/feedback-loop/feedback_loop/weight_updater.py
+++ b/backend/feedback-loop/feedback_loop/weight_updater.py
@@ -8,6 +8,7 @@ from typing import Iterable, Mapping
 import pandas as pd
 
 import requests
+from backend.shared.http import request_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +55,9 @@ def update_weights(
     }
 
     try:
-        response = requests.post(f"{api_url}/weights/feedback", json=weights, timeout=5)
-        response.raise_for_status()
+        request_with_retry(
+            "POST", f"{api_url}/weights/feedback", json=weights, timeout=5
+        )
     except requests.RequestException as exc:
         logger.exception("failed to update weights: %s", exc)
         raise

--- a/backend/feedback-loop/tests/test_weight_updater.py
+++ b/backend/feedback-loop/tests/test_weight_updater.py
@@ -42,3 +42,15 @@ def test_update_weights_error(requests_mock: Any) -> None:
     requests_mock.post(f"{url}/weights/feedback", status_code=500)
     with pytest.raises(RequestException):
         update_weights(url, [{"ctr": 0.1, "conversion_rate": 0.2}])
+
+
+def test_update_weights_retries(requests_mock: Any) -> None:
+    """The function should retry on temporary errors."""
+    url = "http://example.com"
+    requests_mock.post(
+        f"{url}/weights/feedback",
+        [{"status_code": 500}, {"json": {}}],
+    )
+    metrics = [{"ctr": 0.1, "conversion_rate": 0.2}]
+    update_weights(url, metrics)
+    assert requests_mock.call_count == 2

--- a/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .db import create_webhook_event
 
 import requests
+from backend.shared.http import request_with_retry
 
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,9 @@ async def _dispatch_notifications(task_id: int, marketplace: str) -> None:
         if not webhook:
             return
         try:
-            await asyncio.to_thread(requests.post, webhook, json=payload, timeout=2)
+            await asyncio.to_thread(
+                request_with_retry, "POST", webhook, json=payload, timeout=2
+            )
         except requests.RequestException as exc:  # pragma: no cover - best effort
             logger.warning("notification failed: %s", exc)
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/trademark.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/trademark.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, cast
 
 import requests
+from backend.shared.http import request_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +17,9 @@ EUIPO_ENDPOINT = "https://api.tmdn.org/tmview/v1/trademarks"
 def _query_api(url: str, term: str) -> bool:
     """Return ``True`` if ``term`` matches a trademark at ``url``."""
     try:
-        response = requests.get(url, params={"searchText": term}, timeout=10)
-        response.raise_for_status()
+        response = request_with_retry(
+            "GET", url, params={"searchText": term}, timeout=10
+        )
         data = cast(dict[str, Any], response.json())
     except requests.RequestException as exc:  # pragma: no cover - network errors
         logger.warning("trademark lookup failed: %s", exc)

--- a/backend/monitoring/src/monitoring/metrics_store.py
+++ b/backend/monitoring/src/monitoring/metrics_store.py
@@ -11,6 +11,7 @@ from typing import Iterator, MutableMapping, cast
 from backend.shared.cache import sync_delete
 
 import requests
+from backend.shared.http import request_with_retry
 
 import sqlite3
 import psycopg2
@@ -102,7 +103,9 @@ class TimescaleMetricsStore:
             ]
         }
         try:
-            requests.post(f"{self.loki_url}/loki/api/v1/push", json=payload, timeout=2)
+            request_with_retry(
+                "POST", f"{self.loki_url}/loki/api/v1/push", json=payload, timeout=2
+            )
         except requests.RequestException:
             pass
 

--- a/backend/monitoring/src/monitoring/pagerduty.py
+++ b/backend/monitoring/src/monitoring/pagerduty.py
@@ -8,6 +8,7 @@ from typing import Any
 from .settings import settings
 
 import requests
+from backend.shared.http import request_with_retry
 
 PAGERDUTY_URL = "https://events.pagerduty.com/v2/enqueue"
 
@@ -29,7 +30,7 @@ def trigger_sla_violation(duration_hours: float) -> None:
         },
     }
     try:
-        requests.post(PAGERDUTY_URL, json=payload, timeout=5)
+        request_with_retry("POST", PAGERDUTY_URL, json=payload, timeout=5)
     except requests.RequestException:
         pass
 
@@ -51,6 +52,6 @@ def notify_listing_issue(listing_id: int, state: str) -> None:
         },
     }
     try:
-        requests.post(PAGERDUTY_URL, json=payload, timeout=5)
+        request_with_retry("POST", PAGERDUTY_URL, json=payload, timeout=5)
     except requests.RequestException:
         pass

--- a/backend/shared/http.py
+++ b/backend/shared/http.py
@@ -1,0 +1,42 @@
+"""HTTP request helpers with retry support."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+DEFAULT_RETRIES = int(os.getenv("HTTP_RETRIES", "3"))
+
+__all__ = ["request_with_retry"]
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    retries: int | None = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """Return the response from ``requests`` with exponential backoff."""
+    attempts = retries or DEFAULT_RETRIES
+
+    @retry(
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        stop=stop_after_attempt(attempts),
+        retry=retry_if_exception_type(requests.RequestException),
+        reraise=True,
+    )
+    def _send() -> requests.Response:
+        resp = requests.request(method, url, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    return _send()

--- a/backend/shared/tests/test_http.py
+++ b/backend/shared/tests/test_http.py
@@ -1,0 +1,27 @@
+"""Tests for HTTP retry helpers."""
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+from backend.shared.http import request_with_retry
+
+
+def test_request_with_retry_success(requests_mock):
+    requests_mock.get(
+        "http://example.com",
+        [
+            {"status_code": 500},
+            {"text": "ok"},
+        ],
+    )
+    resp = request_with_retry("GET", "http://example.com", retries=2)
+    assert resp.text == "ok"
+    assert requests_mock.call_count == 2
+
+
+def test_request_with_retry_failure(requests_mock):
+    requests_mock.get("http://example.com", exc=requests.ConnectionError)
+    with pytest.raises(requests.ConnectionError):
+        request_with_retry("GET", "http://example.com", retries=2)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,3 +40,4 @@ application settings classes.
 | `DEDUP_TTL` | Time-to-live in seconds for deduplication keys |
 | `PUBLISHER_METRICS_INTERVAL_MINUTES` | Interval for fetching publisher metrics |
 | `WEIGHT_UPDATE_INTERVAL_MINUTES` | Interval for updating scoring weights |
+| `HTTP_RETRIES` | Number of retry attempts for outgoing HTTP calls |


### PR DESCRIPTION
## Summary
- create request helper with retries
- use helper across backend modules
- document HTTP_RETRIES env variable
- test HTTP retry logic

## Testing
- `flake8 backend/shared/http.py backend/feedback-loop/feedback_loop/ingestion.py backend/feedback-loop/feedback_loop/weight_updater.py backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/trademark.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/monitoring/src/monitoring/metrics_store.py backend/monitoring/src/monitoring/pagerduty.py backend/feedback-loop/tests/test_weight_updater.py backend/shared/tests/test_http.py backend/marketplace-publisher/tests/test_clients.py`
- `pydocstyle backend/shared/http.py backend/feedback-loop/feedback_loop/ingestion.py backend/feedback-loop/feedback_loop/weight_updater.py backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/src/marketplace_publisher/trademark.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/monitoring/src/monitoring/metrics_store.py backend/monitoring/src/monitoring/pagerduty.py backend/feedback-loop/tests/test_weight_updater.py backend/shared/tests/test_http.py backend/marketplace-publisher/tests/test_clients.py`
- `mypy --ignore-missing-imports backend/shared/http.py`
- `pytest backend/feedback-loop/tests/test_weight_updater.py backend/shared/tests/test_http.py backend/marketplace-publisher/tests/test_clients.py -W error -vv` *(fails: ModuleNotFoundError: No module named 'tests.test_clients')*

------
https://chatgpt.com/codex/tasks/task_b_687e6840fd808331898904db55fcaf62