### PR TITLE
chore: enforce numpy docstrings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Black
         run: black --check .
       - name: Run Flake8
-        run: flake8 .
+        run: flake8 . --docstring-convention=numpy
       - name: Check docstrings
         run: pydocstyle backend
       - name: Run MyPy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ To get started:
 Black and Prettier run in formatting mode, so staged files will be automatically
 updated.
 
-The hooks enforce Black, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Warnings are treated as errors, so commits will fail until issues are fixed.
+The hooks enforce Black, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Docstrings should follow the Numpy style and are checked with flake8-docstrings. Warnings are treated as errors, so commits will fail until issues are fixed.
 
 ## CI Lint Commands
 
@@ -23,7 +23,7 @@ The continuous integration workflow runs the following commands and fails on any
 
 ```bash
 black --check .
-flake8 .
+flake8 . --docstring-convention=numpy
 mypy backend --explicit-package-bases --exclude "tests"
 npm run lint
 npm run flow

--- a/backend/api-gateway/tests/test_feature_flags.py
+++ b/backend/api-gateway/tests/test_feature_flags.py
@@ -1,3 +1,5 @@
+"""Tests for feature flag routes."""
+
 import sys
 import os
 from pathlib import Path
@@ -13,13 +15,17 @@ from backend.shared import feature_flags  # noqa: E402
 
 
 def setup_module(module: object) -> None:
+    """Initialize the application client for tests."""
+
     os.environ["REDIS_URL"] = "redis://localhost:6379/0"
     feature_flags.redis.Redis = lambda *a, **k: fakeredis.aioredis.FakeRedis(
         decode_responses=True
     )
     import api_gateway.routes as routes
+
     routes.get_async_client = lambda: fakeredis.aioredis.FakeRedis()
     import api_gateway.main as main_module
+
     importlib.reload(main_module)
     importlib.reload(feature_flags)
     feature_flags.initialize()
@@ -28,6 +34,8 @@ def setup_module(module: object) -> None:
 
 
 def test_toggle_flag() -> None:
+    """Toggle a feature flag and verify its value."""
+
     token = create_access_token({"sub": "admin"})
     resp = client.post(
         "/feature-flags/demo",

--- a/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
@@ -21,28 +21,34 @@ class MarketplaceRateLimiter:
         window: int,
         redis: AsyncRedis | None = None,
     ) -> None:
-        """
-        Instantiate the rate limiter.
+        """Instantiate the rate limiter.
 
-        Args:
-            redis: Redis client instance. If ``None``, a default client is used.
-            limits: Allowed requests per window for each marketplace.
-            window: Window size in seconds.
+        Parameters
+        ----------
+        limits : Mapping[Marketplace, int]
+            Allowed requests per window for each marketplace.
+        window : int
+            Window size in seconds.
+        redis : AsyncRedis | None, optional
+            Redis client instance. If ``None``, a default client is used.
         """
         self._redis = redis or get_async_client()
         self._limits = limits
         self._window = window
 
     async def acquire(self, marketplace: Marketplace) -> bool:
-        """
-        Attempt to consume a request slot.
+        """Attempt to consume a request slot.
 
-        Args:
-            marketplace: Marketplace for which to consume a slot.
+        Parameters
+        ----------
+        marketplace : Marketplace
+            Marketplace for which to consume a slot.
 
-        Returns:
-            ``True`` if a slot was consumed, ``False`` if the limit
-            has been exceeded.
+        Returns
+        -------
+        bool
+            ``True`` if a slot was consumed, ``False`` if the limit has been
+            exceeded.
         """
         limit = self._limits.get(marketplace)
         if limit is None:

--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -62,20 +62,25 @@ class MockupGenerator:
         num_inference_steps: int = 30,
         model_identifier: str | None = None,
     ) -> GenerationResult:
-        """
-        Generate an image.
+        """Generate an image.
 
-        If local generation fails, an external provider is used as a
-        fallback.
+        If local generation fails, an external provider is used as a fallback.
 
-        Args:
-            prompt: Text prompt describing the desired image.
-            output_path: Filesystem path to save the resulting image.
-            num_inference_steps: Number of inference steps for the model.
-            model_identifier: Optional model ID to load instead of the default.
+        Parameters
+        ----------
+        prompt : str
+            Text prompt describing the desired image.
+        output_path : str
+            Filesystem path to save the resulting image.
+        num_inference_steps : int, optional
+            Number of inference steps for the model.
+        model_identifier : str | None, optional
+            Model identifier to load instead of the default.
 
-        Returns:
-            GenerationResult containing the image path and duration.
+        Returns
+        -------
+        GenerationResult
+            Result containing the image path and duration.
         """
         from time import perf_counter
 
@@ -102,17 +107,22 @@ class MockupGenerator:
         return GenerationResult(image_path=output_path, duration=duration)
 
     def _fallback_api(self, prompt: str) -> Image.Image:
-        """
-        Fetch an image from a third-party provider.
+        """Fetch an image from a third-party provider.
 
-        Args:
-            prompt: Text prompt to send to the provider.
+        Parameters
+        ----------
+        prompt : str
+            Text prompt to send to the provider.
 
-        Returns:
-            PIL image from the external API.
+        Returns
+        -------
+        Image.Image
+            Image from the external API.
 
-        Raises:
-            GenerationError: If all retry attempts fail.
+        Raises
+        ------
+        GenerationError
+            If all retry attempts fail.
         """
         from io import BytesIO
         import base64

--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -141,19 +141,26 @@ def generate_mockup(
     model: str | None = None,
     gpu_index: int | None = None,
 ) -> list[dict[str, object]]:
-    """
-    Generate mockups sequentially on the GPU.
+    """Generate mockups sequentially on the GPU.
 
-    Args:
-        keywords_batch: A list of keyword groups used to build prompts.
-        output_dir: Directory where generated mockups will be written.
-        model: Optional model identifier to use for generation.
-        gpu_index: Preferred GPU slot index.
+    Parameters
+    ----------
+    self : Task
+        Celery task instance.
+    keywords_batch : list[list[str]]
+        List of keyword groups used to build prompts.
+    output_dir : str
+        Directory where generated mockups will be written.
+    model : str | None, optional
+        Model identifier to use for generation.
+    gpu_index : int | None, optional
+        Preferred GPU slot index.
 
-    Returns:
-        A list of dictionaries containing image paths and listing metadata. If
-        a prompt fails, the item will contain an ``error`` key with the
-        message.
+    Returns
+    -------
+    list[dict[str, object]]
+        Each item contains the image path and listing metadata. If a prompt
+        fails, the item will include an ``error`` key with the message.
     """
     start = perf_counter()
     try:

--- a/backend/mockup-generation/tests/test_celery_broker.py
+++ b/backend/mockup-generation/tests/test_celery_broker.py
@@ -1,3 +1,5 @@
+"""Tests for Celery broker integration."""
+
 from __future__ import annotations
 
 import importlib
@@ -28,7 +30,11 @@ def _port_open(host: str, port: int) -> bool:
         ("rabbitmq", "amqp://guest:guest@localhost:5672//", 5672),
     ],
 )  # type: ignore[misc]
-def test_worker_with_broker(monkeypatch: pytest.MonkeyPatch, broker: str, url: str, port: int) -> None:
+def test_worker_with_broker(
+    monkeypatch: pytest.MonkeyPatch, broker: str, url: str, port: int
+) -> None:
+    """Start a worker with the given broker and ensure tasks run."""
+
     if not _port_open("localhost", port):
         pytest.skip(f"{broker} not available")
 
@@ -37,6 +43,7 @@ def test_worker_with_broker(monkeypatch: pytest.MonkeyPatch, broker: str, url: s
     os.environ["CELERY_RESULT_BACKEND"] = url
 
     import mockup_generation.celery_app as celery_app
+
     importlib.reload(celery_app)
 
     app = celery_app.app

--- a/backend/mockup-generation/tests/test_gpu_metrics.py
+++ b/backend/mockup-generation/tests/test_gpu_metrics.py
@@ -1,3 +1,5 @@
+"""Tests for GPU metrics collection."""
+
 from __future__ import annotations
 
 import importlib

--- a/backend/shared/tests/test_http.py
+++ b/backend/shared/tests/test_http.py
@@ -9,6 +9,7 @@ from backend.shared.http import request_with_retry
 
 
 def test_request_with_retry_success(requests_mock):
+    """Request succeeds after a retry."""
     requests_mock.get(
         "http://example.com",
         [
@@ -22,6 +23,8 @@ def test_request_with_retry_success(requests_mock):
 
 
 def test_request_with_retry_failure(requests_mock):
+    """Retrying request fails and raises an exception."""
+
     requests_mock.get("http://example.com", exc=requests.ConnectionError)
     with pytest.raises(requests.ConnectionError):
         request_with_retry("GET", "http://example.com", retries=2)

--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -12,12 +12,14 @@ def run(command: list[str]) -> None:
 
 
 def dump_postgres(backup_dir: Path, bucket: str) -> None:
-    """
-    Dump Postgres database and upload to S3.
+    """Dump the Postgres database and upload it to S3.
 
-    Args:
-        backup_dir: Directory to store the dump.
-        bucket: Name of the S3 bucket.
+    Parameters
+    ----------
+    backup_dir : Path
+        Directory to store the dump.
+    bucket : str
+        Name of the S3 bucket.
     """
     timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     dump_file = backup_dir / f"postgres_{timestamp}.sql"

--- a/tests/contracts/test_kafka_schemas.py
+++ b/tests/contracts/test_kafka_schemas.py
@@ -1,3 +1,5 @@
+"""Integration tests for Kafka schema helpers."""
+
 import importlib
 import sys
 from pathlib import Path
@@ -38,6 +40,8 @@ class DummyKafkaProducer:
 
 
 def dummy_consumer_factory(messages: list[tuple[str, Dict[str, Any]]]) -> type[object]:
+    """Create a dummy Kafka consumer that yields provided messages."""
+
     class DummyMessage:
         def __init__(self, topic: str, value: Dict[str, Any]) -> None:
             self.topic = topic

--- a/tests/test_trending_route.py
+++ b/tests/test_trending_route.py
@@ -1,3 +1,5 @@
+"""Tests for the trending route proxy."""
+
 from __future__ import annotations
 
 import importlib
@@ -15,6 +17,7 @@ sys.path.append(
 
 
 def test_trending_proxy(monkeypatch: Any) -> None:
+    """Proxy trending requests to the ingestion service."""
     monkeypatch.setenv("SIGNAL_INGESTION_URL", "http://ingest:1234")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
     import backend.shared.config as shared_config


### PR DESCRIPTION
## Summary
- enforce numpy-style docstrings across the repo
- run flake8 with numpy convention
- document numpy docstring style in CONTRIBUTING

## Testing
- `flake8 . --docstring-convention=numpy`
- `pydocstyle backend/api-gateway/tests/test_feature_flags.py backend/mockup-generation/tests/test_celery_broker.py backend/mockup-generation/tests/test_gpu_metrics.py backend/shared/tests/test_http.py backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py scripts/backup.py tests/contracts/test_kafka_schemas.py tests/test_trending_route.py`
- `black --check backend/api-gateway/tests/test_feature_flags.py backend/mockup-generation/tests/test_celery_broker.py backend/mockup-generation/tests/test_gpu_metrics.py backend/shared/tests/test_http.py backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py scripts/backup.py tests/contracts/test_kafka_schemas.py tests/test_trending_route.py`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: unused type ignores and missing stubs)*
- `pytest -q` *(fails: 69 errors during collection)*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run flow` *(fails: flow: not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e7a0e908483318fa0f4b4d8b8a530