### PR TITLE
Add weekly privacy purge

### DIFF
--- a/backend/orchestrator/orchestrator/__init__.py
+++ b/backend/orchestrator/orchestrator/__init__.py
@@ -1,10 +1,17 @@
 """Orchestration pipelines using Dagster."""
 
-from .jobs import cleanup_job, idea_job, backup_job, daily_summary_job
+from .jobs import (
+    cleanup_job,
+    idea_job,
+    backup_job,
+    daily_summary_job,
+    privacy_purge_job,
+)
 from .schedules import (
     daily_backup_schedule,
     hourly_cleanup_schedule,
     daily_summary_schedule,
+    weekly_privacy_purge_schedule,
 )
 from .sensors import idea_sensor, run_failure_notifier
 
@@ -13,9 +20,11 @@ __all__ = [
     "backup_job",
     "cleanup_job",
     "daily_summary_job",
+    "privacy_purge_job",
     "daily_backup_schedule",
     "hourly_cleanup_schedule",
     "daily_summary_schedule",
+    "weekly_privacy_purge_schedule",
     "idea_sensor",
     "run_failure_notifier",
 ]

--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -18,6 +18,7 @@ from .ops import (
     publish_content,
     score_signals,
     sync_listing_states_op,
+    purge_pii_rows_op,
 )
 from .hooks import record_failure, record_success
 
@@ -66,3 +67,9 @@ def rotate_secrets_job() -> None:
 def sync_listings_job() -> None:
     """Job synchronizing marketplace listing states."""
     sync_listing_states_op()
+
+
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+def privacy_purge_job() -> None:
+    """Job removing PII from stored signals."""
+    purge_pii_rows_op()

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -54,6 +54,7 @@ def _post_with_retry(
                 retries,
             )
             time.sleep(2 ** (attempt - 1))
+    raise RuntimeError("unreachable")
 
 
 @op  # type: ignore[misc]
@@ -261,3 +262,14 @@ def sync_listing_states_op(context) -> None:  # type: ignore[no-untyped-def]
     from scripts import listing_sync
 
     listing_sync.main()
+
+
+@op  # type: ignore[misc]
+def purge_pii_rows_op(context) -> None:  # type: ignore[no-untyped-def]
+    """Run :func:`signal_ingestion.privacy.purge_pii_rows`."""
+    context.log.info("purging stored PII")
+    import asyncio
+    from signal_ingestion.privacy import purge_pii_rows
+
+    count = asyncio.run(purge_pii_rows())
+    context.log.info("purged %d rows", count)

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -1,4 +1,5 @@
 """Dagster definitions for the orchestrator."""
