### PR TITLE
Add PWA caching and offline test

### DIFF
--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -6,3 +6,4 @@ Next.js Frontend
 
    nextjs_setup
    api_calls
+   offline

--- a/docs/frontend/offline.md
+++ b/docs/frontend/offline.md
@@ -1,0 +1,12 @@
+# Offline Support
+
+The admin dashboard uses a service worker provided by `next-pwa`.
+Static assets such as images, scripts and stylesheets are cached
+using a cache-first strategy. API calls required on startup are
+cached with a network-first strategy to keep the data fresh while
+still allowing the dashboard to load when the network is unavailable.
+
+The service worker is automatically generated during `next build` and
+served from the `public` directory. When a new version is deployed,
+the worker skips the waiting phase so clients receive updates on the
+next load.

--- a/frontend/admin-dashboard/e2e/offline.spec.ts
+++ b/frontend/admin-dashboard/e2e/offline.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure the dashboard can be loaded from cache when offline.
+test('dashboard accessible offline', async ({ page, context }) => {
+  await page.goto('/dashboard');
+  await page.waitForLoadState('networkidle');
+
+  await context.setOffline(true);
+  await page.reload();
+
+  await expect(page).toHaveURL(/dashboard/);
+  await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible();
+});

--- a/frontend/admin-dashboard/next.config.ts
+++ b/frontend/admin-dashboard/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next';
 import withPWA from 'next-pwa';
+import type { RuntimeCaching } from 'next-pwa';
 
 /**
  * Next.js configuration enabling tree shaking and granular code splitting.
@@ -36,7 +37,30 @@ const nextConfig: NextConfig = {
   },
 };
 
+const runtimeCaching: RuntimeCaching[] = [
+  {
+    urlPattern: /^https?.*\.(?:png|jpg|css|js|json)$/,
+    handler: 'CacheFirst',
+    options: {
+      cacheName: 'static-assets',
+      expiration: { maxEntries: 60, maxAgeSeconds: 7 * 24 * 60 * 60 },
+    },
+  },
+  {
+    urlPattern: /^https?.*\/api\/.*$/,
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'api-calls',
+      networkTimeoutSeconds: 3,
+      expiration: { maxEntries: 30, maxAgeSeconds: 5 * 60 },
+    },
+  },
+];
+
 export default withPWA({
   dest: 'public',
   disable: process.env.NODE_ENV === 'development',
+  runtimeCaching,
+  register: true,
+  skipWaiting: true,
 })(nextConfig);


### PR DESCRIPTION
## Summary
- configure next-pwa runtime caching
- add offline Playwright test
- document service worker behaviour

## Testing
- `npx prettier frontend/admin-dashboard/next.config.ts frontend/admin-dashboard/e2e/offline.spec.ts docs/frontend/offline.md docs/frontend/index.rst --check`
- `npm run lint --prefix frontend/admin-dashboard` *(fails: 3 problems)*
- `npm run test:e2e --prefix frontend/admin-dashboard` *(fails to start webserver)*
- `make -C docs html` *(fails: missing fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_687e8a0bdc8483318d535e6ed5c0ee88