### PR TITLE
Support DALL‑E fallback API

### DIFF
--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -133,9 +133,9 @@ class MockupGenerator:
         session = requests.Session()
         provider = settings.fallback_provider.lower()
 
-        for attempt in range(3):
+        for attempt in range(1, 4):
             try:
-                if provider == "dall-e":
+                if provider in {"openai", "dall-e", "dalle"}:
                     response = session.post(
                         "https://api.openai.com/v1/images/generations",
                         headers={"Authorization": f"Bearer {settings.openai_api_key}"},
@@ -163,9 +163,9 @@ class MockupGenerator:
                     response.raise_for_status()
                     data = base64.b64decode(response.json()["artifacts"][0]["base64"])
                 return Image.open(BytesIO(data))
-            except (requests.RequestException, OSError, ValueError) as exc:
+            except (requests.RequestException, OSError, ValueError, KeyError) as exc:
                 logger.warning("Fallback provider error: %s", exc)
-                if attempt == 2:
+                if attempt == 3:
                     raise GenerationError(
                         "Failed to generate image via fallback provider"
                     ) from exc

--- a/backend/mockup-generation/tests/test_generator.py
+++ b/backend/mockup-generation/tests/test_generator.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 import types
+from typing import Iterator
+
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,26 +14,35 @@ sys.path.append(str(ROOT))  # noqa: E402
 
 # Stub heavy dependencies used by generator
 sys.modules.setdefault("diffusers", types.ModuleType("diffusers"))
-sys.modules["diffusers"].StableDiffusionXLPipeline = object
+sys.modules["diffusers"].StableDiffusionXLPipeline = object  # type: ignore[attr-defined]
 sys.modules.setdefault("torch", types.ModuleType("torch"))
-sys.modules["torch"].cuda = types.SimpleNamespace(is_available=lambda: False)
+sys.modules["torch"].cuda = types.SimpleNamespace(is_available=lambda: False)  # type: ignore[attr-defined]
 sys.modules.setdefault("torch.nn", types.ModuleType("nn"))
 
 from mockup_generation.generator import MockupGenerator, GenerationError  # noqa: E402
+from mockup_generation.settings import settings  # noqa: E402
 
 
 class DummySession:
     """HTTP client that always raises ``RequestException``."""
 
-    def post(self, *a, **k):
+    def post(self, *a: object, **k: object) -> None:
         from requests.exceptions import RequestException
 
         raise RequestException("boom")
 
-    def get(self, *a, **k):
+    def get(self, *a: object, **k: object) -> None:
         from requests.exceptions import RequestException
 
         raise RequestException("boom")
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def restore_provider() -> Iterator[None]:
+    """Restore provider settings after each test."""
+    prev_provider = settings.fallback_provider
+    yield
+    settings.fallback_provider = prev_provider
 
 
 def test_fallback_api_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -41,3 +52,65 @@ def test_fallback_api_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     gen = MockupGenerator()
     with pytest.raises(GenerationError):
         gen._fallback_api("prompt")
+
+
+def test_fallback_api_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Image is returned when OpenAI responds successfully."""
+    from io import BytesIO
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (1, 1)).save(buf, format="PNG")
+    data = buf.getvalue()
+
+    class Session:
+        def post(self, url: str, **_: object) -> object:
+            assert url == "https://api.openai.com/v1/images/generations"
+            return types.SimpleNamespace(
+                json=lambda: {"data": [{"url": "http://x"}]},
+                raise_for_status=lambda: None,
+            )
+
+        def get(self, url: str, **_: object) -> object:
+            assert url == "http://x"
+            return types.SimpleNamespace(content=data, raise_for_status=lambda: None)
+
+    settings.fallback_provider = "openai"
+    settings.openai_api_key = "x"
+    monkeypatch.setattr("requests.Session", lambda: Session())
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    gen = MockupGenerator()
+    img = gen._fallback_api("prompt")
+    assert img.size == (1, 1)
+
+
+def test_fallback_api_stability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Image is returned when Stability responds successfully."""
+    import base64
+    from io import BytesIO
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (1, 1)).save(buf, format="PNG")
+    data = buf.getvalue()
+
+    class Session:
+        def post(self, url: str, **_: object) -> object:
+            assert url.startswith("https://api.stability.ai/v1/generation/")
+            return types.SimpleNamespace(
+                json=lambda: {
+                    "artifacts": [{"base64": base64.b64encode(data).decode()}]
+                },
+                raise_for_status=lambda: None,
+            )
+
+        def get(self, *a: object, **k: object) -> None:
+            raise AssertionError("should not fetch external URL")
+
+    settings.fallback_provider = "stability"
+    settings.stability_ai_api_key = "x"
+    monkeypatch.setattr("requests.Session", lambda: Session())
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    gen = MockupGenerator()
+    img = gen._fallback_api("prompt")
+    assert img.size == (1, 1)


### PR DESCRIPTION
## Summary
- extend `_fallback_api` to switch between OpenAI DALL‑E and Stability AI
- add coverage for each provider with mocked network calls

## Testing
- `flake8 backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator.py`
- `pydocstyle backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator.py`
- `black backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator.py`
- `mypy --follow-imports=skip backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator.py`
- `pytest backend/mockup-generation/tests/test_generator.py -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_b_687ee6875e3c8331b9f5878c24caae89