### PR TITLE
Inject session provider for daily summary

### DIFF
--- a/docs/daily_summary.md
+++ b/docs/daily_summary.md
@@ -6,6 +6,9 @@
 - **mockup_success_rate** – ratio of generated mockups to ideas
 - **marketplace_stats** – count of successful listings per marketplace
 
+``generate_daily_summary`` accepts an optional ``session_provider`` parameter for
+tests. By default it uses ``backend.shared.db.session_scope``.
+
 Run the script manually or schedule it via cron:
 
 ```bash


### PR DESCRIPTION
## Summary
- allow injecting a session provider into `generate_daily_summary`
- use an in-memory SQLite provider in the tests
- document the new optional parameter

## Testing
- `SKIP_HEAVY_DEPS=1 pytest tests/test_daily_summary.py -W error -vv`

------
https://chatgpt.com/codex/tasks/task_b_687e8e3236c88331b59a30c2a9ea61f1