### PR TITLE
Add default HTTP timeout

### DIFF
--- a/backend/api-gateway/tests/test_gateway_timeout.py
+++ b/backend/api-gateway/tests/test_gateway_timeout.py
@@ -1,0 +1,34 @@
+"""Tests for default HTTP timeout handling in the API gateway."""
+
+import importlib
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+from backend.shared.http import DEFAULT_TIMEOUT
+import api_gateway.main as main_module
+import api_gateway.routes as routes
+
+
+class AssertTimeoutClient(httpx.AsyncClient):
+    """``AsyncClient`` subclass asserting the provided timeout."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        assert kwargs.get("timeout") == DEFAULT_TIMEOUT
+        super().__init__(*args, **kwargs)
+
+
+@respx.mock
+def test_system_health_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``system_health`` should instantiate the client with the default timeout."""
+    monkeypatch.setitem(routes, "HEALTH_ENDPOINTS", {"svc": "http://svc/health"})
+    respx.get("http://svc/health").respond(200, json={"status": "ok"})
+    monkeypatch.setattr(httpx, "AsyncClient", AssertTimeoutClient)
+    importlib.reload(routes)
+    client = TestClient(main_module.app)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"svc": "ok"}

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Callable, Coroutine, Iterable
 
 import httpx
+from backend.shared.http import DEFAULT_TIMEOUT
 
 import psutil
 from fastapi import FastAPI, Request, Response
@@ -110,7 +111,7 @@ async def status() -> dict[str, str]:
         "orchestrator": "http://orchestrator:8000/health",
     }
     results: dict[str, str] = {}
-    async with httpx.AsyncClient(timeout=2) as client:
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
         for name, url in services.items():
             try:
                 resp = await client.get(url)

--- a/backend/monitoring/tests/test_monitoring_timeout.py
+++ b/backend/monitoring/tests/test_monitoring_timeout.py
@@ -1,0 +1,38 @@
+"""Tests for timeout configuration in the monitoring service."""
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from backend.shared.http import DEFAULT_TIMEOUT
+import monitoring.main as main_module
+
+
+class AssertTimeoutClient(httpx.AsyncClient):
+    """``AsyncClient`` subclass asserting the provided timeout."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        assert kwargs.get("timeout") == DEFAULT_TIMEOUT
+        super().__init__(*args, **kwargs)
+
+
+@respx.mock
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_status_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``status`` should use the default timeout for HTTP requests."""
+    respx.get("http://mockup-generation:8000/health").respond(
+        200, json={"status": "ok"}
+    )
+    respx.get("http://marketplace-publisher:8000/health").respond(
+        200, json={"status": "ok"}
+    )
+    respx.get("http://orchestrator:8000/health").respond(200, json={"status": "ok"})
+    monkeypatch.setattr(httpx, "AsyncClient", AssertTimeoutClient)
+    result = await main_module.status()
+    assert result == {
+        "mockup_generation": "ok",
+        "marketplace_publisher": "ok",
+        "orchestrator": "ok",
+    }

