### PR TITLE
Implement tRPC ETag caching

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -26,6 +26,13 @@ Cached:   0.25s for 100 runs
 
 Caching reduces request latency by roughly 3x in this small test.
 
+## tRPC Response Caching
+
+The API Gateway now attaches ``ETag`` headers to tRPC responses. When a client
+sends ``If-None-Match`` with a previously returned value, the gateway responds
+with ``304 Not Modified`` and an empty body. This avoids transferring identical
+payloads and improves perceived latency when data has not changed.
+
 ## Scaling Strategy
 
 Production workloads run under Kubernetes with [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).


### PR DESCRIPTION
## Summary
- cache tRPC responses via ETag in API gateway
- send If-None-Match from the tRPC client and cache results
- test 304 handling in the gateway
- document caching behaviour in performance doc

## Testing
- `pip install sqlalchemy pytest-asyncio asyncpg`
- `pip install fastapi`
- `pip install pydantic-settings`
- `pip install prometheus-client`
- `pip install alembic`
- `pip install pgvector`
- `pytest backend/api-gateway/tests/test_routes.py::test_trpc_etag -vv` *(fails: ValueError duplicated timeseries)*

------
https://chatgpt.com/codex/tasks/task_b_687e922dad788331a32b58395ea5f841