### PR TITLE
Implement security headers middleware

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -18,6 +18,7 @@ from .auth import require_role
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
@@ -42,6 +43,7 @@ configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+add_security_headers(app)
 
 
 def _identify_user(request: Request) -> str:

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -17,6 +17,7 @@ from .routes import router
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared.db import run_migrations_if_needed
@@ -70,6 +71,7 @@ configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+add_security_headers(app)
 
 
 @app.on_event("startup")

--- a/backend/api-gateway/tests/test_security_headers.py
+++ b/backend/api-gateway/tests/test_security_headers.py
@@ -1,0 +1,47 @@
+"""Security headers are added to all responses."""
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+import fakeredis.aioredis
+import warnings
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+
+def test_security_headers(monkeypatch: Any) -> None:
+    """Security headers are applied based on configuration."""
+    monkeypatch.setenv("CONTENT_SECURITY_POLICY", "default-src 'self'")
+    monkeypatch.setenv("HSTS", "max-age=3600")
+
+    import backend.shared.config as shared_config
+
+    importlib.reload(shared_config)
+    shared_config.settings.content_security_policy = "default-src 'self'"
+    shared_config.settings.hsts = "max-age=3600"
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setattr(
+        "backend.shared.cache.get_async_client", lambda: fakeredis.aioredis.FakeRedis()
+    )
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import api_gateway.main as main_module
+
+    if hasattr(main_module, "REQUEST_LATENCY"):
+        import prometheus_client
+
+        prometheus_client.REGISTRY.unregister(main_module.REQUEST_LATENCY)
+        prometheus_client.REGISTRY.unregister(main_module.ERROR_COUNTER)
+
+    importlib.reload(main_module)
+
+    client = TestClient(main_module.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Security-Policy"] == "default-src 'self'"
+    assert resp.headers["Strict-Transport-Security"] == "max-age=3600"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["Referrer-Policy"] == "same-origin"

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Coroutine
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from pydantic import BaseModel
 
@@ -26,6 +27,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 register_metrics(app)
+add_security_headers(app)
 logger = logging.getLogger(__name__)
 
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -21,6 +21,7 @@ from backend.shared.config import settings as shared_settings
 from backend.shared.db import models as shared_models
 from backend.shared.db import session_scope
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.profiling import add_profiling
 from backend.shared.tracing import configure_tracing
@@ -134,6 +135,7 @@ async def add_correlation_id(
 
 
 register_metrics(app)
+add_security_headers(app)
 
 
 class PublishRequest(BaseModel):

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -17,6 +17,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 
 from .model_repository import (
@@ -89,6 +90,7 @@ async def add_correlation_id(
 
 
 register_metrics(app)
+add_security_headers(app)
 
 
 @app.get("/health")

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import Histogram
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 
 from backend.shared.tracing import configure_tracing
@@ -58,6 +59,7 @@ configure_sentry(app, settings.app_name)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+add_security_headers(app)
 SIGNAL_TO_PUBLISH_SECONDS = Histogram(
     "signal_to_publish_seconds",
     "Latency from first signal ingestion to listing publish per idea",

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -20,6 +20,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
@@ -45,6 +46,7 @@ configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+add_security_headers(app)
 
 
 def _identify_user(request: Request) -> str:

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -27,6 +27,7 @@ from prometheus_client import (
     generate_latest,
 )
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
@@ -111,6 +112,7 @@ configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+add_security_headers(app)
 REDIS_URL = settings.redis_url
 CACHE_TTL_SECONDS = settings.score_cache_ttl
 redis_client: AsyncRedis = get_async_client()

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -14,6 +14,7 @@ from .settings import settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.currency import start_rate_updater
 
@@ -37,6 +38,7 @@ configure_sentry(app, settings.app_name)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+add_security_headers(app)
 
 
 @app.on_event("startup")

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -11,6 +11,7 @@ from .currency import convert_price, start_rate_updater
 from .metrics import register_metrics
 from .responses import cache_header, json_cached
 from .config import settings
+from .security import add_security_headers
 
 __all__ = [
     "add_profiling",
@@ -27,4 +28,5 @@ __all__ = [
     "cache_header",
     "json_cached",
     "settings",
+    "add_security_headers",
 ]

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):  # type: ignore[misc]
     auth0_client_id: str | None = None
     weights_token: str | None = None
     allowed_origins: list[str] = Field(default_factory=list)
+    content_security_policy: str | None = None
+    hsts: str | None = None
 
     @field_validator("allowed_origins", mode="before")  # type: ignore[misc]
     @classmethod

--- a/backend/shared/security.py
+++ b/backend/shared/security.py
@@ -1,0 +1,32 @@
+"""Utilities for adding common security headers."""
+
+from __future__ import annotations
+
+from typing import Callable, Coroutine
+
+from fastapi import FastAPI, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .config import settings
+
+
+def add_security_headers(app: FastAPI) -> None:
+    """Attach security headers to all responses from ``app``."""
+
+    async def _set_headers(
+        request: Request,
+        call_next: Callable[[Request], Coroutine[None, None, Response]],
+    ) -> Response:
+        response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "same-origin")
+        if settings.content_security_policy:
+            response.headers.setdefault(
+                "Content-Security-Policy", settings.content_security_policy
+            )
+        if settings.hsts:
+            response.headers.setdefault("Strict-Transport-Security", settings.hsts)
+        return response
+
+    app.add_middleware(BaseHTTPMiddleware, dispatch=_set_headers)

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -22,6 +22,7 @@ from backend.shared.config import settings as shared_settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
+from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 
 from backend.shared import add_error_handlers, configure_sentry
@@ -41,6 +42,7 @@ configure_sentry(app, settings.app_name)
 add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
+add_security_headers(app)
 scheduler = create_scheduler()
 
 


### PR DESCRIPTION
## Summary
- introduce `add_security_headers` helper
- apply security headers middleware to all FastAPI apps
- expose CSP and HSTS configuration
- test API Gateway responses include security headers

## Testing
- `flake8 backend/api-gateway/tests/test_security_headers.py backend/shared/security.py backend/shared/__init__.py backend/shared/config.py backend/api-gateway/src/api_gateway/main.py backend/analytics/api.py backend/monitoring/src/monitoring/main.py backend/service-template/src/main.py backend/optimization/api.py backend/feedback-loop/feedback_loop/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `black backend/api-gateway/tests/test_security_headers.py backend/shared/security.py backend/shared/__init__.py backend/shared/config.py backend/api-gateway/src/api_gateway/main.py backend/analytics/api.py backend/monitoring/src/monitoring/main.py backend/service-template/src/main.py backend/optimization/api.py backend/feedback-loop/feedback_loop/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `docformatter -i backend/api-gateway/tests/test_security_headers.py`
- `mypy backend/shared/security.py` *(fails: Returning Any from function declared to return "str | None" and other errors)*
- `pytest backend/api-gateway/tests/test_security_headers.py -q` *(fails: KeyError: 'Content-Security-Policy')*


------
https://chatgpt.com/codex/tasks/task_b_687e8a0fd7688331b0a10c7690138267