### PR TITLE
Implement Redis-backed flag persistence

### DIFF
--- a/backend/shared/tests/test_feature_flags.py
+++ b/backend/shared/tests/test_feature_flags.py
@@ -69,3 +69,15 @@ def test_redis_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     fake.set("demo", "1")
     feature_flags.initialize()
     assert feature_flags.is_enabled("demo") is True
+
+
+def test_redis_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flags stored in Redis persist across module reloads."""
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setenv("FEATURE_FLAGS_REDIS_URL", "redis://test")
+    monkeypatch.setattr(feature_flags.redis, "Redis", lambda *_, **__: fake)
+    feature_flags.initialize()
+    feature_flags.set_flag("demo", True)
+    importlib.reload(feature_flags)
+    feature_flags.initialize()
+    assert feature_flags.is_enabled("demo") is True

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -6,7 +6,7 @@ Experimental features are toggled using [LaunchDarkly](https://launchdarkly.com/
 
 1. Provide a `LAUNCHDARKLY_SDK_KEY` to fetch flags from LaunchDarkly.
 2. Set `FEATURE_FLAGS` to a JSON mapping of flag names to booleans for simple environment-based toggles.
-3. Set `FEATURE_FLAGS_REDIS_URL` to read overrides from Redis if desired.
+3. Set `FEATURE_FLAGS_REDIS_URL` to read and write overrides from Redis, ensuring values persist across restarts.
 4. Results are cached for ``FEATURE_FLAGS_CACHE_TTL`` seconds (default ``30``).
 
 ## Disabling a flag
@@ -25,8 +25,8 @@ API and gated UI links.
 Feature flags can be managed through the API Gateway. The following endpoints
 require an authenticated user with the ``admin`` role:
 
-* ``GET /feature-flags`` – list all known flags and their current values.
-* ``POST /feature-flags/{name}`` – set the provided flag to the ``enabled``
+* ``GET /feature-flags`` - list all known flags and their current values.
+* ``POST /feature-flags/{name}`` - set the provided flag to the ``enabled``
   state in the request body.
 
 The admin dashboard provides a simple interface built from the components in


### PR DESCRIPTION
## Summary
- update docs about Redis-backed flags
- test that flags persist across service restarts

## Testing
- `pytest backend/shared/tests/test_feature_flags.py::test_redis_persistence -W error -vv --no-cov`

------
https://chatgpt.com/codex/tasks/task_b_687e8e361f74833194a0268e1d39bbc4