### PR TITLE
Add API key check for readiness endpoints

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Any, Callable, Coroutine, Dict, Iterable, cast
 
 from fastapi import Depends, FastAPI, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func
@@ -227,6 +228,7 @@ async def health() -> Response:
 
 
 @app.get("/ready")  # type: ignore[misc]
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -17,7 +17,7 @@ from .routes import router
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
-from backend.shared.security import add_security_headers
+from backend.shared.security import add_security_headers, require_status_api_key
 from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared.db import run_migrations_if_needed
@@ -167,8 +167,9 @@ async def health() -> Response:
 
 
 @app.get("/ready", tags=["Status"], summary="Service readiness")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Any, Callable, Coroutine
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
@@ -84,8 +85,9 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -30,6 +30,7 @@ from backend.shared.security import add_security_headers
 from backend.shared.tracing import configure_tracing
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, ConfigDict  # noqa: I201
 
@@ -381,8 +382,9 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Callable, Coroutine
 
 from fastapi import FastAPI, HTTPException, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -100,8 +101,9 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -14,6 +14,7 @@ from backend.shared.http import DEFAULT_TIMEOUT
 
 import psutil
 from fastapi import FastAPI, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import Histogram
 from backend.shared.metrics import register_metrics
@@ -250,8 +251,9 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -13,6 +13,7 @@ import uuid
 from typing import Callable, Coroutine, List, cast
 
 from fastapi import FastAPI, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -180,6 +181,7 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Callable, Coroutine, cast
 
 from fastapi import FastAPI, HTTPException, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from backend.shared.cache import AsyncRedis, get_async_client
@@ -380,8 +381,9 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Callable, Coroutine, cast
 
 from fastapi import FastAPI, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 
 from .logging_config import configure_logging
@@ -89,8 +90,9 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     allowed_origins: list[str] = Field(default_factory=list)
     content_security_policy: str | None = None
     hsts: str | None = None
+    allow_status_unauthenticated: bool = True
 
     @field_validator("allowed_origins", mode="before")  # type: ignore[misc]
     @classmethod

--- a/backend/shared/security.py
+++ b/backend/shared/security.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Callable, Coroutine
 
 from fastapi import FastAPI, Request, Response
+from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .config import settings
@@ -30,3 +31,11 @@ def add_security_headers(app: FastAPI) -> None:
         return response
 
     app.add_middleware(BaseHTTPMiddleware, dispatch=_set_headers)
+
+
+def require_status_api_key(request: Request) -> None:
+    """Validate API key header for readiness endpoints."""
+    if not settings.allow_status_unauthenticated and not request.headers.get(
+        "X-API-Key"
+    ):
+        raise HTTPException(status_code=401, detail="missing api key")

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -9,6 +9,7 @@ from typing import Callable, Coroutine, cast
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from fastapi import Depends, FastAPI, Request, Response
+from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 
 from .database import get_session, init_db
@@ -101,8 +102,9 @@ async def health() -> Response:
 
 
 @app.get("/ready")
-async def ready() -> Response:
+async def ready(request: Request) -> Response:
     """Return service readiness."""
+    require_status_api_key(request)
     return json_cached({"status": "ready"})
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ application settings classes.
 | `LOG_LEVEL` | Logging verbosity |
 | `APPROVAL_SERVICE_URL` | Base URL of the manual approval service |
 | `ALLOWED_ORIGINS` | Comma separated whitelist of origins for CORS |
+| `ALLOW_STATUS_UNAUTHENTICATED` | Set to `false` to require an API key for `/ready` |
 | `WEIGHTS_TOKEN` | Token required for updating scoring weights |
 | `ENABLED_ADAPTERS` | Comma separated list of ingestion adapters to run; if unset all adapters are used |
 | `PAGERDUTY_ROUTING_KEY` | Integration key for sending PagerDuty incidents |

--- a/docs/security.md
+++ b/docs/security.md
@@ -60,3 +60,11 @@ header. The value is an HMAC SHA-256 digest of the raw request body using a
 secret unique to each marketplace. Secrets are stored under ``secrets/`` and are
 loaded by the settings module from ``/run/secrets`` in production. Requests
 without a valid signature are rejected with ``403 Forbidden``.
+
+## Health endpoints
+
+Each service exposes ``/health`` and ``/ready`` for liveness and readiness
+checks. ``/health`` is always public. Access to ``/ready`` can be restricted by
+setting the ``ALLOW_STATUS_UNAUTHENTICATED`` environment variable to ``false``.
+When disabled, clients must include an ``X-API-Key`` header. This allows public
+liveness checks while keeping readiness information private.

--- a/tests/test_ready_auth.py
+++ b/tests/test_ready_auth.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+SERVICES = [
+    ("backend/service-template/src", "main"),
+    ("backend/api-gateway/src", "api_gateway.main"),
+    ("backend/signal-ingestion/src", "signal_ingestion.main"),
+    ("backend/feedback-loop/feedback_loop", "feedback_loop.main"),
+    ("backend/marketplace-publisher/src", "marketplace_publisher.main"),
+    ("backend/mockup-generation/mockup_generation", "mockup_generation.api"),
+    ("backend/analytics", "backend.analytics.api"),
+    ("backend/optimization", "backend.optimization.api"),
+    ("backend/scoring-engine/scoring_engine", "scoring_engine.app"),
+    ("backend/monitoring/src", "monitoring.main"),
+]
+
+
+@pytest.mark.parametrize("base,module", SERVICES)
+def test_ready_requires_api_key(
+    base: str, module: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``/ready`` returns 401 without API key when unauthenticated access is
+    disabled."""
+    monkeypatch.setenv("ALLOW_STATUS_UNAUTHENTICATED", "false")
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / base))
+    mod = importlib.import_module(module)
+    importlib.reload(mod)
+    app = getattr(mod, "app")
+    with TestClient(app) as client:
+        resp = client.get("/ready")
+        assert resp.status_code == 401
+        resp = client.get("/ready", headers={"X-API-Key": "test"})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- enforce `ALLOW_STATUS_UNAUTHENTICATED` for `/ready` across all services
- require API key if unauthenticated access is disabled
- document the new configuration option and secure health endpoints
- add regression tests for API key requirement

## Testing
- `flake8 backend/shared/config.py backend/shared/security.py backend/service-template/src/main.py backend/api-gateway/src/api_gateway/main.py backend/analytics/api.py backend/feedback-loop/feedback_loop/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/monitoring/src/monitoring/main.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py tests/test_ready_auth.py`
- `pydocstyle backend/shared/config.py backend/shared/security.py backend/service-template/src/main.py backend/api-gateway/src/api_gateway/main.py backend/analytics/api.py backend/feedback-loop/feedback_loop/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/monitoring/src/monitoring/main.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py tests/test_ready_auth.py docs/security.md docs/configuration.md`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pytest -q tests/test_ready_auth.py tests/test_api.py tests/test_monitoring.py backend/api-gateway/tests/test_health.py backend/feedback-loop/tests/test_health.py backend/scoring-engine/tests/test_health.py` *(fails: ModuleNotFoundError: No module named 'sentry_sdk')*

------
https://chatgpt.com/codex/tasks/task_b_687eb13a67008331ad5b987b69b31a76