### PR TITLE
Add ETag caching for signal ingestion

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/adapters/events.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/events.py
@@ -22,13 +22,13 @@ class EventsAdapter(BaseAdapter):
     ) -> None:
         """Initialize adapter with optional ``base_url``."""
         self.country_code = country_code or os.environ.get("EVENTS_COUNTRY_CODE", "US")
-        self.fetch_limit = fetch_limit or int(
-            os.environ.get("EVENTS_FETCH_LIMIT", "1")
-        )
+        self.fetch_limit = fetch_limit or int(os.environ.get("EVENTS_FETCH_LIMIT", "1"))
         super().__init__(base_url or "https://date.nager.at", proxies, rate_limit)
 
     async def fetch(self) -> list[dict[str, Any]]:
         """Return upcoming public holidays."""
         resp = await self._request(f"/api/v3/NextPublicHolidays/{self.country_code}")
+        if resp is None:
+            return []
         data = resp.json()[: self.fetch_limit]
         return data

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/instagram.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/instagram.py
@@ -38,11 +38,15 @@ class InstagramAdapter(BaseAdapter):
             f"&limit={self.fetch_limit}&access_token={self.token}"
         )
         resp = await self._request(path)
+        if resp is None:
+            return []
         data = resp.json()
         posts = data.get("data", [])
         next_url = data.get("paging", {}).get("next")
         while next_url and len(posts) < self.fetch_limit:
             resp = await self._request(next_url)
+            if resp is None:
+                break
             page = resp.json()
             posts.extend(page.get("data", []))
             next_url = page.get("paging", {}).get("next")

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/nostalgia.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/nostalgia.py
@@ -33,6 +33,8 @@ class NostalgiaAdapter(BaseAdapter):
         resp = await self._request(
             f"/advancedsearch.php?q={self.query}&output=json&rows={remaining}"
         )
+        if resp is None:
+            return []
         data = resp.json()
         docs = data.get("response", {}).get("docs", [])
         start = len(docs)
@@ -41,6 +43,8 @@ class NostalgiaAdapter(BaseAdapter):
             resp = await self._request(
                 f"/advancedsearch.php?q={self.query}&output=json&rows={remaining}&start={start}"
             )
+            if resp is None:
+                break
             page = resp.json()
             page_docs = page.get("response", {}).get("docs", [])
             if not page_docs:

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/tiktok.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/tiktok.py
@@ -37,5 +37,7 @@ class TikTokAdapter(BaseAdapter):
         results: list[dict[str, Any]] = []
         for url in self.video_urls[: self.fetch_limit]:
             resp = await self._request(f"/oembed?url={url}")
+            if resp is None:
+                continue
             results.append(resp.json())
         return results

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/youtube.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/youtube.py
@@ -31,6 +31,8 @@ class YouTubeAdapter(BaseAdapter):
         """Fetch oEmbed data for ``video_id``."""
         url = f"https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v={video_id}"
         resp = await self._request(url)
+        if resp is None:
+            return {}
         return resp.json()
 
     async def fetch(self) -> list[dict[str, Any]]:
@@ -39,6 +41,8 @@ class YouTubeAdapter(BaseAdapter):
         resp = await self._request(
             f"/youtube/v3/videos?part=id&chart=mostPopular&maxResults={remaining}&key={self.api_key}"
         )
+        if resp is None:
+            return []
         data = resp.json()
         ids = [item["id"] for item in data.get("items", [])]
         next_token = data.get("nextPageToken")
@@ -47,6 +51,8 @@ class YouTubeAdapter(BaseAdapter):
             resp = await self._request(
                 f"/youtube/v3/videos?part=id&chart=mostPopular&maxResults={remaining}&pageToken={next_token}&key={self.api_key}"
             )
+            if resp is None:
+                break
             page = resp.json()
             ids.extend([item["id"] for item in page.get("items", [])])
             next_token = page.get("nextPageToken")

--- a/backend/signal-ingestion/tests/test_etag_cache.py
+++ b/backend/signal-ingestion/tests/test_etag_cache.py
@@ -1,0 +1,84 @@
+"""Tests for ETag caching in the base adapter."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Generator
+
+import fakeredis.aioredis
+import httpx
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from backend.shared import cache  # noqa: E402
+from backend.shared.config import settings as shared_settings  # noqa: E402
+import signal_ingestion.rate_limit as rl  # noqa: E402
+import warnings
+from signal_ingestion.adapters.base import BaseAdapter  # noqa: E402
+
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="redis.*")
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _fake_redis(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Provide a fake Redis client."""
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(cache, "get_async_client", lambda: fake)
+    monkeypatch.setattr(rl, "get_async_client", lambda: fake)
+    monkeypatch.setattr(shared_settings, "redis_url", "redis://localhost:6379/0")
+    yield
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(fake.aclose())
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_etag_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Store and send ETag headers for subsequent requests."""
+
+    calls: list[dict[str, str]] = []
+
+    class DummyClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "DummyClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            pass
+
+        async def get(
+            self, url: str, headers: dict[str, str] | None = None
+        ) -> httpx.Response:
+            calls.append(headers or {})
+            request = httpx.Request("GET", url)
+            if len(calls) == 1:
+                return httpx.Response(
+                    200, json={}, headers={"ETag": "v1"}, request=request
+                )
+            return httpx.Response(304, request=request)
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+    adapter = BaseAdapter(base_url="https://example.com")
+
+    first = await adapter._request("/a")
+    assert first is not None
+    client = cache.get_async_client()
+    stored = await client.get("etag:https://example.com/a")
+    assert (stored.decode() if isinstance(stored, bytes) else stored) == "v1"
+
+    second = await adapter._request("/a")
+    assert second is None
+    assert calls[1].get("If-None-Match") == "v1"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,3 +40,11 @@ python scripts/manage_spot_instances.py release i-0abcd1234ef567890
 
 Workers will checkpoint tasks using Celery's statedb so another node can resume
 processing when a spot instance is reclaimed.
+
+## Quota Handling
+
+The signal ingestion service caches HTTP ``ETag`` headers in Redis. When a
+resource has not changed, the adapter sends the cached value using the
+``If-None-Match`` header and skips further processing when receiving a
+``304 Not Modified`` response. This reduces bandwidth usage and helps stay
+within third-party API quotas.


### PR DESCRIPTION
## Summary
- cache adapter responses using Redis and send `If-None-Match`
- handle 304 responses in adapters
- document ingestion quota handling
- test ETag cache behaviour

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/adapters/base.py backend/signal-ingestion/src/signal_ingestion/adapters/events.py backend/signal-ingestion/src/signal_ingestion/adapters/instagram.py backend/signal-ingestion/src/signal_ingestion/adapters/nostalgia.py backend/signal-ingestion/src/signal_ingestion/adapters/reddit.py backend/signal-ingestion/src/signal_ingestion/adapters/tiktok.py backend/signal-ingestion/src/signal_ingestion/adapters/youtube.py backend/signal-ingestion/tests/test_etag_cache.py`
- `pytest backend/signal-ingestion/tests/test_etag_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687e8181b3488331b3ac891951507435