### PR TITLE
Add weight feedback auth and persistence

### DIFF
--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -284,8 +284,14 @@ async def update_weights_endpoint(
 
 
 @app.post("/weights/feedback")
-async def feedback_weights(body: WeightsUpdate) -> JSONResponse:
-    """Update weights from feedback loop with smoothing."""
+async def feedback_weights(request: Request, body: WeightsUpdate) -> JSONResponse:
+    """Update weights from feedback loop with smoothing.
+
+    Requires ``X-Weights-Token`` header matching ``settings.weights_token``.
+    """
+    token = request.headers.get("X-Weights-Token")
+    if settings.weights_token and token != settings.weights_token:
+        raise HTTPException(status_code=401, detail="invalid token")
     weights = await run_in_threadpool(
         update_weights, smoothing=FEEDBACK_SMOOTHING, **body.model_dump()
     )

--- a/backend/scoring-engine/tests/test_weights.py
+++ b/backend/scoring-engine/tests/test_weights.py
@@ -4,6 +4,7 @@
 
 from fastapi.testclient import TestClient
 import importlib
+from pathlib import Path
 from scoring_engine.app import app
 
 scoring_module = importlib.import_module("scoring_engine.app")
@@ -14,10 +15,11 @@ def setup_module(module) -> None:
     from tests import DummyRedis
 
     scoring_module.redis_client = DummyRedis()
+    scoring_module.settings.weights_token = "secret"
 
 
-def test_feedback_weight_update() -> None:
-    """Weights updated via feedback endpoint persist."""
+def test_feedback_weight_update(tmp_path) -> None:
+    """Weights updated via feedback endpoint persist and file written."""
     client = TestClient(app)
     payload = {
         "freshness": 0.5,
@@ -26,12 +28,25 @@ def test_feedback_weight_update() -> None:
         "community_fit": 0.2,
         "seasonality": 0.1,
     }
-    resp = client.post("/weights/feedback", json=payload)
+    resp = client.post(
+        "/weights/feedback",
+        json=payload,
+        headers={"X-Weights-Token": "secret"},
+    )
     assert resp.status_code == 200
     resp = client.get("/weights")
     data = resp.json()
     for key, val in payload.items():
         assert data[key] == val
+    weights_file = Path("backend/scoring-engine/scoring_engine/weights.json").resolve()
+    assert weights_file.exists()
+
+
+def test_feedback_requires_token() -> None:
+    """Request without token should return 401."""
+    client = TestClient(app)
+    resp = client.post("/weights/feedback", json={})
+    assert resp.status_code == 401
 
 
 def test_feedback_weight_smoothing() -> None:
@@ -44,7 +59,11 @@ def test_feedback_weight_smoothing() -> None:
         "community_fit": 1.0,
         "seasonality": 1.0,
     }
-    client.put("/weights", json=reset_payload)
+    client.put(
+        "/weights",
+        json=reset_payload,
+        headers={"X-Weights-Token": "secret"},
+    )
 
     payload = {
         "freshness": 0.0,
@@ -56,7 +75,11 @@ def test_feedback_weight_smoothing() -> None:
     smoothing = scoring_module.weight_repository.FEEDBACK_SMOOTHING
     iterations = 5
     for _ in range(iterations):
-        resp = client.post("/weights/feedback", json=payload)
+        resp = client.post(
+            "/weights/feedback",
+            json=payload,
+            headers={"X-Weights-Token": "secret"},
+        )
         assert resp.status_code == 200
 
     resp = client.get("/weights")


### PR DESCRIPTION
## Summary
- require token for `/weights/feedback`
- persist weight updates to `weights.json`
- test auth failures and persistence for weight updates

## Testing
- `flake8 backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/scoring_engine/weight_repository.py backend/scoring-engine/tests/test_weights.py`
- `mypy backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/scoring_engine/weight_repository.py` *(fails: Interrupted)*
- `SKIP_HEAVY_DEPS=1 PYTHONPATH=. pytest backend/scoring-engine/tests/test_weights.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_687ee0172214833198927426dcd1b2c9