### PR TITLE
Add approval and slack notification for secret rotation

### DIFF
--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -60,6 +60,7 @@ def daily_summary_job() -> None:
 @job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
 def rotate_secrets_job() -> None:
     """Job rotating API tokens and updating Kubernetes secrets."""
+    await_approval()
     rotate_k8s_secrets_op()
 
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -66,3 +66,12 @@ The `daily_query_plan_schedule` Dagster schedule runs the analysis once a day.
 In production Docker Compose deployments a `backup` service runs `scripts/backup.py`
 using cron. The container uploads a PostgreSQL dump to the bucket defined by
 `BACKUP_BUCKET` every night at midnight UTC.
+
+## Monthly Secret Rotation
+
+Secrets used by internal services are rotated automatically. The
+`monthly_secret_rotation_schedule` triggers `rotate_secrets_job` on the first day
+of every month. The job waits for manual approval via the `/approvals` API
+before executing `scripts/rotate_secrets.rotate()`.
+Once the rotation completes a Slack message is sent if `SLACK_WEBHOOK_URL` is
+configured.

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,4 +38,6 @@ The ``scripts/rotate_secrets.py`` helper generates new random tokens and patches
 the corresponding Kubernetes secrets using ``kubectl``. A Dagster job executes
 this script once per month. The ``monthly_secret_rotation_schedule`` defined in
 ``backend.orchestrator.orchestrator.schedules`` triggers the job on the first
-day of every month at midnight UTC.
+day of every month at midnight UTC. The run waits for approval via the
+``/approvals`` API before applying rotations and sends a Slack notification when
+complete.


### PR DESCRIPTION
## Summary
- notify Slack when rotating secrets
- wait for approval in rotate_secrets_job
- document secret rotation process
- check job and schedule behaviour in tests

## Testing
- `mypy backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/tests/test_jobs.py --follow-imports=skip --ignore-missing-imports`
- `flake8 backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/tests/test_jobs.py`
- `pydocstyle backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/tests/test_jobs.py`
- `pytest backend/orchestrator/tests/test_jobs.py -W error -q`

------
https://chatgpt.com/codex/tasks/task_b_687e86267f208331b0daffa9b8e391e2