### PR TITLE
Implement scheduler shutdown logic

### DIFF
--- a/backend/feedback-loop/README.md
+++ b/backend/feedback-loop/README.md
@@ -5,3 +5,9 @@ This service manages user feedback processing and periodic weight updates.
 ## Environment Variables
 
 Copy `.env.example` to `.env` and adjust the values for your environment.
+
+## Scheduler lifecycle
+
+The service creates a single APScheduler instance during application startup.
+The scheduler runs background ingestion and weight update jobs and is stopped
+gracefully when the FastAPI application shuts down.

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import uuid
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, Coroutine, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from apscheduler.schedulers.background import BackgroundScheduler
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
@@ -29,6 +31,9 @@ app.add_middleware(
 register_metrics(app)
 add_security_headers(app)
 logger = logging.getLogger(__name__)
+
+# BackgroundScheduler instance running application tasks
+scheduler: Optional[BackgroundScheduler] = None
 
 
 class AllocationResponse(BaseModel):
@@ -51,16 +56,31 @@ manager = ABTestManager(
 
 
 async def startup() -> None:
-    """Start background scheduler."""
+    """Start background scheduler and setup exception logging."""
+    global scheduler
     # Import here to avoid heavy dependencies at module import time
     from .scheduler import setup_scheduler
 
-    # Setup scheduler with no-op defaults for health endpoints
     scheduler = setup_scheduler([], "")
     scheduler.start()
 
+    def log_unhandled(
+        exc_type: type[BaseException], exc: BaseException, tb: object
+    ) -> None:
+        """Log any unhandled exception before exiting."""
+        logger.exception("Unhandled exception", exc_info=(exc_type, exc, tb))
+
+    sys.excepthook = log_unhandled
+
+
+async def shutdown() -> None:
+    """Stop the background scheduler."""
+    if scheduler:
+        scheduler.shutdown()
+
 
 app.add_event_handler("startup", startup)
+app.add_event_handler("shutdown", shutdown)
 
 
 @app.middleware("http")

--- a/backend/feedback-loop/tests/test_lifecycle.py
+++ b/backend/feedback-loop/tests/test_lifecycle.py
@@ -1,0 +1,42 @@
+"""Lifecycle tests for startup and shutdown."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+import feedback_loop.main as main  # noqa: E402
+
+
+class DummyScheduler:
+    """Capture start and shutdown calls."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def shutdown(self) -> None:
+        self.stopped = True
+
+
+def test_scheduler_shutdown(monkeypatch) -> None:
+    """Scheduler should be stopped on application shutdown."""
+    dummy = DummyScheduler()
+
+    def fake_setup_scheduler(*_: object, **__: object) -> DummyScheduler:
+        return dummy
+
+    import feedback_loop.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "setup_scheduler", fake_setup_scheduler)
+
+    with TestClient(main.app) as client:
+        assert dummy.started
+        client.get("/health")
+    assert dummy.stopped


### PR DESCRIPTION
## Summary
- shutdown the APScheduler instance on FastAPI shutdown
- log unhandled exceptions via a custom excepthook
- test the scheduler lifecycle
- ensure integration tests include role claims
- document scheduler lifecycle

## Testing
- `pytest backend/feedback-loop/tests/test_lifecycle.py backend/feedback-loop/tests/test_main.py backend/feedback-loop/tests/test_scheduler.py backend/feedback-loop/tests/test_health.py`

------
https://chatgpt.com/codex/tasks/task_b_687eb13ae4f88331924bc364fd968431