### PR TITLE
Add mockup tracking

### DIFF
--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -18,7 +18,12 @@ from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from backend.shared.metrics import register_metrics
 
-from .model_repository import list_models, register_model, set_default
+from .model_repository import (
+    list_generated_mockups,
+    list_models,
+    register_model,
+    set_default,
+)
 from .celery_app import app as celery_app
 
 configure_logging()
@@ -147,3 +152,9 @@ async def generate(payload: GeneratePayload) -> dict[str, list[str]]:
         for batch in payload.batches
     ]
     return {"tasks": task_ids}
+
+
+@app.get("/mockups")
+async def get_mockups() -> list[dict[str, object]]:
+    """Return recently generated mockups."""
+    return [m.__dict__ for m in list_generated_mockups()]

--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -141,6 +141,7 @@ def generate_mockup(
     *,
     model: str | None = None,
     gpu_index: int | None = None,
+    num_inference_steps: int = 30,
 ) -> list[dict[str, object]]:
     """
     Generate mockups sequentially on the GPU.
@@ -189,6 +190,7 @@ def generate_mockup(
                     gen_result = generator.generate(
                         prompt,
                         str(output_path),
+                        num_inference_steps=num_inference_steps,
                         model_identifier=model,
                     )
 
@@ -219,7 +221,7 @@ def generate_mockup(
                     metadata = listing_gen.generate(keywords)
                     model_repository.save_generated_mockup(
                         prompt,
-                        30,
+                        num_inference_steps,
                         0,
                         uri,
                         metadata.title,

--- a/backend/mockup-generation/tests/test_api_mockups.py
+++ b/backend/mockup-generation/tests/test_api_mockups.py
@@ -1,0 +1,216 @@
+"""Tests for listing generated mockups via the API."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+root = Path(__file__).resolve().parents[3]
+sys.path.append(str(root))
+sys.path.append(str(root / "backend" / "mockup-generation"))
+
+# Minimal stubs for optional dependencies
+fastapi_mod = types.ModuleType("fastapi")
+fastapi_mod.FastAPI = object
+fastapi_mod.Request = object
+fastapi_mod.Response = object
+fastapi_mod.HTTPException = Exception
+responses_mod = types.ModuleType("fastapi.responses")
+responses_mod.JSONResponse = object
+sys.modules.setdefault("fastapi.responses", responses_mod)
+fastapi_mod.responses = responses_mod
+sys.modules.setdefault("fastapi", fastapi_mod)
+
+trace_root = types.ModuleType("opentelemetry.trace")
+trace_root.set_tracer_provider = lambda *a, **k: None
+
+
+class _DummySpan:
+    def get_span_context(self) -> types.SimpleNamespace:
+        return types.SimpleNamespace(trace_id=0)
+
+
+trace_root.get_current_span = lambda: _DummySpan()
+sys.modules.setdefault("opentelemetry.trace", trace_root)
+fastapi_instr = types.ModuleType("opentelemetry.instrumentation.fastapi")
+fastapi_instr.FastAPIInstrumentor = type(
+    "FastAPIInstrumentor",
+    (),
+    {"instrument_app": lambda *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.instrumentation.fastapi", fastapi_instr)
+flask_instr = types.ModuleType("opentelemetry.instrumentation.flask")
+flask_instr.FlaskInstrumentor = object
+sys.modules.setdefault("opentelemetry.instrumentation.flask", flask_instr)
+res_mod = types.ModuleType("opentelemetry.sdk.resources")
+res_mod.Resource = type(
+    "Resource",
+    (),
+    {"create": staticmethod(lambda *a, **k: object())},
+)
+sys.modules.setdefault("opentelemetry.sdk.resources", res_mod)
+trace_mod = types.ModuleType("opentelemetry.sdk.trace")
+trace_mod.TracerProvider = type(
+    "TracerProvider",
+    (),
+    {
+        "__init__": lambda self, *a, **k: None,
+        "add_span_processor": lambda *a, **k: None,
+    },
+)
+sys.modules.setdefault("opentelemetry.sdk.trace", trace_mod)
+export_mod = types.ModuleType("opentelemetry.sdk.trace.export")
+export_mod.BatchSpanProcessor = type(
+    "BatchSpanProcessor",
+    (),
+    {"__init__": lambda self, *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.sdk.trace.export", export_mod)
+exp_http_mod = types.ModuleType("opentelemetry.exporter.otlp.proto.http.trace_exporter")
+exp_http_mod.OTLPSpanExporter = type(
+    "OTLPSpanExporter",
+    (),
+    {"__init__": lambda self, *a, **k: None},
+)
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    exp_http_mod,
+)
+
+for name in [
+    "opentelemetry",
+    "opentelemetry.trace",
+    "opentelemetry.instrumentation.fastapi",
+    "opentelemetry.instrumentation.flask",
+    "opentelemetry.sdk.resources",
+    "opentelemetry.sdk.trace",
+    "opentelemetry.sdk.trace.export",
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    "sentry_sdk",
+    "sentry_sdk.integrations.asgi",
+    "sentry_sdk.integrations.logging",
+]:
+    sys.modules.setdefault(name, types.ModuleType(name))
+
+sentry_mod = sys.modules.setdefault("sentry_sdk", types.ModuleType("sentry_sdk"))
+sentry_mod.init = lambda *args, **kwargs: None
+sentry_mod.Hub = types.SimpleNamespace(current=types.SimpleNamespace(client=None))
+sentry_asgi = sys.modules.setdefault(
+    "sentry_sdk.integrations.asgi", types.ModuleType("sentry_sdk.integrations.asgi")
+)
+sentry_asgi.SentryAsgiMiddleware = object
+logging_mod = sys.modules.setdefault(
+    "sentry_sdk.integrations.logging",
+    types.ModuleType("sentry_sdk.integrations.logging"),
+)
+logging_mod.LoggingIntegration = object
+
+uc_mod = sys.modules.setdefault("UnleashClient", types.ModuleType("UnleashClient"))
+uc_mod.UnleashClient = object
+ld_mod = sys.modules.setdefault("ldclient", types.ModuleType("ldclient"))
+ld_mod.LDClient = object
+prom_mod = sys.modules.setdefault(
+    "prometheus_client", types.ModuleType("prometheus_client")
+)
+prom_mod.CONTENT_TYPE_LATEST = ""
+prom_mod.Counter = lambda *a, **k: types.SimpleNamespace(
+    labels=lambda *_, **__: types.SimpleNamespace(inc=lambda *_, **__: None)
+)
+prom_mod.Histogram = lambda *a, **k: types.SimpleNamespace(
+    labels=lambda *_, **__: types.SimpleNamespace(observe=lambda *_, **__: None)
+)
+prom_mod.generate_latest = lambda *a, **k: b""
+sys.modules.setdefault("pgvector.sqlalchemy", types.ModuleType("pgvector.sqlalchemy"))
+sys.modules["pgvector.sqlalchemy"].Vector = object
+
+
+class DummyClient:
+    """Collect uploaded objects."""
+
+    def upload_file(self, src: str, bucket: str, obj: str) -> None:
+        """Pretend to upload ``src`` to ``bucket/obj``."""
+        return None
+
+
+class DummyGenerator:
+    """Generate a dummy file and keep track of cleanup."""
+
+    def __init__(self) -> None:
+        self.cleaned = False
+
+    def generate(
+        self,
+        prompt: str,
+        output: str,
+        *,
+        num_inference_steps: int = 30,
+        model_identifier: str | None = None,
+    ) -> types.SimpleNamespace:
+        Path(output).write_text("x")
+        return types.SimpleNamespace(image_path=output)
+
+    def cleanup(self) -> None:
+        self.cleaned = True
+
+
+class DummyListing:
+    """Simple listing container."""
+
+    title = "t"
+    description = "d"
+    tags = ["a"]
+
+
+class DummyListingGen:
+    """Return :class:`DummyListing` instances."""
+
+    def generate(self, keywords: list[str]) -> DummyListing:
+        """Return listing regardless of ``keywords``."""
+        return DummyListing()
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_metadata_recorded_and_listed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Generated mockups are saved and listed via the API."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    for mod in [
+        "backend.shared.config",
+        "backend.shared.db",
+        "mockup_generation.model_repository",
+        "mockup_generation.tasks",
+        "mockup_generation.api",
+    ]:
+        sys.modules.pop(mod, None)
+    tasks = importlib.import_module("mockup_generation.tasks")
+    api = importlib.import_module("mockup_generation.api")
+    monkeypatch.setattr(tasks, "generator", DummyGenerator())
+    monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
+    monkeypatch.setattr(tasks, "_get_storage_client", lambda: DummyClient())
+    monkeypatch.setattr(tasks, "remove_background", lambda img: img)
+    monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)
+    monkeypatch.setattr(tasks, "ensure_not_nsfw", lambda img: None)
+    monkeypatch.setattr(tasks, "validate_dpi_image", lambda img: True)
+    monkeypatch.setattr(tasks, "validate_color_space", lambda img: True)
+    monkeypatch.setattr(tasks, "validate_dimensions", lambda img: True)
+    monkeypatch.setattr(tasks, "validate_file_size", lambda p: True)
+    tasks.settings.s3_bucket = "b"
+    tasks.settings.s3_endpoint = "http://test"
+    tasks.settings.s3_base_url = "http://cdn.test"
+
+    tasks.generate_mockup.run([["kw"]], str(tmp_path), model="m", gpu_index=0)
+
+    client = TestClient(api.app)
+    resp = client.get("/mockups")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "t"

--- a/backend/shared/db/alembic_mockup_generation.ini
+++ b/backend/shared/db/alembic_mockup_generation.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = backend/shared/db/migrations/mockup_generation
+sqlalchemy.url = sqlite:///shared.db
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/shared/db/migrations/abcdef123456_merge_mockup_generation_head.py
+++ b/backend/shared/db/migrations/abcdef123456_merge_mockup_generation_head.py
@@ -1,0 +1,20 @@
+"""Merge mockup_generation head with previous heads."""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "abcdef123456"
+down_revision = ("4ed6b262010c", "0001")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the no-op merge migration."""
+    pass
+
+
+def downgrade() -> None:
+    """Revert the no-op merge migration."""
+    pass

--- a/backend/shared/db/migrations/mockup_generation/env.py
+++ b/backend/shared/db/migrations/mockup_generation/env.py
@@ -1,0 +1,54 @@
+"""Alembic environment for the mockup generation service."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+import os
+
+# this metadata is not used directly but required by Alembic
+# because models are created dynamically elsewhere
+
+target_metadata = None
+
+config = context.config
+fileConfig(config.config_file_name)
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode."""
+    url = config.get_main_option("sqlalchemy.url") or os.getenv(
+        "DATABASE_URL", "sqlite:///shared.db"
+    )
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in online mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/shared/db/migrations/mockup_generation/script.py.mako
+++ b/backend/shared/db/migrations/mockup_generation/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/shared/db/migrations/mockup_generation/versions/0001_create_generated_mockups_table.py
+++ b/backend/shared/db/migrations/mockup_generation/versions/0001_create_generated_mockups_table.py
@@ -1,0 +1,34 @@
+"""Create generated_mockups table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create generated_mockups table."""
+    op.create_table(
+        "generated_mockups",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("prompt", sa.String(), nullable=False),
+        sa.Column("num_inference_steps", sa.Integer, nullable=False),
+        sa.Column("seed", sa.Integer, nullable=False),
+        sa.Column("image_uri", sa.String(), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop generated_mockups table."""
+    op.drop_table("generated_mockups")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -34,6 +34,7 @@ def _run_migration(config_path: str, tmp_path: Path) -> None:
         "backend/shared/db/alembic_api_gateway.ini",
         "backend/shared/db/alembic_marketplace_publisher.ini",
         "backend/shared/db/alembic_signal_ingestion.ini",
+        "backend/shared/db/alembic_mockup_generation.ini",
     ],
 )
 def test_migrations(config_path: str, tmp_path: Path) -> None:
@@ -48,6 +49,7 @@ def test_migrations(config_path: str, tmp_path: Path) -> None:
         "backend/shared/db/alembic_api_gateway.ini",
         "backend/shared/db/alembic_marketplace_publisher.ini",
         "backend/shared/db/alembic_signal_ingestion.ini",
+        "backend/shared/db/alembic_mockup_generation.ini",
     ],
 )
 def test_single_head(config_path: str) -> None:


### PR DESCRIPTION
## Summary
- create alembic environment for mockup generation
- add generated_mockups table
- allow tasks to set inference steps when saving
- expose `/mockups` API endpoint
- test API listing and migrations

## Testing
- `pip install -r requirements-dev.txt` *(fails: ERESOLVE)*
- `python -m pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', then missing packages)*

------
https://chatgpt.com/codex/tasks/task_b_687e861717e48331938d23ce07d87688