### PR TITLE
Add Grafana dashboards and configure Helm sidecar

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -36,10 +36,15 @@ docker compose -f docker-compose.yml -f docker-compose.tracing.yml up -d otel-co
 
 ## Grafana Dashboards
 
-Prebuilt dashboard JSON files reside in `infrastructure/grafana` and
-`infrastructure/grafana/dashboards`.
+Prebuilt dashboard JSON files reside in `infrastructure/grafana/dashboards`.
 Import them into Grafana via **Dashboards → Import** and select the
-TimescaleDB data source when prompted.
+TimescaleDB data source when prompted. Dashboards are automatically
+loaded when deploying via Helm because `grafana.sidecar.dashboards` is
+enabled.
 
-The optimization metrics board is available at
-`infrastructure/grafana/dashboards/optimization.json`.
+Dashboards include:
+
+- `latency.json`
+- `queue_length.json`
+- `resource_usage.json`
+- `optimization.json`

--- a/infrastructure/grafana/dashboards/latency.json
+++ b/infrastructure/grafana/dashboards/latency.json
@@ -1,0 +1,25 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "TimescaleDB",
+      "type": "timeseries",
+      "title": "Average Publish Latency",
+      "targets": [
+        {
+          "rawSql": "SELECT bucket AS time, avg_latency FROM latency_hourly ORDER BY bucket",
+          "refId": "A",
+          "format": "time_series"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 30,
+  "title": "Latency Overview",
+  "version": 1
+}

--- a/infrastructure/grafana/dashboards/queue_length.json
+++ b/infrastructure/grafana/dashboards/queue_length.json
@@ -9,21 +9,17 @@
     {
       "datasource": "TimescaleDB",
       "type": "timeseries",
-      "title": "Average Publish Latency",
+      "title": "Average Queue Length",
       "targets": [
         {
-          "rawSql": "SELECT bucket AS time, avg_latency FROM latency_hourly ORDER BY bucket",
+          "rawSql": "SELECT bucket AS time, avg_queue_length FROM queue_metrics ORDER BY bucket",
           "refId": "A",
           "format": "time_series"
         }
       ]
     }
   ],
-  "schemaVersion": 38,
-  "style": "dark",
-  "time": {"from": "now-24h", "to": "now"},
-  "timepicker": {},
-  "timezone": "browser",
-  "title": "Latency Overview",
+  "schemaVersion": 30,
+  "title": "Queue Length Overview",
   "version": 1
 }

--- a/infrastructure/grafana/dashboards/resource_usage.json
+++ b/infrastructure/grafana/dashboards/resource_usage.json
@@ -9,21 +9,17 @@
     {
       "datasource": "TimescaleDB",
       "type": "timeseries",
-      "title": "Average Score",
+      "title": "CPU and Memory Usage",
       "targets": [
         {
-          "rawSql": "SELECT time_bucket('1 hour', timestamp) AS time, AVG(score) FROM scores GROUP BY time ORDER BY time",
+          "rawSql": "SELECT bucket AS time, cpu_usage, memory_usage FROM resource_usage ORDER BY bucket",
           "refId": "A",
           "format": "time_series"
         }
       ]
     }
   ],
-  "schemaVersion": 38,
-  "style": "dark",
-  "time": {"from": "now-24h", "to": "now"},
-  "timepicker": {},
-  "timezone": "browser",
-  "title": "Score Overview",
+  "schemaVersion": 30,
+  "title": "Resource Usage Overview",
   "version": 1
 }

--- a/infrastructure/helm/all-services/values-dev.yaml
+++ b/infrastructure/helm/all-services/values-dev.yaml
@@ -33,3 +33,11 @@ backup-jobs:
 logrotate-jobs:
   image:
     tag: latest
+
+# Grafana configuration
+grafana:
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      searchNamespace: ALL

--- a/infrastructure/helm/all-services/values-prod.yaml
+++ b/infrastructure/helm/all-services/values-prod.yaml
@@ -33,3 +33,11 @@ backup-jobs:
 logrotate-jobs:
   image:
     tag: latest
+
+# Grafana configuration
+grafana:
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      searchNamespace: ALL

--- a/infrastructure/helm/all-services/values-production.yaml
+++ b/infrastructure/helm/all-services/values-production.yaml
@@ -33,3 +33,11 @@ backup-jobs:
 logrotate-jobs:
   image:
     tag: latest
+
+# Grafana configuration
+grafana:
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      searchNamespace: ALL

--- a/infrastructure/helm/all-services/values-staging.yaml
+++ b/infrastructure/helm/all-services/values-staging.yaml
@@ -33,3 +33,11 @@ backup-jobs:
 logrotate-jobs:
   image:
     tag: latest
+
+# Grafana configuration
+grafana:
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      searchNamespace: ALL

--- a/infrastructure/helm/all-services/values.yaml
+++ b/infrastructure/helm/all-services/values.yaml
@@ -159,3 +159,11 @@ monitoring:
     maxReplicas: 5
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 70
+
+# Grafana configuration
+grafana:
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      searchNamespace: ALL


### PR DESCRIPTION
## Summary
- add latency, queue length and resource usage dashboards
- configure Grafana sidecar in Helm values
- update monitoring docs

## Testing
- `flake8`
- `pydocstyle docs/monitoring.md`
- `docformatter --check docs/monitoring.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687eb13c0b1083319c932f9e9afabf25