### PR TITLE
Add k6 load testing integration

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -53,6 +53,17 @@ jobs:
         env:
           S3_BUCKET: ${{ env.BUCKET }}
         run: ./scripts/run-integration-tests.sh
+      - name: Run load tests
+        env:
+          S3_BUCKET: ${{ env.BUCKET }}
+          K6_RESULTS: k6_results.json
+        run: ./scripts/run_load_tests.sh
+      - name: Upload k6 results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-results
+          path: k6_results.json
       - name: Teardown resources
         if: always()
         run: |

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -1,6 +1,8 @@
 # Load Testing
 
 The repository provides load tests for each API endpoint using [Locust](https://locust.io/).
+An additional [k6](https://k6.io/) script exercises the API gateway endpoints to
+measure throughput under stress.
 
 ## Baseline Scenarios
 
@@ -27,11 +29,14 @@ performance characteristics.
    ./scripts/run_load_tests.sh
    ```
    Adjust `USERS`, `SPAWN_RATE` and `RUN_TIME` environment variables to change the
-   intensity.
+   intensity. The script also runs the k6 scenario against the API gateway and
+   writes a summary to `k6_results.json` when `K6_RESULTS` is set.
 
 ## Continuous Integration
 
 The `loadtest` workflow provisions a temporary staging namespace on each pull
 request and push to `main`. Services are deployed to that namespace and an
 ephemeral S3 bucket is created. The integration suite runs against these AWS
-resources and all assets are removed once the run completes.
+resources. After running both Locust and k6, the workflow uploads the `k6_results.json`
+artifact so results can be inspected. All assets are removed once the run
+completes.

--- a/load_tests/k6_api_gateway.js
+++ b/load_tests/k6_api_gateway.js
@@ -1,0 +1,27 @@
+// @flow
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: __ENV.USERS ? parseInt(__ENV.USERS, 10) : 10,
+  duration: __ENV.RUN_TIME || '1m',
+};
+
+const host = __ENV.GATEWAY_HOST || 'http://localhost:8080';
+
+export default function () {
+  const statusRes = http.get(`${host}/status`);
+  check(statusRes, { 'status is 200': (r) => r.status === 200 });
+
+  const optRes = http.get(`${host}/optimizations`);
+  check(optRes, { 'optimizations 200': (r) => r.status === 200 });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  if (__ENV.RESULTS_PATH) {
+    return { [__ENV.RESULTS_PATH]: JSON.stringify(data, null, 2) };
+  }
+  return {};
+}

--- a/scripts/run_load_tests.sh
+++ b/scripts/run_load_tests.sh
@@ -9,4 +9,9 @@ locust -f load_tests/locustfile.py \
   -r "${SPAWN_RATE:-5}" \
   --run-time "${RUN_TIME:-1m}"
 
+# Run the k6 script against the API gateway
+k6 run \
+  --env RESULTS_PATH="${K6_RESULTS:-load_tests/k6_results.json}" \
+  load_tests/k6_api_gateway.js
+
 pytest -W error backend/mockup-generation/tests/test_performance.py::test_concurrent_generation_gpu_utilization "$@"


### PR DESCRIPTION
## Summary
- add k6 load test script
- run k6 from the load test script
- upload k6 results in loadtest workflow
- document k6 usage

## Testing
- `npx prettier --check load_tests/k6_api_gateway.js docs/load_testing.md`
- `pytest -W error` *(fails: connection refused errors)*

------
https://chatgpt.com/codex/tasks/task_b_687e7e63af68833197da06f34033c75d