### PR TITLE
Add gallery publish e2e flow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,12 @@ jobs:
       - name: Check formatting
         run: npm run format:check --prefix frontend/admin-dashboard
       - name: Run tests
-        run: make test
+        run: |
+          docker compose -f docker-compose.dev.yml -f docker-compose.test.yml up -d
+          python -m pytest -W error -vv
+          npm test
+          npm run test:e2e
+          docker compose -f docker-compose.dev.yml -f docker-compose.test.yml down
       - name: Smoke test docker compose services
         run: ./scripts/smoke_compose.sh
       - name: Upload Python coverage

--- a/frontend/admin-dashboard/e2e/admin-flow.spec.ts
+++ b/frontend/admin-dashboard/e2e/admin-flow.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { server } from './msw-server';
+
+test.beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+test.afterAll(() => server.close());
+test.afterEach(() => server.resetHandlers());
 
 test('login and publish design', async ({ page }) => {
   await page.goto('/');

--- a/frontend/admin-dashboard/e2e/gallery-publish.spec.ts
+++ b/frontend/admin-dashboard/e2e/gallery-publish.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { server } from './msw-server';
+
+test.beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+test.afterAll(() => server.close());
+test.afterEach(() => server.resetHandlers());
+
+test('select mockup from gallery and publish', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByRole('link', { name: /gallery/i }).click();
+  await expect(page).toHaveURL(/dashboard\/gallery/);
+
+  const firstImage = page.getByRole('img').first();
+  await firstImage.click();
+
+  await expect(page).toHaveURL(/dashboard\/publish/);
+  await expect(page.getByTestId('selected-mockup')).toBeVisible();
+});

--- a/frontend/admin-dashboard/e2e/msw-server.ts
+++ b/frontend/admin-dashboard/e2e/msw-server.ts
@@ -1,0 +1,24 @@
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+export const handlers = [
+  rest.get('/api/health', (_req, res, ctx) => res(ctx.json({ api: 'ok' }))),
+  rest.get('http://localhost:8000/latency', (_req, res, ctx) =>
+    res(ctx.json({ average_seconds: 3600 }))
+  ),
+  rest.post('http://localhost:8000/trpc/signals.list', (_req, res, ctx) =>
+    res(ctx.json({ result: [{ id: 1, content: 'hello', source: 'test' }] }))
+  ),
+  rest.post('http://localhost:8000/trpc/gallery.list', (_req, res, ctx) =>
+    res(
+      ctx.json({
+        result: [{ id: 1, imageUrl: '/mock.png', title: 'Mockup 1' }],
+      })
+    )
+  ),
+  rest.post('http://localhost:8000/trpc/publishTasks.list', (_req, res, ctx) =>
+    res(ctx.json({ result: [] }))
+  ),
+];
+
+export const server = setupServer(...handlers);

--- a/frontend/admin-dashboard/e2e/offline.spec.ts
+++ b/frontend/admin-dashboard/e2e/offline.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { server } from './msw-server';
+
+test.beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+test.afterAll(() => server.close());
+test.afterEach(() => server.resetHandlers());
 
 // Ensure the dashboard can be loaded from cache when offline.
 test('dashboard accessible offline', async ({ page, context }) => {

--- a/frontend/admin-dashboard/playwright.config.ts
+++ b/frontend/admin-dashboard/playwright.config.ts
@@ -3,7 +3,8 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   testDir: './e2e',
   webServer: {
-    command: 'npm run build && npm start',
+    command:
+      '(cd ../.. && docker compose -f docker-compose.dev.yml -f docker-compose.test.yml up admin-dashboard)',
     port: 3000,
     timeout: 120_000,
     reuseExistingServer: true,

--- a/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import Image from 'next/image';
+import Link from 'next/link';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import { useGalleryItems } from '../../lib/trpc/hooks';
@@ -18,14 +19,15 @@ function GalleryPage() {
       ) : (
         <div className="grid grid-cols-3 gap-2">
           {items.map((item) => (
-            <Image
-              key={item.id}
-              src={item.imageUrl}
-              alt={item.title}
-              width={200}
-              height={200}
-              className="border"
-            />
+            <Link key={item.id} href={`/dashboard/publish?mockupId=${item.id}`}>
+              <Image
+                src={item.imageUrl}
+                alt={item.title}
+                width={200}
+                height={200}
+                className="border"
+              />
+            </Link>
           ))}
         </div>
       )}

--- a/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
@@ -3,14 +3,20 @@ import React from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import { useTranslation } from 'react-i18next';
 import { usePublishTasks } from '../../lib/trpc/hooks';
+import { useRouter } from 'next/router';
 
 function PublishPage() {
   const { t } = useTranslation();
   const { data: tasks, isLoading } = usePublishTasks();
+  const { query } = useRouter();
+  const mockupId = query.mockupId as string | undefined;
 
   return (
     <div className="space-y-2">
       <h1>{t('publishTasks')}</h1>
+      {mockupId && (
+        <p data-testid="selected-mockup">Publishing mockup {mockupId}</p>
+      )}
       {isLoading || !tasks ? (
         <div>{t('loading')}</div>
       ) : (

--- a/frontend/docs/testing.md
+++ b/frontend/docs/testing.md
@@ -1,0 +1,16 @@
+# End-to-End Testing
+
+This project uses **Playwright** for E2E tests located in `frontend/admin-dashboard/e2e`.
+The tests run against the dashboard Docker image via `docker compose`.
+
+## Running Tests Locally
+
+```bash
+npm run test:e2e
+```
+
+The command starts the dashboard container and executes Playwright with mocks powered by **MSW**.
+
+## Continuous Integration
+
+The CI workflow builds the dashboard image and runs the Playwright suite using that container. API calls are mocked so no external services are contacted.


### PR DESCRIPTION
## Summary
- add MSW server for Playwright
- test publishing a mockup from gallery
- link gallery items to the publish page
- show selected mockup on publish page
- run Playwright via docker compose in CI
- document e2e workflow

## Testing
- `python -m pip install -r requirements.txt -r requirements-dev.txt` *(fails: Getting requirements to build wheel did not run successfully)*
- `npm ci` *(fails: could not resolve dependency)*
- `python -m pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npx eslint frontend/admin-dashboard/src/pages/dashboard/gallery.tsx` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_687ea61b8efc83319382aec6618db439