+
 from dagster import Definitions
 
 from .jobs import (
@@ -9,6 +10,7 @@ from .jobs import (
     rotate_secrets_job,
     daily_summary_job,
     sync_listings_job,
+    privacy_purge_job,
 )
 from .schedules import (
     daily_backup_schedule,
@@ -17,6 +19,7 @@ from .schedules import (
     daily_summary_schedule,
     monthly_secret_rotation_schedule,
     daily_listing_sync_schedule,
+    weekly_privacy_purge_schedule,
 )
 from .sensors import idea_sensor, run_failure_notifier
 
@@ -30,6 +33,7 @@ defs = Definitions(
         daily_summary_job,
         rotate_secrets_job,
         sync_listings_job,
+        privacy_purge_job,
     ],
     schedules=[
         daily_backup_schedule,
@@ -38,6 +42,7 @@ defs = Definitions(
         daily_summary_schedule,
         monthly_secret_rotation_schedule,
         daily_listing_sync_schedule,
+        weekly_privacy_purge_schedule,
     ],
     sensors=[idea_sensor, run_failure_notifier],
 )

--- a/backend/orchestrator/orchestrator/schedules.py
+++ b/backend/orchestrator/orchestrator/schedules.py
@@ -9,6 +9,7 @@ from .jobs import (
     daily_summary_job,
     rotate_secrets_job,
     sync_listings_job,
+    privacy_purge_job,
 )
 
 
@@ -51,4 +52,12 @@ def daily_listing_sync_schedule(
     _context: ScheduleEvaluationContext,
 ) -> dict[str, object]:
     """Trigger ``sync_listings_job`` every day."""
+    return {}
+
+
+@schedule(cron_schedule="0 0 * * 0", job=privacy_purge_job, execution_timezone="UTC")
+def weekly_privacy_purge_schedule(
+    _context: ScheduleEvaluationContext,
+) -> dict[str, object]:
+    """Run ``privacy_purge_job`` once a week."""
     return {}

--- a/backend/orchestrator/tests/test_privacy_job.py
+++ b/backend/orchestrator/tests/test_privacy_job.py
@@ -1,0 +1,56 @@
+"""Tests for the privacy purge job."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from dagster import DagsterInstance
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+ROOT = Path(__file__).resolve().parents[3]
+ORCHESTRATOR_PATH = ROOT / "backend" / "orchestrator"
+sys.path.append(str(ORCHESTRATOR_PATH))  # noqa: E402
+MONITORING_SRC = ROOT / "backend" / "monitoring" / "src"
+sys.path.append(str(MONITORING_SRC))  # noqa: E402
+SIGNAL_SRC = ROOT / "backend" / "signal-ingestion" / "src"
+sys.path.append(str(SIGNAL_SRC))  # noqa: E402
+
+from orchestrator.jobs import privacy_purge_job  # noqa: E402
+from signal_ingestion import database  # noqa: E402
+from signal_ingestion.models import Signal  # noqa: E402
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_privacy_purge_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the job removes PII from stored signals."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    database.engine = engine
+    database.SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    await database.init_db()
+
+    async with database.SessionLocal() as session:
+        session.add(
+            Signal(
+                source="t",
+                content="Contact me at user@example.com",
+                embedding=[0.0],
+            )
+        )
+        await session.commit()
+
+    monkeypatch.setattr(
+        "signal_ingestion.privacy.SessionLocal",
+        database.SessionLocal,
+        raising=False,
+    )
+
+    instance = DagsterInstance.ephemeral()
+    result = privacy_purge_job.execute_in_process(instance=instance)
+    assert result.success
+
+    async with database.SessionLocal() as session:
+        row = (await session.execute(select(Signal))).scalars().first()
+        assert "[REDACTED]" in row.content

--- a/backend/signal-ingestion/src/signal_ingestion/privacy.py
+++ b/backend/signal-ingestion/src/signal_ingestion/privacy.py
@@ -63,3 +63,27 @@ def purge_row(row: dict[str, Any]) -> dict[str, Any]:
         A new dictionary with all string values sanitized.
     """
     return {k: purge_text(v) if isinstance(v, str) else v for k, v in row.items()}
+
+
+async def purge_pii_rows(limit: int | None = None) -> int:
+    """
+    Remove PII from stored signals.
+
+    The function opens a database session using :mod:`signal_ingestion.database`
+    and applies :func:`purge_pii` from :mod:`signal_ingestion.purge_pii`.
+
+    Parameters
+    ----------
+    limit:
+        Optional maximum number of rows to process.
+
+    Returns
+    -------
+    int
+        The number of rows that were sanitized.
+    """
+    from . import database
+    from .purge_pii import purge_pii
+
+    async with database.SessionLocal() as session:
+        return await purge_pii(session, limit)  # type: ignore[no-any-return]

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,6 +5,8 @@ This project stores user generated signals and analytics metrics. To comply with
 ## PII Purging
 
 Incoming signal data is sanitized by `signal_ingestion.privacy.purge_row`, which strips email addresses and phone numbers before a signal is persisted.
+Stored records can be cleaned retroactively via `signal_ingestion.privacy.purge_pii_rows`.
+The Dagster `privacy_purge_job` runs this routine once per week.
 
 ## Data Retention
 


### PR DESCRIPTION
## Summary
- create Dagster op that runs privacy purge
- define `privacy_purge_job` and schedule weekly execution
- expose job and schedule from orchestrator
- test that purging removes PII from stored signals
- document periodic privacy purge

## Testing
- `mypy backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/schedules.py backend/orchestrator/orchestrator/repository.py backend/orchestrator/orchestrator/__init__.py backend/orchestrator/tests/test_privacy_job.py backend/signal-ingestion/src/signal_ingestion/privacy.py --explicit-package-bases --ignore-missing-imports --follow-imports skip --allow-untyped-decorators --no-warn-unused-ignores`
- `pytest -W error -vv backend/orchestrator/tests/test_privacy_job.py` *(fails: Expected string or URL object)*

------
https://chatgpt.com/codex/tasks/task_b_687e6bd8d4bc83318c7a196de3c3494d