### PR TITLE
Add trend analysis utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ docs/sphinx/api/
 # Local Kubernetes secrets
 infrastructure/k8s/secrets.yaml
 
+
+.coverage
+coverage.xml

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -99,15 +99,16 @@ def record_resource_usage(target_store: MetricsStore = store) -> None:
 
 
 @app.on_event("startup")
-async def start_metrics_collection() -> None:
-    """Begin periodic recording of container resource usage."""
-
-    async def _run() -> None:
-        while True:
-            record_resource_usage()
-            await asyncio.sleep(30)
-
-    asyncio.create_task(_run())
+def start_metrics_collection() -> None:
+    """Schedule periodic resource usage collection."""
+    if not scheduler.running:
+        scheduler.start()
+    scheduler.add_job(
+        record_resource_usage,
+        trigger=IntervalTrigger(seconds=30),
+        id="collect_metrics",
+        replace_existing=True,
+    )
 
 
 @app.on_event("startup")

--- a/backend/optimization/metrics.py
+++ b/backend/optimization/metrics.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, TYPE_CHECKING
 
 import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type checking
+    from .storage import MetricsStore
 
 
 @dataclass
@@ -21,6 +24,17 @@ class ResourceMetric:
 
 class MetricsAnalyzer:
     """Analyze resource metrics for optimization recommendations."""
+
+    @classmethod
+    def from_store(
+        cls, store: "MetricsStore", limit: int | None = None
+    ) -> "MetricsAnalyzer":
+        """Create analyzer from a :class:`MetricsStore` instance."""
+        if limit is None:
+            metrics = store.get_metrics()
+        else:
+            metrics = store.get_recent_metrics(limit)
+        return cls(metrics)
 
     def __init__(self, metrics: Iterable[ResourceMetric]) -> None:
         """Initialize the analyzer with historical metrics."""

--- a/backend/optimization/tests/test_metrics_analyzer.py
+++ b/backend/optimization/tests/test_metrics_analyzer.py
@@ -59,3 +59,21 @@ def test_trend_calculation() -> None:
     assert analyzer.cpu_trend() > 0
     assert analyzer.memory_trend() > 0
     assert analyzer.disk_usage_trend() > 0
+
+
+def test_recommendations_for_high_usage() -> None:
+    """Recommendations should mention scaling when usage is high."""
+    now = datetime.now(timezone.utc)
+    metrics = [
+        ResourceMetric(
+            timestamp=now - timedelta(minutes=20 - i),
+            cpu_percent=85 + i,
+            memory_mb=1500 + 10 * i,
+            disk_usage_mb=11 * 1024 + 50 * i,
+        )
+        for i in range(20)
+    ]
+    analyzer = MetricsAnalyzer(metrics)
+    recs = analyzer.recommend_optimizations()
+    assert any("CPU usage is trending upward" in r for r in recs)
+    assert any("Disk usage exceeds" in r for r in recs)

--- a/backend/optimization/tests/test_scheduler.py
+++ b/backend/optimization/tests/test_scheduler.py
@@ -26,3 +26,12 @@ def test_scheduler_job_registration(monkeypatch) -> None:
     assert isinstance(job.trigger, IntervalTrigger)
     assert int(job.trigger.interval.total_seconds()) == 3600
     opt_api.scheduler.shutdown()
+
+
+def test_metrics_collection_scheduled(monkeypatch) -> None:
+    """Metrics collection job should be added on startup."""
+    monkeypatch.setattr(opt_api, "scheduler", BackgroundScheduler())
+    opt_api.start_metrics_collection()
+    jobs = {job.id for job in opt_api.scheduler.get_jobs()}
+    assert "collect_metrics" in jobs
+    opt_api.scheduler.shutdown()


### PR DESCRIPTION
## Summary
- implement MetricsAnalyzer.from_store helper
- add recent/since retrieval in MetricsStore
- schedule metrics recording with AsyncIOScheduler
- extend recommendations test coverage
- add scheduler unit test for new job

## Testing
- `flake8 backend/optimization`
- `pydocstyle backend/optimization`
- `docformatter --check backend/optimization/*.py backend/optimization/tests/*.py`
- `mypy backend/optimization/metrics.py backend/optimization/storage.py backend/optimization/api.py` *(fails: returns errors in unrelated shared modules)*
- `pytest backend/optimization/tests/test_metrics_analyzer.py backend/optimization/tests/test_scheduler.py backend/optimization/tests/test_api_routes.py backend/optimization/tests/test_metrics_store.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_687f02e3c8148331a10f5d936512db5f