### PR TITLE
Add CDN proxy service and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ TAG ?= latest
 ENV ?= dev
 
 up:
-	docker compose -f docker-compose.dev.yml up -d
+        docker compose -f docker-compose.dev.yml up -d
+
+cdn-up:
+        docker compose -f docker-compose.dev.yml up -d cdn-proxy
 
 prod-up:
 	docker compose -f docker-compose.prod.yml up -d

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -312,6 +312,14 @@ services:
     - openai_api_key
     - stability_ai_api_key
     - huggingface_token
+  cdn-proxy:
+    image: nginx:1.25-alpine
+    ports:
+    - 8080:80
+    depends_on:
+    - admin-dashboard
+    volumes:
+    - ./docker/cdn_proxy/nginx.conf:/etc/nginx/nginx.conf:ro
   orchestrator:
     build:
       context: .

--- a/docker/cdn_proxy/Dockerfile
+++ b/docker/cdn_proxy/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:1.25-alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+
+COPY LICENSES /licenses/LICENSES

--- a/docker/cdn_proxy/LICENSES
+++ b/docker/cdn_proxy/LICENSES
@@ -1,0 +1,1 @@
+Nginx 1.25 - 2-clause BSD

--- a/docker/cdn_proxy/nginx.conf
+++ b/docker/cdn_proxy/nginx.conf
@@ -1,0 +1,27 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=cdn_cache:10m max_size=50m inactive=60m use_temp_path=off;
+
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://admin-dashboard:3000;
+            proxy_cache cdn_cache;
+            proxy_cache_valid 200 302 60m;
+            proxy_cache_valid 404      1m;
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+    }
+}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -50,3 +50,16 @@ Static assets are distributed through a CloudFront CDN for low latency delivery.
 The helper script ``scripts/configure_cdn.sh`` provisions a distribution with a
 default TTL of one hour and HTTPS enforced. Refer to the script for exact
 settings.
+
+To create a distribution:
+
+```bash
+# configure your AWS credentials first
+aws configure
+
+# <bucket> and <origin> depend on your setup
+./scripts/configure_cdn.sh <bucket> <origin-domain>
+```
+
+The command prints a distribution ID which is later required when running
+``scripts/invalidate_cache.sh``.

--- a/frontend/admin-dashboard/README.md
+++ b/frontend/admin-dashboard/README.md
@@ -16,6 +16,8 @@ The dashboard reads the following variables at build time:
 
 - `NEXT_PUBLIC_MONITORING_URL` - Base URL for the monitoring API. Defaults to
   `http://localhost:8000` when not specified.
+- `NEXT_PUBLIC_CDN_BASE_URL` - If set, static asset URLs are prefixed with this
+  value so that content can be served through the CDN proxy.
 
 ### Auth0 Configuration
 

--- a/frontend/admin-dashboard/next.config.ts
+++ b/frontend/admin-dashboard/next.config.ts
@@ -5,7 +5,10 @@ import type { RuntimeCaching } from 'next-pwa';
 /**
  * Next.js configuration enabling tree shaking and granular code splitting.
  */
+const assetPrefix = process.env.NEXT_PUBLIC_CDN_BASE_URL ?? '';
+
 const nextConfig: NextConfig = {
+  assetPrefix,
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- document how to run `scripts/configure_cdn.sh`
- emulate CDN behaviour locally via an nginx `cdn-proxy` service
- expose `cdn-up` target in `Makefile`
- prefix dashboard assets with optional CDN base URL

## Testing
- `npx prettier -w frontend/admin-dashboard/next.config.ts frontend/admin-dashboard/README.md`
- `npx prettier -w docs/performance.md`
- `npm run lint`
- `npm run lint:css`
- `npm run flow`
- `python -m pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687e8e2f8c0c8331a5943554b416765d