### PR TITLE
Improve prompt generation and post-processing

### DIFF
--- a/backend/mockup-generation/mockup_generation/prompt_builder.py
+++ b/backend/mockup-generation/mockup_generation/prompt_builder.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from random import Random
+from typing import Any, Dict, List
 
 from jinja2 import Template
 
@@ -17,12 +18,33 @@ class PromptContext:
     extra: Dict[str, Any] = field(default_factory=dict)
 
 
-TEMPLATE = Template(
-    "A {{ style }} design featuring {{ keywords | join(', ') }}. "
-    "{{ extra.get('note', '') }}"
-)
+TEMPLATES: List[Template] = [
+    Template(
+        "A {{ style }} design featuring {{ keywords | join(', ') }}. {{ extra.get('note', '') }}"
+    ),
+    Template(
+        "Create a {{ style }} composition with {{ keywords | join(' and ') }}. {{ extra.get('note', '') }}"
+    ),
+]
 
 
-def build_prompt(context: PromptContext) -> str:
-    """Return a formatted prompt string."""
-    return TEMPLATE.render(**context.__dict__)
+def _mix_keywords(keywords: list[str], rng: Random) -> list[str]:
+    """Return ``keywords`` shuffled and occasionally combined."""
+
+    mixed = keywords.copy()
+    rng.shuffle(mixed)
+    if len(mixed) > 1 and rng.random() > 0.5:
+        idx = rng.randrange(len(mixed) - 1)
+        mixed[idx] = f"{mixed[idx]} and {mixed[idx + 1]}"
+        del mixed[idx + 1]
+    return mixed
+
+
+def build_prompt(context: PromptContext, rng: Random | None = None) -> str:
+    """Return a formatted prompt string using mixed keywords."""
+
+    rng = rng or Random()
+    keywords = _mix_keywords(context.keywords, rng)
+    template = rng.choice(TEMPLATES)
+    data = {**context.__dict__, "keywords": keywords}
+    return template.render(**data)

--- a/backend/mockup-generation/tests/test_post_processor_rules.py
+++ b/backend/mockup-generation/tests/test_post_processor_rules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import pytest
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT))  # noqa: E402
@@ -11,7 +12,11 @@ sys.path.append(str(ROOT / "backend" / "mockup-generation"))  # noqa: E402
 
 from PIL import Image
 
-from mockup_generation.post_processor import validate_dimensions, validate_file_size
+from mockup_generation.post_processor import (
+    post_process_image,
+    validate_dimensions,
+    validate_file_size,
+)
 
 
 def test_validate_dimensions(tmp_path: Path) -> None:
@@ -27,3 +32,20 @@ def test_validate_file_size(tmp_path: Path) -> None:
     path.write_bytes(b"x" * 1024)
     assert validate_file_size(path, max_file_size_mb=1)
     assert not validate_file_size(path, max_file_size_mb=0)
+
+
+def test_post_process_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    img = Image.new("RGB", (10, 10))
+    path = tmp_path / "img.png"
+    img.save(path)
+    monkeypatch.setattr(
+        "mockup_generation.post_processor.remove_background", lambda i: i
+    )
+    monkeypatch.setattr("mockup_generation.post_processor.convert_to_cmyk", lambda i: i)
+    monkeypatch.setattr(
+        "mockup_generation.post_processor.ensure_not_nsfw", lambda i: None
+    )
+    monkeypatch.setattr(
+        "mockup_generation.post_processor.validate_color_space", lambda i: True
+    )
+    assert post_process_image(path).exists()

--- a/backend/mockup-generation/tests/test_prompt_builder.py
+++ b/backend/mockup-generation/tests/test_prompt_builder.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from random import Random
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from mockup_generation.prompt_builder import PromptContext, build_prompt  # noqa: E402
+
+
+def test_build_prompt_deterministic() -> None:
+    ctx = PromptContext(keywords=["red", "cat", "hat"], extra={"note": "test"})
+    rng = Random(0)
+    prompt1 = build_prompt(ctx, rng=rng)
+    rng.seed(0)
+    prompt2 = build_prompt(ctx, rng=rng)
+    assert prompt1 == prompt2
+    assert "vector art" in prompt1
+    assert "test" in prompt1


### PR DESCRIPTION
## Summary
- support multiple grammar templates and keyword mixing in prompts
- add a full post-processing pipeline function
- auto-scale Celery workers according to GPU queue length
- test prompt builder and post-process pipeline

## Testing
- `black backend/mockup-generation/mockup_generation/prompt_builder.py backend/mockup-generation/mockup_generation/post_processor.py backend/mockup-generation/mockup_generation/celery_app.py backend/mockup-generation/tests/test_post_processor_rules.py backend/mockup-generation/tests/test_prompt_builder.py`
- `flake8 backend/mockup-generation/mockup_generation/prompt_builder.py backend/mockup-generation/mockup_generation/post_processor.py backend/mockup-generation/mockup_generation/celery_app.py backend/mockup-generation/tests/test_post_processor_rules.py backend/mockup-generation/tests/test_prompt_builder.py`
- `mypy backend/mockup-generation/mockup_generation/prompt_builder.py`
- `mypy backend/mockup-generation/mockup_generation/post_processor.py`
- `mypy backend/mockup-generation/mockup_generation/celery_app.py` *(fails: library stubs missing)*
- `pytest backend/mockup-generation/tests/test_post_processor_rules.py backend/mockup-generation/tests/test_prompt_builder.py -q` *(fails: coverage threshold)*

------
https://chatgpt.com/codex/tasks/task_b_687ee2d63a8c8331abffd1b67ff5ac82