### PR TITLE
Add unique content_hash to Signal models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Features
 
 - Add kafka utilities and schema registry
+- Enforce unique ``content_hash`` on ``signals`` table
 - *(i18n)* Add i18next integration
 - *(frontend)* Add aria labels and accessibility tests
 - *(analytics)* Add analytics service

--- a/backend/shared/db/migrations/scoring_engine/versions/0016_add_content_hash_to_signals.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0016_add_content_hash_to_signals.py
@@ -1,0 +1,28 @@
+"""Add unique content_hash column to signals."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add content_hash column."""
+    op.add_column(
+        "signals",
+        sa.Column("content_hash", sa.String(length=32), nullable=False),
+    )
+    op.create_unique_constraint(
+        op.f("uq_signals_content_hash"), "signals", ["content_hash"]
+    )
+
+
+def downgrade() -> None:
+    """Remove content_hash column."""
+    op.drop_constraint(op.f("uq_signals_content_hash"), "signals", type_="unique")
+    op.drop_column("signals", "content_hash")

--- a/backend/shared/db/migrations/signal_ingestion/versions/0003_add_content_hash_column.py
+++ b/backend/shared/db/migrations/signal_ingestion/versions/0003_add_content_hash_column.py
@@ -1,0 +1,28 @@
+"""Add unique content_hash column to signals."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003"
+down_revision = "08af30763bce"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add content_hash column."""
+    op.add_column(
+        "signals",
+        sa.Column("content_hash", sa.String(length=32), nullable=False),
+    )
+    op.create_unique_constraint(
+        op.f("uq_signals_content_hash"), "signals", ["content_hash"]
+    )
+
+
+def downgrade() -> None:
+    """Remove content_hash column."""
+    op.drop_constraint(op.f("uq_signals_content_hash"), "signals", type_="unique")
+    op.drop_column("signals", "content_hash")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -36,6 +36,7 @@ class Signal(Base):
     timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     engagement_rate: Mapped[float] = mapped_column(Float)
     details: Mapped[str | None] = mapped_column(String, nullable=True)
+    content_hash: Mapped[str] = mapped_column(String(32), unique=True)
 
     idea: Mapped[Idea] = relationship(back_populates="signals")
 

--- a/backend/signal-ingestion/src/signal_ingestion/models.py
+++ b/backend/signal-ingestion/src/signal_ingestion/models.py
@@ -21,5 +21,6 @@ class Signal(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     source: Mapped[str] = mapped_column(String(50))
     content: Mapped[str] = mapped_column(String)
+    content_hash: Mapped[str] = mapped_column(String(32), unique=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     embedding: Mapped[list[float] | None] = mapped_column(Vector(768), nullable=True)

--- a/tests/integration/test_pipeline_metrics.py
+++ b/tests/integration/test_pipeline_metrics.py
@@ -89,6 +89,7 @@ async def test_pipeline_with_metrics(
                 signal = models.Signal(
                     source=adapter.__class__.__name__,
                     content=str(row),
+                    content_hash=f"{adapter.__class__.__name__}:{row['id']}",
                     timestamp=datetime.now(timezone.utc),
                     embedding=[0.0, 0.0],
                 )

--- a/tests/test_signal_constraints.py
+++ b/tests/test_signal_constraints.py
@@ -1,0 +1,41 @@
+"""Tests for signal database constraints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from backend.shared.db import Base, SessionLocal, engine
+from backend.shared.db.models import Signal
+
+
+def setup_module(module: object) -> None:
+    """Create tables for tests."""
+    Base.metadata.create_all(engine)
+
+
+def teardown_module(module: object) -> None:
+    """Drop tables after tests."""
+    Base.metadata.drop_all(engine)
+
+
+def test_signal_content_hash_unique() -> None:
+    """Duplicated content_hash should raise an integrity error."""
+    with SessionLocal() as session:
+        sig1 = Signal(
+            content_hash="dup",
+            timestamp=datetime.utcnow(),
+            engagement_rate=0.5,
+        )
+        session.add(sig1)
+        session.commit()
+        sig2 = Signal(
+            content_hash="dup",
+            timestamp=datetime.utcnow(),
+            engagement_rate=0.7,
+        )
+        session.add(sig2)
+        with pytest.raises(IntegrityError):
+            session.commit()


### PR DESCRIPTION
## Summary
- add `content_hash` field to `Signal` models
- create Alembic migrations for new column
- ensure pipeline metric tests use new column
- add tests for the constraint
- document schema update in changelog

## Testing
- `flake8 backend/shared/db/models.py backend/signal-ingestion/src/signal_ingestion/models.py tests/integration/test_pipeline_metrics.py tests/test_signal_constraints.py backend/shared/db/migrations/scoring_engine/versions/0016_add_content_hash_to_signals.py backend/shared/db/migrations/signal_ingestion/versions/0003_add_content_hash_column.py`
- `mypy backend/shared/db/models.py backend/signal-ingestion/src/signal_ingestion/models.py --ignore-missing-imports`
- `pytest -q` *(fails: 69 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687eadaf95d8833193731fd77bf569b8