### PR TITLE
Add cache headers for static endpoints

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -18,6 +18,7 @@ from .auth import require_role
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
@@ -218,12 +219,12 @@ def export_marketplace_metrics(
 
 
 @app.get("/health")  # type: ignore[misc]
-async def health() -> Dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")  # type: ignore[misc]
-async def ready() -> Dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -17,6 +17,7 @@ from .routes import router
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
@@ -150,15 +151,15 @@ async def enforce_rate_limit(
 
 
 @app.get("/health", tags=["Status"], summary="Service liveness")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready", tags=["Status"], summary="Service readiness")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 app.include_router(router)

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Coroutine
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 from pydantic import BaseModel
 
 from .ab_testing import ABTestManager
@@ -75,15 +76,15 @@ async def add_correlation_id(
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 def _validate_variant(variant: str) -> None:

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -21,6 +21,7 @@ from backend.shared.config import settings as shared_settings
 from backend.shared.db import models as shared_models
 from backend.shared.db import session_scope
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 from backend.shared.profiling import add_profiling
 from backend.shared.tracing import configure_tracing
 
@@ -355,15 +356,15 @@ async def metrics(listing_id: int) -> dict[str, float]:
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 @app.get("/oauth/{marketplace}")

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -17,6 +17,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 
 from .model_repository import list_models, register_model, set_default
 from .celery_app import app as celery_app
@@ -86,15 +87,15 @@ register_metrics(app)
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 @app.get("/models")

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import Histogram
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
@@ -228,15 +229,15 @@ async def logs() -> dict[str, str]:
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -20,6 +20,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
@@ -171,12 +172,12 @@ def get_recommendations() -> List[str]:
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -27,6 +27,7 @@ from prometheus_client import (
     generate_latest,
 )
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 
@@ -356,15 +357,15 @@ async def score_signal(payload: ScoreRequest) -> JSONResponse:
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -14,6 +14,7 @@ from .settings import settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 from backend.shared.currency import start_rate_updater
 
 from backend.shared import add_error_handlers, configure_sentry
@@ -77,15 +78,15 @@ async def add_correlation_id(
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -9,6 +9,7 @@ from .feature_flags import initialize as init_feature_flags, is_enabled
 from .errors import add_error_handlers, add_flask_error_handlers
 from .currency import convert_price, start_rate_updater
 from .metrics import register_metrics
+from .responses import cache_header, json_cached
 from .config import settings
 
 __all__ = [
@@ -23,5 +24,7 @@ __all__ = [
     "convert_price",
     "start_rate_updater",
     "register_metrics",
+    "cache_header",
+    "json_cached",
     "settings",
 ]

--- a/backend/shared/metrics.py
+++ b/backend/shared/metrics.py
@@ -6,6 +6,8 @@ from time import perf_counter
 from typing import Callable, Coroutine
 
 from fastapi import FastAPI, Request, Response
+
+from .responses import cache_header
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
     Counter,
@@ -42,4 +44,5 @@ def register_metrics(app: FastAPI) -> None:
     @app.get("/metrics")
     async def metrics() -> Response:
         data = generate_latest()
-        return Response(content=data, media_type=CONTENT_TYPE_LATEST)
+        headers = cache_header()
+        return Response(content=data, media_type=CONTENT_TYPE_LATEST, headers=headers)

--- a/backend/shared/responses.py
+++ b/backend/shared/responses.py
@@ -1,0 +1,19 @@
+"""Helper utilities for HTTP responses."""
+
+from __future__ import annotations
+
+from fastapi.responses import JSONResponse, Response
+
+CACHE_TTL_SECONDS = 60
+
+
+def cache_header(ttl: int = CACHE_TTL_SECONDS) -> dict[str, str]:
+    """Return Cache-Control header dictionary with ``ttl`` seconds."""
+    return {"Cache-Control": f"public, max-age={ttl}"}
+
+
+def json_cached(
+    payload: dict[str, object], ttl: int = CACHE_TTL_SECONDS
+) -> JSONResponse:
+    """Return ``JSONResponse`` with Cache-Control header."""
+    return JSONResponse(content=payload, headers=cache_header(ttl))

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -21,6 +21,7 @@ from backend.shared.config import settings as shared_settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
 
 from backend.shared import add_error_handlers, configure_sentry
 
@@ -90,15 +91,15 @@ async def add_correlation_id(
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Response:
     """Return service liveness."""
-    return {"status": "ok"}
+    return json_cached({"status": "ok"})
 
 
 @app.get("/ready")
-async def ready() -> dict[str, str]:
+async def ready() -> Response:
     """Return service readiness."""
-    return {"status": "ready"}
+    return json_cached({"status": "ready"})
 
 
 @app.post("/ingest")

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -43,3 +43,10 @@ The context manager `tasks.gpu_slot` updates two metrics:
 - ``gpu_slot_acquire_total`` – a counter incremented whenever a slot is obtained.
 
 These metrics appear alongside existing ones on the ``/metrics`` endpoint.
+
+## CDN Configuration
+
+Static assets are distributed through a CloudFront CDN for low latency delivery.
+The helper script ``scripts/configure_cdn.sh`` provisions a distribution with a
+default TTL of one hour and HTTPS enforced. Refer to the script for exact
+settings.

--- a/frontend/admin-dashboard/next.config.ts
+++ b/frontend/admin-dashboard/next.config.ts
@@ -16,6 +16,15 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      {
+        source: '/:path(health|metrics)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=60',
+          },
+        ],
+      },
     ];
   },
   webpack: (config) => {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,9 @@ def test_health_ready_endpoints() -> None:
     """Health and readiness endpoints return status."""
     response = client.get("/health")
     assert response.status_code == 200
+    assert response.headers["Cache-Control"].startswith("public")
     assert response.json() == {"status": "ok"}
     response = client.get("/ready")
     assert response.status_code == 200
+    assert response.headers["Cache-Control"].startswith("public")
     assert response.json() == {"status": "ready"}

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -20,6 +20,7 @@ def test_metrics_endpoint() -> None:
     response = client.get("/metrics")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/plain")
+    assert response.headers["Cache-Control"].startswith("public")
 
 
 def test_overview_endpoint() -> None:
@@ -35,9 +36,11 @@ def test_health_ready_endpoints() -> None:
     """Health and readiness should return status."""
     response = client.get("/health")
     assert response.status_code == 200
+    assert response.headers["Cache-Control"].startswith("public")
     assert response.json() == {"status": "ok"}
     response = client.get("/ready")
     assert response.status_code == 200
+    assert response.headers["Cache-Control"].startswith("public")
     assert response.json() == {"status": "ready"}
 
 

--- a/tests/test_tracing_profiling.py
+++ b/tests/test_tracing_profiling.py
@@ -70,6 +70,7 @@ def test_tracing_and_profiling(
         client = TestClient(app)
         resp = client.get("/health")
         assert resp.status_code == 200
+        assert resp.headers["Cache-Control"].startswith("public")
     else:
         app.config.update(TESTING=True)
         client = app.test_client()


### PR DESCRIPTION
## Summary
- ensure `/metrics` endpoint returns cache headers
- send short caching headers for `/health` endpoints
- expose helper for cached JSON responses
- extend Next.js headers for health/metrics
- document CDN config
- verify cache headers in tests

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt --progress-bar off`
- `npm ci --silent`
- `npx eslint frontend/admin-dashboard/next.config.ts` *(fails: Cannot find module '@eslint/eslintrc')*
- `npx stylelint "**/*.css"` *(fails: npm error canceled)*
- `flake8 backend/shared/responses.py backend/shared/__init__.py backend/shared/metrics.py backend/mockup-generation/mockup_generation/api.py backend/optimization/api.py backend/service-template/src/main.py backend/feedback-loop/feedback_loop/main.py backend/monitoring/src/monitoring/main.py backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/signal-ingestion/src/signal_ingestion/main.py backend/scoring-engine/scoring_engine/app.py tests/test_api.py tests/test_monitoring.py tests/test_tracing_profiling.py`
- `mypy backend/shared/responses.py backend/shared/__init__.py backend/shared/metrics.py backend/mockup-generation/mockup_generation/api.py backend/optimization/api.py backend/service-template/src/main.py backend/feedback-loop/feedback_loop/main.py backend/monitoring/src/monitoring/main.py backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/signal-ingestion/src/signal_ingestion/main.py backend/scoring-engine/scoring_engine/app.py tests/test_api.py tests/test_monitoring.py tests/test_tracing_profiling.py` *(fails: Found 147 errors)*
- `pydocstyle backend/shared/responses.py docs/performance.md`
- `docformatter -r -i backend/shared/responses.py docs/performance.md`
- `pytest -q` *(fails: 64 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687e861d0b188331927df17bf5b9d251