--- a/backend/shared/http.py
+++ b/backend/shared/http.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+import httpx
+
 import requests
 from tenacity import (
     retry,
@@ -14,8 +16,9 @@ from tenacity import (
 )
 
 DEFAULT_RETRIES = int(os.getenv("HTTP_RETRIES", "3"))
+DEFAULT_TIMEOUT = httpx.Timeout(10.0)
 
-__all__ = ["request_with_retry"]
+__all__ = ["request_with_retry", "DEFAULT_TIMEOUT"]
 
 
 def request_with_retry(

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
@@ -10,6 +10,7 @@ from ..rate_limit import AdapterRateLimiter
 from backend.shared.cache import async_get, async_set
 
 import httpx
+from backend.shared.http import DEFAULT_TIMEOUT
 
 
 class BaseAdapter:
@@ -63,7 +64,9 @@ class BaseAdapter:
         """
         await self._rate_limiter.acquire(self.__class__.__name__)
         proxy = next(self._proxies_cycle)
-        async with httpx.AsyncClient(proxy=cast(Any, proxy)) as client:
+        async with httpx.AsyncClient(
+            proxy=cast(Any, proxy), timeout=DEFAULT_TIMEOUT
+        ) as client:
             url = path if path.startswith("http") else f"{self.base_url}{path}"
             etag_key = f"etag:{url}"
             req_headers = dict(headers or {})

--- a/backend/signal-ingestion/tests/test_adapter_timeout.py
+++ b/backend/signal-ingestion/tests/test_adapter_timeout.py
@@ -1,0 +1,53 @@
+"""Tests for timeout usage in the signal ingestion adapters."""
+
+from types import TracebackType
+from typing import Any, Optional
+
+import httpx
+import pytest
+import respx
+
+from backend.shared.http import DEFAULT_TIMEOUT
+from signal_ingestion.adapters.base import BaseAdapter
+
+
+class _DummyAdapter(BaseAdapter):
+    """Minimal adapter for testing."""
+
+    async def fetch(self) -> list[dict[str, object]]:
+        return []
+
+
+class AssertTimeoutClient:
+    """Context manager mimicking ``AsyncClient`` and asserting timeout."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        assert kwargs.get("timeout") == DEFAULT_TIMEOUT
+
+    async def __aenter__(self) -> "AssertTimeoutClient":
+        """Enter context manager."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        """Exit context manager without swallowing exceptions."""
+        return None
+
+    async def get(
+        self, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, json={}, request=request)
+
+
+@respx.mock
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_request_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify ``_request`` uses the default timeout."""
+    monkeypatch.setattr(httpx, "AsyncClient", AssertTimeoutClient)
+    adapter = _DummyAdapter(base_url="https://example.com", rate_limit=1)
+    await adapter._request("/ping")

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -35,3 +35,12 @@ PostgreSQL. Then run the following once per database:
 .. code-block:: sql
 
    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+HTTP Timeouts
+-------------
+
+All services make outbound requests using ``httpx``. The recommended timeout
+for these calls is 10 seconds and is exposed as
+``backend.shared.http.DEFAULT_TIMEOUT``. Instantiate
+``httpx.AsyncClient`` with this timeout to ensure consistent behavior across
+services.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ pytest-cov
 fakeredis
 tenacity
 responses
+respx
 Pillow
 redis
 asyncpg


### PR DESCRIPTION
## Summary
- define `DEFAULT_TIMEOUT` in shared HTTP helpers
- use `DEFAULT_TIMEOUT` across async HTTP clients
- recommend using the timeout in architecture docs
- add tests verifying timeout handling with `respx`
- include `respx` in dev requirements

## Testing
- `flake8 backend/shared/http.py backend/api-gateway/src/api_gateway/routes.py backend/monitoring/src/monitoring/main.py backend/signal-ingestion/src/signal_ingestion/adapters/base.py backend/api-gateway/tests/test_gateway_timeout.py backend/monitoring/tests/test_monitoring_timeout.py backend/signal-ingestion/tests/test_adapter_timeout.py`
- `pydocstyle backend/shared/http.py backend/api-gateway/src/api_gateway/routes.py backend/monitoring/src/monitoring/main.py backend/signal-ingestion/src/signal_ingestion/adapters/base.py backend/api-gateway/tests/test_gateway_timeout.py backend/monitoring/tests/test_monitoring_timeout.py backend/signal-ingestion/tests/test_adapter_timeout.py`
- `mypy backend/shared/http.py backend/api-gateway/src/api_gateway/routes.py backend/monitoring/src/monitoring/main.py backend/signal-ingestion/src/signal_ingestion/adapters/base.py backend/api-gateway/tests/test_gateway_timeout.py backend/monitoring/tests/test_monitoring_timeout.py backend/signal-ingestion/tests/test_adapter_timeout.py` *(fails: many missing type hints)*
- `pytest` *(fails: missing dependency 'sqlalchemy')*
- `make -C docs html` *(fails: sphinx-build missing)*

------
https://chatgpt.com/codex/tasks/task_b_687e861435fc8331ae5ea7c5515fc59c