### PR TITLE
Implement normalization schema and dedup startup init

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -16,6 +16,7 @@ from .database import get_session, init_db
 from backend.shared.db import run_migrations_if_needed
 from .scheduler import create_scheduler
 from .ingestion import ingest
+from . import dedup
 from .trending import get_top_keywords
 from .logging_config import configure_logging
 from .settings import settings
@@ -57,6 +58,9 @@ async def startup() -> None:
     """Initialize resources."""
     await run_migrations_if_needed("backend/shared/db/alembic_signal_ingestion.ini")
     await init_db()
+    dedup.initialize(
+        settings.dedup_error_rate, settings.dedup_capacity, settings.dedup_ttl
+    )
     scheduler.start()
 
 

--- a/backend/signal-ingestion/src/signal_ingestion/normalization.py
+++ b/backend/signal-ingestion/src/signal_ingestion/normalization.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict
 
 
 @dataclass
-class NormalizedSignal:
+class Signal:
     """Standard representation of an ingested signal."""
 
     id: str
@@ -18,6 +18,10 @@ class NormalizedSignal:
     def asdict(self) -> Dict[str, Any]:
         """Return the signal as a plain dictionary."""
         return asdict(self)
+
+
+# Backwards compatibility alias until all call sites are updated
+NormalizedSignal = Signal
 
 
 def _extract_between(text: str | None, start: str, end: str) -> str:
@@ -32,12 +36,12 @@ def _extract_between(text: str | None, start: str, end: str) -> str:
     return text[s:e] if e != -1 else text[s:]
 
 
-def normalize_tiktok(data: Dict[str, Any]) -> NormalizedSignal:
-    """Normalize TikTok API response into a :class:`NormalizedSignal`."""
+def normalize_tiktok(data: Dict[str, Any]) -> Signal:
+    """Normalize TikTok API response into a :class:`Signal`."""
     video_id = data.get("embed_product_id") or _extract_between(
         data.get("html"), 'data-video-id="', '"'
     )
