### PR TITLE
Integrate marketplace metrics polling

### DIFF
--- a/backend/feedback-loop/feedback_loop/scheduler.py
+++ b/backend/feedback-loop/feedback_loop/scheduler.py
@@ -51,6 +51,7 @@ def setup_scheduler(
         schedule_marketplace_ingestion(
             scheduler,
             list(listing_ids),
+            scoring_api,
             interval_minutes=settings.publisher_metrics_interval_minutes,
         )
     return scheduler


### PR DESCRIPTION
## Summary
- hook up periodic marketplace ingestion to update weights
- schedule ingestion in service startup
- test startup ingestion scheduling and metric storage

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement scikit)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687ef61dbf388331939fb9f59e70f317