### PR TITLE
Add Loki URL configuration

### DIFF
--- a/backend/api-gateway/tests/test_feature_flags.py
+++ b/backend/api-gateway/tests/test_feature_flags.py
@@ -38,4 +38,3 @@ def test_toggle_flag() -> None:
     resp = client.get("/feature-flags", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
     assert resp.json().get("demo") is True
-

--- a/backend/monitoring/src/monitoring/metrics_store.py
+++ b/backend/monitoring/src/monitoring/metrics_store.py
@@ -90,7 +90,8 @@ class TimescaleMetricsStore:
         self, message: str, labels: MutableMapping[str, str] | None = None
     ) -> None:
         """Send a log line to Loki if configured."""
-        if not self.loki_url:
+        loki_url = self.loki_url or os.environ.get("LOKI_URL")
+        if not loki_url:
             return
         payload = {
             "streams": [
@@ -104,7 +105,10 @@ class TimescaleMetricsStore:
         }
         try:
             request_with_retry(
-                "POST", f"{self.loki_url}/loki/api/v1/push", json=payload, timeout=2
+                "POST",
+                f"{loki_url}/loki/api/v1/push",
+                json=payload,
+                timeout=2,
             )
         except requests.RequestException:
             pass

--- a/docs/logs_with_loki.md
+++ b/docs/logs_with_loki.md
@@ -5,6 +5,10 @@ messages to a Loki instance. Set the ``LOKI_URL`` environment variable to the
 Loki HTTP endpoint (e.g. ``http://loki:3100``) and each service will push JSON
 logs containing ``correlation_id`` and ``user`` fields. Docker Compose and the
 Kubernetes base manifests include a Loki service listening on port ``3100``.
+The Helm chart for the monitoring service exposes a ``loki_url`` value which is
+templated into the ``LOKI_URL`` environment variable of the container. Update
+``values.yaml`` or the ``all-services`` chart to point at your own Loki instance
+if needed.
 
 An ``otel-collector`` container is available in all Docker Compose
 configurations. Services send traces to this collector by setting the
@@ -12,3 +16,16 @@ configurations. Services send traces to this collector by setting the
 ``http://otel-collector:4318``. The communication protocol can be adjusted with
 ``OTEL_EXPORTER_OTLP_PROTOCOL`` which defaults to ``http/protobuf``. Both HTTP
 ``4318`` and gRPC ``4317`` ports are exposed by the collector.
+
+## Local Testing
+
+Run a disposable Loki container and push a test log entry:
+
+```bash
+docker run -d --name loki -p 3100:3100 grafana/loki:2.8.2
+curl -X POST "http://localhost:3100/loki/api/v1/push" \
+  -H 'Content-Type: application/json' \
+  -d '{"streams": [{"stream": {"app": "test"}, "values": [["'$(date +%s%N)'", "hello"]]}]}'
+```
+
+The message should appear in Loki or Grafana if configured.

--- a/infrastructure/helm/all-services/Chart.yaml
+++ b/infrastructure/helm/all-services/Chart.yaml
@@ -32,3 +32,6 @@ dependencies:
   - name: logrotate-jobs
     version: 0.1.0
     repository: "file://../logrotate-jobs"
+  - name: monitoring
+    version: 0.1.0
+    repository: "file://../monitoring"

--- a/infrastructure/helm/all-services/values.yaml
+++ b/infrastructure/helm/all-services/values.yaml
@@ -140,3 +140,22 @@ logrotate-jobs:
     pullPolicy: IfNotPresent
   schedule: "0 1 * * *"
   logDir: /var/log
+
+monitoring:
+  replicaCount: 1
+  image:
+    repository: example/monitoring
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+  resources: {}
+  env:
+    LOKI_URL: http://loki:3100
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70

--- a/infrastructure/helm/monitoring/Chart.yaml
+++ b/infrastructure/helm/monitoring/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: monitoring
+version: 0.1.0
+description: Helm chart for monitoring microservice
+type: application
+appVersion: "1.0"

--- a/infrastructure/helm/monitoring/templates/_helpers.tpl
+++ b/infrastructure/helm/monitoring/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "monitoring.fullname" -}}
+{{ include "monitoring.name" . }}
+{{- end -}}
+
+{{- define "monitoring.name" -}}
+{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "monitoring.labels" -}}
+app.kubernetes.io/name: {{ include "monitoring.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "monitoring.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "monitoring.name" . }}
+{{- end -}}

--- a/infrastructure/helm/monitoring/templates/deployment.yaml
+++ b/infrastructure/helm/monitoring/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "monitoring.fullname" . }}
+  labels: {{- include "monitoring.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "monitoring.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "monitoring.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.service.port }}
+          env:
+            - name: LOKI_URL
+              value: {{ .Values.loki_url | quote }}
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}

--- a/infrastructure/helm/monitoring/templates/hpa.yaml
+++ b/infrastructure/helm/monitoring/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "monitoring.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "monitoring.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/monitoring/templates/service.yaml
+++ b/infrastructure/helm/monitoring/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "monitoring.fullname" . }}
+  labels: {{- include "monitoring.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{- include "monitoring.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/infrastructure/helm/monitoring/values.yaml
+++ b/infrastructure/helm/monitoring/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+image:
+  repository: example/monitoring
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}
+
+loki_url: http://loki:3100
+
+# Environment variables
+env:
+  {}
+
+# Horizontal pod autoscaler
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,35 +2,35 @@ flake8
 black
 mypy
 pydocstyle
-flake8 - docstrings
+flake8-docstrings
 docformatter
 watchdog
 vcrpy
 pytest
-pytest - cov
+pytest-cov
 fakeredis
 tenacity
 responses
 Pillow
 redis
 asyncpg
-scikit - learn
-pytest - asyncio
+scikit-learn
+pytest-asyncio
 aiosqlite
 locust
 pynvml
 
 UnleashClient
-launchdarkly - server - sdk
+launchdarkly-server-sdk
 
-pip - audit
-sphinxcontrib - openapi
-myst - parser
-sentry - sdk
+pip-audit
+sphinxcontrib-openapi
+myst-parser
+sentry-sdk
 Deprecated
 testing.postgresql
-sphinxcontrib - mermaid
-openapi - schema - validator
-opentelemetry - exporter - otlp
-python - jose[cryptography]
+sphinxcontrib-mermaid
+openapi-schema-validator
+opentelemetry-exporter-otlp
+python-jose[cryptography]
 pytest-recording


### PR DESCRIPTION
## Summary
- add new monitoring helm chart with `loki_url` value
- expose monitoring chart in `all-services`
- update metrics store to pull LOKI_URL from environment at send time
- document how to test logs with a local Loki container
- fix requirements-dev formatting
- remove trailing newline from a test file

## Testing
- `flake8 .`
- `pydocstyle backend/ docs/`
- `docformatter --check --recursive backend/ docs/ infrastructure/helm/monitoring/`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: Found 223 errors)*
- `npm run lint` *(fails: 3 errors)*
- `npm run lint:css`
- `npm run flow`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_687e737e31708331b2938a9e5ff30993