-    return NormalizedSignal(
+    return Signal(
         id=str(video_id),
         title=data.get("title"),
         url=data.get("author_url"),
@@ -45,9 +49,9 @@ def normalize_tiktok(data: Dict[str, Any]) -> NormalizedSignal:
     )
 
 
-def normalize_instagram(data: Dict[str, Any]) -> NormalizedSignal:
-    """Normalize Instagram data into a :class:`NormalizedSignal`."""
-    return NormalizedSignal(
+def normalize_instagram(data: Dict[str, Any]) -> Signal:
+    """Normalize Instagram data into a :class:`Signal`."""
+    return Signal(
         id=str(data.get("id", "")),
         title=data.get("caption") or data.get("title") or data.get("author_name"),
         url=data.get("permalink") or data.get("author_url"),
@@ -55,8 +59,8 @@ def normalize_instagram(data: Dict[str, Any]) -> NormalizedSignal:
     )
 
 
-def normalize_reddit(data: Dict[str, Any]) -> NormalizedSignal:
-    """Normalize Reddit data into a :class:`NormalizedSignal`."""
+def normalize_reddit(data: Dict[str, Any]) -> Signal:
+    """Normalize Reddit data into a :class:`Signal`."""
     if "data" in data:
         post = data["data"]["children"][0]["data"]
         post_id = post["id"]
@@ -66,13 +70,13 @@ def normalize_reddit(data: Dict[str, Any]) -> NormalizedSignal:
         post_id = str(data.get("id", ""))
         title = data.get("title")
         url = None
-    return NormalizedSignal(id=post_id, title=title, url=url, source="reddit")
+    return Signal(id=post_id, title=title, url=url, source="reddit")
 
 
-def normalize_youtube(data: Dict[str, Any]) -> NormalizedSignal:
-    """Normalize YouTube data into a :class:`NormalizedSignal`."""
+def normalize_youtube(data: Dict[str, Any]) -> Signal:
+    """Normalize YouTube data into a :class:`Signal`."""
     video_id = _extract_between(data.get("html"), "embed/", "?")
-    return NormalizedSignal(
+    return Signal(
         id=video_id,
         title=data.get("title"),
         url=data.get("url"),
@@ -80,9 +84,9 @@ def normalize_youtube(data: Dict[str, Any]) -> NormalizedSignal:
     )
 
 
-def normalize_events(data: Dict[str, Any]) -> NormalizedSignal:
-    """Normalize event data into a :class:`NormalizedSignal`."""
-    return NormalizedSignal(
+def normalize_events(data: Dict[str, Any]) -> Signal:
+    """Normalize event data into a :class:`Signal`."""
+    return Signal(
         id=data["date"],
         title=data["name"],
         url=None,
@@ -90,11 +94,11 @@ def normalize_events(data: Dict[str, Any]) -> NormalizedSignal:
     )
 
 
-def normalize_nostalgia(data: Dict[str, Any]) -> NormalizedSignal:
-    """Normalize Internet Archive data into a :class:`NormalizedSignal`."""
+def normalize_nostalgia(data: Dict[str, Any]) -> Signal:
+    """Normalize Internet Archive data into a :class:`Signal`."""
     doc = data["response"]["docs"][0]
     identifier = doc.get("identifier", "")
-    return NormalizedSignal(
+    return Signal(
         id=identifier,
         title=doc.get("title"),
         url=f"https://archive.org/details/{identifier}" if identifier else None,
@@ -102,7 +106,7 @@ def normalize_nostalgia(data: Dict[str, Any]) -> NormalizedSignal:
     )
 
 
-NORMALIZERS: Dict[str, Callable[[Dict[str, Any]], NormalizedSignal]] = {
+NORMALIZERS: Dict[str, Callable[[Dict[str, Any]], Signal]] = {
     "tiktok": normalize_tiktok,
     "instagram": normalize_instagram,
     "reddit": normalize_reddit,
@@ -112,8 +116,8 @@ NORMALIZERS: Dict[str, Callable[[Dict[str, Any]], NormalizedSignal]] = {
 }
 
 
-def normalize(source: str, data: Dict[str, Any]) -> NormalizedSignal:
-    """Normalize ``data`` from ``source`` into a :class:`NormalizedSignal`."""
+def normalize(source: str, data: Dict[str, Any]) -> Signal:
+    """Normalize ``data`` from ``source`` into a :class:`Signal`."""
     if source not in NORMALIZERS:
         raise ValueError(f"Unknown source: {source}")
     return NORMALIZERS[source](data)

--- a/backend/signal-ingestion/src/signal_ingestion/tasks.py
+++ b/backend/signal-ingestion/src/signal_ingestion/tasks.py
@@ -20,10 +20,10 @@ from .adapters.youtube import YouTubeAdapter
 from .celery_app import app
 from .database import SessionLocal
 from .dedup import add_key, is_duplicate
-from .models import Signal
+from .models import Signal as DBSignal
 from .embedding import generate_embedding
 from .privacy import purge_row
-from .normalization import NormalizedSignal, normalize
+from .normalization import Signal as NormalizedSignal, normalize
 from .publisher import publish
 from .retention import purge_old_signals
 from .settings import settings
@@ -87,7 +87,7 @@ async def _ingest_from_adapter(session: AsyncSession, adapter: BaseAdapter) -> N
         add_key(key)
         clean_row = purge_row(signal_data.asdict())
         sanitized_json = json.dumps(clean_row)
-        signal = Signal(
+        signal = DBSignal(
             source=adapter.__class__.__name__,
             content=sanitized_json,
             embedding=generate_embedding(sanitized_json),

--- a/backend/signal-ingestion/tests/test_duplicate_detection.py
+++ b/backend/signal-ingestion/tests/test_duplicate_detection.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy import select
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from signal_ingestion import database, tasks
+from signal_ingestion.adapters.base import BaseAdapter
+from signal_ingestion.models import Signal
+
+
+class DummyAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        super().__init__(base_url="")
+
+    async def fetch(self) -> list[dict[str, object]]:
+        return [{"id": 1, "title": "a", "url": "u"}]
+
+
+@pytest.mark.asyncio()
+async def test_duplicate_rows_are_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    database.engine = engine
+    database.SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    await database.init_db()
+
+    called = []
+    monkeypatch.setattr(tasks, "publish", lambda *a, **k: called.append(a))
+    monkeypatch.setattr(tasks, "is_duplicate", lambda key: True)
+    monkeypatch.setattr(tasks, "add_key", lambda key: None)
+    monkeypatch.setattr(tasks, "store_keywords", lambda *a, **k: None)
+
+    async with database.SessionLocal() as session:
+        await tasks._ingest_from_adapter(session, DummyAdapter())
+        row = (await session.execute(select(Signal))).scalars().first()
+
+    assert row is None
+    assert called == []

--- a/backend/signal-ingestion/tests/test_normalization.py
+++ b/backend/signal-ingestion/tests/test_normalization.py
@@ -24,6 +24,7 @@ from signal_ingestion.normalization import normalize
 
 ADAPTERS: list[tuple[Type[object], str]] = [
     (TikTokAdapter, "tiktok"),
+    (InstagramAdapter, "instagram"),
     (RedditAdapter, "reddit"),
     (YouTubeAdapter, "youtube"),
     (EventsAdapter, "events"),
@@ -36,7 +37,8 @@ ADAPTERS: list[tuple[Type[object], str]] = [
 async def test_normalize_success(adapter_cls: Type[object], name: str) -> None:
     """Adapter fetch results can be normalized."""
     adapter = adapter_cls()
-    cassette = f"backend/signal-ingestion/tests/cassettes/{name}_real.yaml"
+    suffix = "_real" if name != "instagram" else ""
+    cassette = f"backend/signal-ingestion/tests/cassettes/{name}{suffix}.yaml"
     with vcr.use_cassette(cassette, record_mode="new_episodes"):
         rows = await adapter.fetch()
     sig = normalize(name, rows[0])

--- a/backend/signal-ingestion/tests/test_parallel_ingestion.py
+++ b/backend/signal-ingestion/tests/test_parallel_ingestion.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from signal_ingestion import database, tasks
-from signal_ingestion.normalization import NormalizedSignal
+from signal_ingestion.normalization import Signal as NormalizedSignal
 from signal_ingestion.adapters.base import BaseAdapter
-from signal_ingestion.models import Signal
+from signal_ingestion.models import Signal as DBSignal
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy import select
 import pytest
@@ -68,7 +68,7 @@ async def test_ingest_from_adapter_publishes(monkeypatch: pytest.MonkeyPatch) ->
 
     async with database.SessionLocal() as session:
         await tasks._ingest_from_adapter(session, DummyAdapter())
-        row = (await session.execute(select(Signal))).scalars().first()
+        row = (await session.execute(select(DBSignal))).scalars().first()
 
     assert row is not None
     assert isinstance(row.embedding, list)
@@ -114,7 +114,7 @@ async def test_ingest_from_adapter_redacts_pii(monkeypatch: pytest.MonkeyPatch) 
 
     async with database.SessionLocal() as session:
         await tasks._ingest_from_adapter(session, DummyAdapter())
-        row = (await session.execute(select(Signal))).scalars().first()
+        row = (await session.execute(select(DBSignal))).scalars().first()
 
     assert row is not None
     assert "user@example.com" not in row.content

--- a/backend/signal-ingestion/tests/test_startup.py
+++ b/backend/signal-ingestion/tests/test_startup.py
@@ -1,0 +1,67 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio()
+async def test_dedup_initialized_on_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+    sys.modules.setdefault("pgvector.sqlalchemy", SimpleNamespace(Vector=lambda *a, **k: None))
+    sys.modules.setdefault(
+        "signal_ingestion.database",
+        SimpleNamespace(get_session=lambda: None, init_db=lambda: None, SessionLocal=lambda: None),
+    )
+    sys.modules.setdefault(
+        "signal_ingestion.models", SimpleNamespace(Base=object, Signal=object)
+    )
+    sys.modules.setdefault(
+        "celery", SimpleNamespace(Celery=lambda *a, **k: SimpleNamespace(conf=SimpleNamespace()))
+    )
+    scheduler = SimpleNamespace(start=lambda: None, shutdown=lambda: None)
+    sys.modules.setdefault(
+        "signal_ingestion.scheduler", SimpleNamespace(create_scheduler=lambda: scheduler)
+    )
+    sys.modules.setdefault(
+        "signal_ingestion.ingestion", SimpleNamespace(ingest=lambda *a, **k: None)
+    )
+    sys.modules.setdefault("signal_ingestion.tasks", SimpleNamespace())
+    sys.modules.setdefault(
+        "signal_ingestion.publisher", SimpleNamespace(publish=lambda *a, **k: None)
+    )
+
+    called = False
+
+    def fake_init(*_args: object) -> None:
+        nonlocal called
+        called = True
+
+    sys.modules["signal_ingestion.dedup"] = SimpleNamespace(
+        add_key=lambda *a, **k: None,
+        is_duplicate=lambda *a, **k: False,
+        initialize=fake_init,
+    )
+
+    sys.modules.setdefault(
+        "backend.shared.kafka.schema_registry",
+        SimpleNamespace(SchemaRegistryClient=lambda *a, **k: None),
+    )
+    sys.modules.setdefault(
+        "kafka",
+        SimpleNamespace(
+            KafkaProducer=lambda *a, **k: SimpleNamespace(send=lambda *a, **k: None, flush=lambda: None),
+            KafkaConsumer=object,
+        ),
+    )
+    sys.modules.setdefault(
+        "backend.shared.db",
+        SimpleNamespace(run_migrations_if_needed=lambda *_a, **_k: None),
+    )
+
+    from signal_ingestion import main as main_module
+
+    await main_module.startup()
+
+    assert called


### PR DESCRIPTION
## Summary
- ensure signal payloads normalize to a unified `Signal` dataclass
- initialise deduplication bloom filter on service startup
- avoid naming conflicts in tasks
- expand normalization tests to cover Instagram
- add tests for duplicate detection and startup initialization

## Testing
- `python -m pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `flake8` *(fails: command not found)*
- `black --check backend/signal-ingestion/src/signal_ingestion/main.py`
- `mypy backend/signal-ingestion/src/signal_ingestion`

------
https://chatgpt.com/codex/tasks/task_b_687ed3cacfcc8331a48d621b30dfbdad