### PR TITLE
Implement WebSocket throttling

### DIFF
--- a/backend/api-gateway/.env.example
+++ b/backend/api-gateway/.env.example
@@ -22,3 +22,6 @@ KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
 # Error Tracking
 SENTRY_DSN=
+
+# WebSocket update interval in milliseconds
+API_GATEWAY_WS_INTERVAL_MS=5000

--- a/backend/api-gateway/README.md
+++ b/backend/api-gateway/README.md
@@ -5,3 +5,6 @@ This microservice exposes REST and tRPC-compatible endpoints and uses JWT authen
 ## Environment Variables
 
 Copy `.env.example` to `.env` and adjust the values.
+
+`API_GATEWAY_WS_INTERVAL_MS` controls how often metrics are pushed over
+WebSocket connections.

--- a/backend/api-gateway/docs/index.rst
+++ b/backend/api-gateway/docs/index.rst
@@ -8,3 +8,9 @@ Metrics
 -------
 
 Prometheus metrics are exposed at ``/metrics``.
+
+Environment Variables
+---------------------
+
+``API_GATEWAY_WS_INTERVAL_MS``
+    Interval in milliseconds between WebSocket metric updates.

--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -579,6 +579,7 @@ async def retry_publish_task(
 async def metrics_ws(websocket: WebSocket) -> None:
     """Stream monitoring metrics to the connected client."""
     await websocket.accept()
+    await websocket.send_json({"interval_ms": settings.ws_interval_ms})
     try:
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
             while True:
@@ -590,7 +591,7 @@ async def metrics_ws(websocket: WebSocket) -> None:
                 if analytics.status_code == 200:
                     data.update(cast(Dict[str, Any], analytics.json()))
                 await websocket.send_json(data)
-                await asyncio.sleep(5)
+                await asyncio.sleep(settings.ws_interval_ms / 1000)
     except WebSocketDisconnect:
         return
 

--- a/backend/api-gateway/src/api_gateway/settings.py
+++ b/backend/api-gateway/src/api_gateway/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pydantic import RedisDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -17,8 +18,9 @@ class Settings(BaseSettings):
     redis_url: RedisDsn = RedisDsn(shared_settings.redis_url)
     rate_limit_per_user: int = 60
     rate_limit_window: int = 60
+    ws_interval_ms: int = int(os.environ.get("API_GATEWAY_WS_INTERVAL_MS", "5000"))
 
-    @field_validator("rate_limit_per_user", "rate_limit_window")
+    @field_validator("rate_limit_per_user", "rate_limit_window", "ws_interval_ms")
     @classmethod
     def _positive(cls, value: int) -> int:
         if value <= 0:


### PR DESCRIPTION
## Summary
- add `API_GATEWAY_WS_INTERVAL_MS` env var with docs
- throttle metrics WebSocket using the configured interval
- expose interval in WebSocket payload
- respect server interval in frontend hook
- adjust websocket tests for interval handshake

## Testing
- `flake8 backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/src/api_gateway/settings.py backend/api-gateway/tests/test_ws_metrics.py backend/api-gateway/tests/test_metrics_ws.py`
- `mypy backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/src/api_gateway/settings.py --ignore-missing-imports` *(fails: missing stubs)*
- `pytest backend/api-gateway/tests/test_ws_metrics.py backend/api-gateway/tests/test_metrics_ws.py` *(fails: tests not passing)*

------
https://chatgpt.com/codex/tasks/task_b_687eb137d33c8331b6fe44d3feaca562