### PR TITLE
Add connection pool metrics

### DIFF
--- a/backend/feedback-loop/feedback_loop/ab_testing.py
+++ b/backend/feedback-loop/feedback_loop/ab_testing.py
@@ -18,11 +18,12 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.pool import StaticPool
+from backend.shared.db import register_pool_metrics
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 import numpy as np
 
 
-class Base(DeclarativeBase):
+class Base(DeclarativeBase):  # type: ignore[misc]
     """Base class for ORM models."""
 
 
@@ -67,8 +68,10 @@ def create_engine_and_session(url: str) -> tuple[Session, sessionmaker]:
             connect_args={"check_same_thread": False},
             poolclass=StaticPool,
         )
+        register_pool_metrics(engine)
     else:
         engine = create_engine(url, future=True)
+        register_pool_metrics(engine)
     Base.metadata.create_all(engine)
     SessionLocal = sessionmaker(
         bind=engine,

--- a/backend/signal-ingestion/src/signal_ingestion/database.py
+++ b/backend/signal-ingestion/src/signal_ingestion/database.py
@@ -11,10 +11,12 @@ from collections.abc import AsyncGenerator
 
 from .models import Base
 from backend.shared.config import settings
+from backend.shared.db import register_pool_metrics
 
 
 DATABASE_URL = settings.effective_database_url
 engine = create_async_engine(DATABASE_URL, echo=False)
+register_pool_metrics(engine)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -51,6 +51,15 @@ The context manager `tasks.gpu_slot` updates two metrics:
 
 These metrics appear alongside existing ones on the ``/metrics`` endpoint.
 
+## Database Connection Metrics
+
+Each service now reports connection pool usage via two gauges:
+
+- ``db_pool_size`` – total size of the SQLAlchemy connection pool.
+- ``db_pool_in_use`` – currently checked out connections.
+
+Monitoring these values helps detect connection leaks and tune pool sizes.
+
 ## CDN Configuration
 
 Static assets are distributed through a CloudFront CDN for low latency delivery.

--- a/tests/test_db_metrics.py
+++ b/tests/test_db_metrics.py
@@ -1,0 +1,26 @@
+"""Verify Prometheus gauges for database pool usage."""
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
+
+from backend.shared.db import DB_POOL_IN_USE, DB_POOL_SIZE, register_pool_metrics
+
+
+def test_pool_metrics_change() -> None:
+    """Connection metrics should reflect acquired sessions."""
+    engine = create_engine("sqlite:///:memory:", poolclass=QueuePool)
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    register_pool_metrics(engine)
+
+    start_in_use = DB_POOL_IN_USE._value.get()
+    size = (
+        engine.pool.size()
+        if callable(getattr(engine.pool, "size", None))
+        else engine.pool.size
+    )
+    assert DB_POOL_SIZE._value.get() == size
+
+    with SessionLocal() as session:
+        session.execute(text("SELECT 1"))
+        assert DB_POOL_IN_USE._value.get() == start_in_use + 1


### PR DESCRIPTION
## Summary
- expose `db_pool_size` and `db_pool_in_use` gauges
- register pool metrics for async and sync engines
- integrate pool metrics into signal-ingestion and feedback-loop
- test that acquiring sessions updates metrics
- document database connection metrics

## Testing
- `pytest tests/test_db_metrics.py -vv -W error --cov=backend/shared/db/__init__.py --cov-report=term --cov-fail-under=0`
- `make -C docs html` *(fails: ModuleNotFoundError: No module named 'ldclient')*

------
https://chatgpt.com/codex/tasks/task_b_687ea61855108331aa873c42d0278f03