### PR TITLE
Expose daily summary report

### DIFF
--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -104,7 +104,7 @@ def test_trpc_ping(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_trpc_etag(monkeypatch: pytest.MonkeyPatch) -> None:
-    """tRPC endpoint should respond with 304 when ETag matches."""
+    """TRPC endpoint should respond with 304 when ETag matches."""
     import importlib
     import warnings
     import fakeredis.aioredis

--- a/backend/marketplace-publisher/tests/validators/test_marketplace_settings.py
+++ b/backend/marketplace-publisher/tests/validators/test_marketplace_settings.py
@@ -12,5 +12,6 @@ from marketplace_publisher.settings import Settings  # noqa: E402
 
 
 def test_blank_unleash_token() -> None:
+    """Validation fails when Unleash token is blank."""
     with pytest.raises(ValidationError):
         Settings(unleash_api_token=" ")

--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -158,6 +158,8 @@ def generate_mockup(
         Model identifier to use for generation.
     gpu_index : int | None, optional
         Preferred GPU slot index.
+    num_inference_steps : int, optional
+        Number of inference steps for the diffusion model.
 
     Returns
     -------

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -221,6 +221,18 @@ async def daily_summary() -> dict[str, object]:
     return dict(summary)
 
 
+@app.get("/daily_summary/report")
+async def daily_summary_report() -> dict[str, object]:
+    """Return the latest persisted daily summary report."""
+    path = Path(settings.daily_summary_file)
+    if not path.exists():
+        return {}
+    import json
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return dict(data)
+
+
 @app.get("/logs")
 async def logs() -> dict[str, str]:
     """Return the latest application logs."""

--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     ENABLE_PAGERDUTY: bool = True
     sla_alert_cooldown_minutes: int = 60
     SLA_ALERT_COOLDOWN_MINUTES: int = 60
+    daily_summary_file: str = "daily_summary.json"
+    DAILY_SUMMARY_FILE: str = "daily_summary.json"
 
     @field_validator("sla_threshold_hours")
     @classmethod
@@ -39,6 +41,13 @@ class Settings(BaseSettings):
     def _log_ext(cls, value: str) -> str:
         if not value.endswith(".log"):
             raise ValueError("log_file must end with .log")
+        return value
+
+    @field_validator("daily_summary_file")
+    @classmethod
+    def _summary_ext(cls, value: str) -> str:
+        if not value.endswith(".json"):
+            raise ValueError("daily_summary_file must end with .json")
         return value
 
 

--- a/backend/monitoring/tests/validators/test_monitoring_settings.py
+++ b/backend/monitoring/tests/validators/test_monitoring_settings.py
@@ -12,5 +12,12 @@ from monitoring.settings import Settings  # noqa: E402
 
 
 def test_invalid_log_file() -> None:
+    """Validation fails when log file does not have .log extension."""
     with pytest.raises(ValidationError):
         Settings(log_file="invalid.txt")
+
+
+def test_invalid_summary_file() -> None:
+    """Validation fails when summary file extension is not json."""
+    with pytest.raises(ValidationError):
+        Settings(daily_summary_file="summary.txt")

--- a/backend/signal-ingestion/tests/validators/test_signal_settings.py
+++ b/backend/signal-ingestion/tests/validators/test_signal_settings.py
@@ -12,10 +12,12 @@ from signal_ingestion.settings import Settings  # noqa: E402
 
 
 def test_invalid_instagram_token() -> None:
+    """Validation fails for empty Instagram token."""
     with pytest.raises(ValidationError):
         Settings(instagram_token=" ")
 
 
 def test_invalid_tiktok_url() -> None:
+    """Validation fails for malformed TikTok URL list."""
     with pytest.raises(ValidationError):
         Settings(tiktok_video_urls="not_a_url")

--- a/docs/daily_summary.md
+++ b/docs/daily_summary.md
@@ -15,9 +15,24 @@ Run the script manually or schedule it via cron:
 ./scripts/daily_summary.py
 ```
 
+The script writes the summary to the path defined by the
+``DAILY_SUMMARY_FILE`` environment variable which defaults to
+``daily_summary.json``:
+
+```bash
+DAILY_SUMMARY_FILE=/var/reports/summary.json ./scripts/daily_summary.py
+```
+
 The monitoring service exposes the same information via the
 `/daily_summary` HTTP endpoint:
 
 ```bash
 curl http://monitoring:8000/daily_summary
+```
+
+You can retrieve the last generated summary file directly from
+`/daily_summary/report`:
+
+```bash
+curl http://monitoring:8000/daily_summary/report
 ```

--- a/tests/test_daily_summary.py
+++ b/tests/test_daily_summary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+import json
 
 sys.path.append(
     str(
@@ -25,7 +26,7 @@ from scripts.daily_summary import generate_daily_summary
 
 
 @pytest.mark.asyncio
-async def test_generate_daily_summary() -> None:
+async def test_generate_daily_summary(tmp_path: Path) -> None:
     """Summary returns all expected keys."""
     from unittest.mock import AsyncMock, patch
 
@@ -44,7 +45,12 @@ async def test_generate_daily_summary() -> None:
             finally:
                 session.close()
 
-        result = await generate_daily_summary(session_provider=provider)
+        output = tmp_path / "report.json"
+        result = await generate_daily_summary(
+            session_provider=provider, output_file=output
+        )
     assert "ideas_generated" in result
     assert "mockup_success_rate" in result
     assert "marketplace_stats" in result
+    assert output.exists()
+    assert json.loads(output.read_text(encoding="utf-8")) == result

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -62,3 +62,20 @@ def test_daily_summary_endpoint(monkeypatch: Any) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["ideas_generated"] == 1
+
+
+def test_daily_summary_report_endpoint(tmp_path: Path, monkeypatch: Any) -> None:
+    """Daily summary report endpoint returns persisted JSON."""
+    import json
+
+    report = {"ideas_generated": 1, "mockup_success_rate": 1.0, "marketplace_stats": {}}
+    file_path = tmp_path / "report.json"
+    file_path.write_text(json.dumps(report), encoding="utf-8")
+    from monitoring import settings as monitoring_settings
+
+    monkeypatch.setattr(
+        monitoring_settings.settings, "daily_summary_file", str(file_path)
+    )
+    response = client.get("/daily_summary/report")
+    assert response.status_code == 200
+    assert response.json() == report


### PR DESCRIPTION
## Summary
- write daily summaries to a file
- expose `/daily_summary/report` endpoint
- validate `daily_summary_file` in monitoring settings
- document summary file access
- test new endpoint and summary file creation
- fix docstring warnings in various tests

## Testing
- `flake8 .`
- `pydocstyle .`
- `mypy scripts/daily_summary.py backend/monitoring/src/monitoring/main.py backend/monitoring/src/monitoring/settings.py tests/test_daily_summary.py tests/test_monitoring.py backend/monitoring/tests/validators/test_monitoring_settings.py backend/api-gateway/tests/test_routes.py backend/marketplace-publisher/tests/validators/test_marketplace_settings.py backend/signal-ingestion/tests/validators/test_signal_settings.py backend/mockup-generation/mockup_generation/tasks.py`
- `python -m pytest -W error -vv` *(fails: connection refused)*
- `npm ci` *(fails: dependency conflict)*
- `make -C docs html` *(fails: Redis DSN decode error)*


------
https://chatgpt.com/codex/tasks/task_b_687e9ceb41a08331ba9598d899c5d6f2