### PR TITLE
Add example Kubernetes secrets manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ flow-typed/
 !.env.*.example
 !.env.example
 docs/sphinx/api/
+
+# Local Kubernetes secrets
+infrastructure/k8s/secrets.yaml
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,7 +36,14 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
    ```bash
    kubectl apply -k infrastructure/k8s/base
    ```
-2. Provide environment variables via ConfigMaps and mount sensitive values using Kubernetes Secrets. The applications automatically load secrets from `/run/secrets`.
+2. Provide environment variables via ConfigMaps and mount sensitive values using Kubernetes Secrets. The applications automatically load secrets from `/run/secrets`. A starting template is available at `infrastructure/k8s/examples/secrets.yaml`.
+
+   Create the secret using Helm:
+
+   ```bash
+   helm upgrade --install shared-secret infrastructure/k8s/examples \
+     -f infrastructure/k8s/examples/secrets.yaml
+   ```
 3. Configure ingress and TLS termination for external access. An ingress controller such as NGINX is recommended.
 4. Deploy individual services using the Helm charts in `infrastructure/helm`. Each chart exposes
    values for the container image tag, environment variables and optional horizontal pod

--- a/infrastructure/k8s/examples/secrets.yaml
+++ b/infrastructure/k8s/examples/secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shared-secret
+type: Opaque
+stringData:
+  SECRET_KEY: "change-me"
+  OPENAI_API_KEY: ""
+  STABILITY_AI_API_KEY: ""
+  HUGGINGFACE_TOKEN: ""
+  S3_ACCESS_KEY: "replace_me"
+  S3_SECRET_KEY: "replace_me"
+  INSTAGRAM_TOKEN: ""
+  YOUTUBE_API_KEY: ""
+  PAGERDUTY_ROUTING_KEY: ""


### PR DESCRIPTION
## Summary
- create `infrastructure/k8s/examples/secrets.yaml` template
- reference secrets template in deployment guide
- ignore local secret manifests in `.gitignore`

## Testing
- `pip install -r requirements-dev.txt` *(fails: No matching distribution found for scikit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687e9428e95883319a4bdc654c6e7092