### PR TITLE
Configure coverage collection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,24 @@ jobs:
         run: make test
       - name: Smoke test docker compose services
         run: ./scripts/smoke_compose.sh
+      - name: Upload Python coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-coverage-${{ matrix.python-version }}
+          path: coverage.xml
+      - name: Upload frontend coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage-${{ matrix.node-version }}
+          path: frontend/admin-dashboard/coverage
+      - name: Upload coverage to Codecov
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: |
+            coverage.xml
+            frontend/admin-dashboard/coverage/lcov.info
 
   publish:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,3 +104,16 @@ COPY LICENSES /licenses/LICENSES
 ```
 
 The resulting images must contain `/licenses/LICENSES` in the final layer.
+
+## Viewing Coverage
+
+Running `make test` generates coverage reports for both the backend and frontend.
+The Python suite writes `coverage.xml` in the repository root. Frontend tests
+create a `coverage` directory under `frontend/admin-dashboard` containing an
+HTML report. GitHub Actions uploads these files as artifacts for each run. When
+the `CODECOV_TOKEN` secret is configured, the workflow also pushes coverage data
+to Codecov.
+
+To view results locally, open
+`frontend/admin-dashboard/coverage/lcov-report/index.html` in your browser and
+use any coverage tool that supports the XML format to inspect `coverage.xml`.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:css": "npm run lint:stylelint",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:css && npm run flow",
     "flow": "flow check --max-warnings=0",
-    "test:frontend": "npm test --prefix frontend/admin-dashboard",
+    "test:frontend": "npm test --prefix frontend/admin-dashboard -- --coverage",
     "test": "npm run test:frontend",
     "test:e2e": "playwright test --config frontend/admin-dashboard/playwright.config.ts"
   },


### PR DESCRIPTION
## Summary
- enable upload of Python and frontend coverage artifacts
- send coverage to Codecov when token available
- run jest with coverage
- document how to view coverage reports

## Testing
- `pre-commit run --files package.json .github/workflows/tests.yml CONTRIBUTING.md` *(fails: requires credentials)*
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: build error for prometheus-client)*
- `pytest -k test_health_ready_endpoints tests/test_api.py -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687e9424e37c8331b8dfec6ce0386458