### PR TITLE
Add API snippets and tRPC docs

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -27,8 +27,8 @@ pg\_stat\_statements
 --------------------
 
 The :code:`pg_stat_statements` extension tracks execution statistics for all
-SQL queries. It must be enabled so that
-:mod:`scripts.analyze_query_plans` can inspect slow statements. Ensure
+SQL queries. It must be enabled so that ``scripts.analyze_query_plans`` can
+inspect slow statements. Ensure
 ``shared_preload_libraries`` includes ``pg_stat_statements`` and restart
 PostgreSQL. Then run the following once per database:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -101,7 +101,7 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
 
 ## Cloud Providers
 
-See the [Cloud Provider Strategy](blueprints/DesignIdeaEngineCompleteBlueprint.md#cloud-provider-strategy)
+See the [Cloud Provider Strategy](blueprints/DesignIdeaEngineCompleteBlueprint.md)
 section of the project blueprint for recommendations on multi-cloud deployments.
 
 ### AWS

--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -6,3 +6,4 @@ Next.js Frontend
 
    nextjs_setup
    api_calls
+   trpc_usage

--- a/docs/frontend/trpc_usage.rst
+++ b/docs/frontend/trpc_usage.rst
@@ -1,0 +1,33 @@
+tRPC Usage Examples
+===================
+
+The admin dashboard communicates with the API Gateway using **tRPC**. Below is a minimal example showing how to create a query and mutation using the generated tRPC client.
+
+.. code-block:: text
+
+   // src/trpc.ts
+   import { createTRPCReact } from '@trpc/react-query';
+   import type { AppRouter } from '../server/router';
+
+   export const trpc = createTRPCReact<AppRouter>();
+
+.. code-block:: text
+
+   // Example query inside a React component
+   const Example: React.FC = () => {
+       const { data, error } = trpc.trending.useQuery();
+       if (error) return <p>Error: {error.message}</p>;
+       return <pre>{JSON.stringify(data)}</pre>;
+   };
+
+.. code-block:: text
+
+   // Example mutation
+   const ApproveItem: React.FC<{id: string}> = ({ id }) => {
+       const mutation = trpc.approve.useMutation();
+       return (
+           <button onClick={() => mutation.mutate({ id })}>
+               Approve
+           </button>
+       );
+   };

--- a/docs/scoring_engine/modules.rst
+++ b/docs/scoring_engine/modules.rst
@@ -6,6 +6,7 @@ API Reference
 
 .. automodule:: scoring_engine.affinity
    :members:
+   :noindex:
 
 .. automodule:: scoring_engine.app
    :members:

--- a/docs/source/api/api-gateway.rst
+++ b/docs/source/api/api-gateway.rst
@@ -3,3 +3,14 @@ API Gateway HTTP API
 
 ``GET /trending``
     Return the most popular keywords observed by the ingestion service.
+
+Example request using ``requests``:
+
+.. code-block:: python
+
+   import requests
+
+   base_url = "https://api.example.com"
+   response = requests.get(f"{base_url}/trending", timeout=10)
+   response.raise_for_status()
+   print(response.json())


### PR DESCRIPTION
## Summary
- document pg_stat_statements analysis script
- fix blueprint link in deployment guide
- add new tRPC usage page and link from frontend docs
- avoid duplicate affinity module index entry
- show Python requests example for trending API

## Testing
- `docformatter --check --recursive docs/frontend docs/source`
- `flake8 docs/frontend docs/source`
- `SKIP_OPENAPI=1 make -C docs html`

------
https://chatgpt.com/codex/tasks/task_b_687e8a1813a8833191e524a671568463