### PR TITLE
Ensure metrics scraping in services

### DIFF
--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -15,11 +15,13 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
+from backend.shared.tracing import configure_tracing
 from pydantic import BaseModel
 
 from .ab_testing import ABTestManager
 from .auth import require_role
 from backend.shared.config import settings as shared_settings
+from .settings import settings
 
 app = FastAPI(title="Feedback Loop")
 app.add_middleware(
@@ -29,6 +31,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+configure_tracing(app, "feedback-loop")
 register_metrics(app)
 add_security_headers(app)
 logger = logging.getLogger(__name__)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -242,6 +242,10 @@ services:
     - kafka
     - redis
     - postgres
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -255,6 +259,10 @@ services:
     - 5002:5002
     depends_on:
     - postgres
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=5002
 
     secrets:
     - secret_key
@@ -269,6 +277,10 @@ services:
     depends_on:
     - postgres
     - redis
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -283,6 +295,10 @@ services:
     depends_on:
     - postgres
     - kafka
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -294,6 +310,10 @@ services:
     command: python -m feedback_loop.main
     ports:
     - 8005:8000
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -326,6 +346,10 @@ services:
       dockerfile: backend/orchestrator/Dockerfile
     ports:
     - 3001:3000
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=3000
     secrets:
     - secret_key
     - openai_api_key

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -238,6 +238,10 @@ services:
     - kafka
     - redis
     - postgres
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -250,6 +254,10 @@ services:
     - 5002:5002
     depends_on:
     - postgres
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=5002
 
     secrets:
     - secret_key
@@ -263,6 +271,10 @@ services:
     depends_on:
     - postgres
     - redis
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -276,6 +288,10 @@ services:
     depends_on:
     - postgres
     - kafka
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -288,6 +304,10 @@ services:
       dockerfile: backend/feedback-loop/Dockerfile
     ports:
     - 8005:8000
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
 
     secrets:
     - secret_key
@@ -312,6 +332,10 @@ services:
       dockerfile: backend/orchestrator/Dockerfile
     ports:
     - 3001:3000
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=3000
 
     secrets:
     - secret_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,10 @@ services:
       - kafka
       - redis
       - postgres
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=8000"
 
   scoring-engine:
     build: ./backend/scoring-engine
@@ -186,6 +190,10 @@ services:
       - "5002:5002"
     depends_on:
       - postgres
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=5002"
 
   marketplace-publisher:
     build: ./backend/marketplace-publisher
@@ -195,6 +203,10 @@ services:
     depends_on:
       - postgres
       - redis
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=8000"
 
   signal-ingestion:
     build: ./backend/signal-ingestion
@@ -204,12 +216,20 @@ services:
     depends_on:
       - postgres
       - kafka
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=8000"
 
   feedback-loop:
     build: ./backend/feedback-loop
     command: python -m feedback_loop.main
     ports:
       - "8005:8000"
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=8000"
 
   admin-dashboard:
     build: ./frontend/admin-dashboard
@@ -224,6 +244,10 @@ services:
       dockerfile: backend/orchestrator/Dockerfile
     ports:
       - "3001:3000"
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=3000"
 volumes:
   postgres-data:
   redis-data:

--- a/infrastructure/helm/ai-mockup-generation/templates/service.yaml
+++ b/infrastructure/helm/ai-mockup-generation/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "ai-mockup-generation.fullname" . }}
   labels: {{- include "ai-mockup-generation.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   type: {{ .Values.service.type }}
   selector: {{- include "ai-mockup-generation.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/feedback-loop/templates/service.yaml
+++ b/infrastructure/helm/feedback-loop/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "feedback-loop.fullname" . }}
   labels: {{- include "feedback-loop.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   type: {{ .Values.service.type }}
   selector: {{- include "feedback-loop.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/marketplace-publisher/templates/service.yaml
+++ b/infrastructure/helm/marketplace-publisher/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "marketplace-publisher.fullname" . }}
   labels: {{- include "marketplace-publisher.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   type: {{ .Values.service.type }}
   selector: {{- include "marketplace-publisher.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/monitoring/templates/service.yaml
+++ b/infrastructure/helm/monitoring/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "monitoring.fullname" . }}
   labels: {{- include "monitoring.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   type: {{ .Values.service.type }}
   selector: {{- include "monitoring.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/orchestrator/templates/service.yaml
+++ b/infrastructure/helm/orchestrator/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels: {{- include "orchestrator.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   type: {{ .Values.service.type }}
   selector: {{- include "orchestrator.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/scoring-engine/templates/service.yaml
+++ b/infrastructure/helm/scoring-engine/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "scoring-engine.fullname" . }}
   labels: {{- include "scoring-engine.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   type: {{ .Values.service.type }}
   selector: {{- include "scoring-engine.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/signal-ingestion/templates/service.yaml
+++ b/infrastructure/helm/signal-ingestion/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "signal-ingestion.fullname" . }}
   labels: {{- include "signal-ingestion.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   type: {{ .Values.service.type }}
   selector: {{- include "signal-ingestion.selectorLabels" . | nindent 4 }}

--- a/tests/test_metrics_endpoints.py
+++ b/tests/test_metrics_endpoints.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from prometheus_client.parser import text_string_to_metric_families
 
 SERVICES = [
     ("backend/service-template/src", "main"),
@@ -35,3 +36,5 @@ def test_metrics_endpoint(base: str, module: str) -> None:
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("text/plain")
         assert b"# TYPE" in resp.content
+        metrics = {m.name for m in text_string_to_metric_families(resp.text)}
+        assert "http_requests_total" in metrics


### PR DESCRIPTION
## Summary
- import tracing in Feedback Loop service
- expose Prometheus metrics for docker-compose services
- add scrape annotations to Helm service templates
- extend metrics integration test to parse metrics

## Testing
- `flake8`
- `docformatter -c backend/feedback-loop/feedback_loop/main.py`
- `pydocstyle backend/feedback-loop/feedback_loop/main.py`
- `black --check backend/feedback-loop/feedback_loop/main.py`
- `flake8 tests/test_metrics_endpoints.py`
- `docformatter -c tests/test_metrics_endpoints.py`
- `pydocstyle tests/test_metrics_endpoints.py`
- `black --check tests/test_metrics_endpoints.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_687efd3105c083319ab7125c2c23a60a