### PR TITLE
Implement auto migrations on startup

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -18,6 +18,7 @@ from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.logging import configure_logging
+from backend.shared.db import run_migrations_if_needed
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from .rate_limiter import UserRateLimiter
@@ -68,6 +69,13 @@ configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+
+
+@app.on_event("startup")
+async def apply_migrations() -> None:
+    """Ensure database schema is current."""
+    await run_migrations_if_needed("backend/shared/db/alembic_api_gateway.ini")
+
 
 rate_limiter = UserRateLimiter(
     settings.rate_limit_per_user,

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -45,6 +45,7 @@ from .db import (
     init_db,
     update_listing,
 )
+from backend.shared.db import run_migrations_if_needed
 from .logging_config import configure_logging
 from .pricing import create_listing_metadata
 from .publisher import publish_with_retry
@@ -89,6 +90,9 @@ rate_limiter = MarketplaceRateLimiter(
 @app.on_event("startup")
 async def startup() -> None:
     """Initialize database tables and load rules."""
+    await run_migrations_if_needed(
+        "backend/shared/db/alembic_marketplace_publisher.ini"
+    )
     await init_db()
     rules_path = (
         Path(__file__).resolve().parent.parent.parent

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -16,6 +16,8 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.currency import start_rate_updater
 
+from backend.shared.db import run_migrations_if_needed
+
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 
@@ -39,6 +41,7 @@ register_metrics(app)
 @app.on_event("startup")
 async def start_rates() -> None:
     """Start background exchange rate updates."""
+    await run_migrations_if_needed("backend/shared/db/alembic_api_gateway.ini")
     start_rate_updater()
 
 

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -12,6 +12,7 @@ from fastapi import Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from .database import get_session, init_db
+from backend.shared.db import run_migrations_if_needed
 from .scheduler import create_scheduler
 from .ingestion import ingest
 from .trending import get_top_keywords
@@ -50,6 +51,7 @@ def _identify_user(request: Request) -> str:
 @app.on_event("startup")
 async def startup() -> None:
     """Initialize resources."""
+    await run_migrations_if_needed("backend/shared/db/alembic_signal_ingestion.ini")
     await init_db()
     scheduler.start()
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -66,3 +66,9 @@ empty database:
 pytest tests/test_migrations.py
 ```
 
+## Automatic Migrations
+
+Every FastAPI service runs ``alembic upgrade head`` on startup to apply any
+pending migrations before initializing resources. Set the environment variable
+``SKIP_MIGRATIONS=1`` to bypass this step during tests.
+


### PR DESCRIPTION
## Summary
- add `run_migrations_if_needed` helper to shared DB utils
- trigger alembic upgrade in each service startup
- document automatic migration behaviour

## Testing
- `flake8 backend/shared/db/__init__.py backend/signal-ingestion/src/signal_ingestion/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/main.py backend/api-gateway/src/api_gateway/main.py docs/migrations.md`
- `pydocstyle backend/shared/db/__init__.py backend/signal-ingestion/src/signal_ingestion/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/main.py backend/api-gateway/src/api_gateway/main.py docs/migrations.md`
- `mypy backend/shared/db/__init__.py backend/signal-ingestion/src/signal_ingestion/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/main.py backend/api-gateway/src/api_gateway/main.py (fails)`
- `make -C docs html` *(fails)*
- `pytest -W error -vv` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687e8610cee083319bcc3e7575ad70d8