### PR TITLE
Add extra dashboard pages and hooks

### DIFF
--- a/frontend/admin-dashboard/__tests__/dashboardPages.test.tsx
+++ b/frontend/admin-dashboard/__tests__/dashboardPages.test.tsx
@@ -3,12 +3,22 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AuditLogsPage from '../src/pages/dashboard/audit-logs';
 import OptimizationsPage from '../src/pages/dashboard/optimizations';
 import MetricsPage from '../src/pages/dashboard/metrics';
+import SignalsPage from '../src/pages/dashboard/signals';
+import MockupGalleryPage from '../src/pages/dashboard/mockup-gallery';
+import MetricsChartsPage from '../src/pages/dashboard/metrics-charts';
+import OptimizationRecommendationsPage from '../src/pages/dashboard/optimization-recommendations';
 
 jest.mock('../src/trpc', () => ({
   trpc: {
     auditLogs: { list: () => Promise.resolve({ total: 0, items: [] }) },
     optimizations: { list: () => Promise.resolve([]) },
-    metrics: { list: () => Promise.resolve('') },
+    metrics: {
+      list: () => Promise.resolve(''),
+      summary: () => Promise.resolve([]),
+    },
+    signals: { list: () => Promise.resolve([]) },
+    mockups: { list: () => Promise.resolve([]) },
+    recommendations: { list: () => Promise.resolve([]) },
   },
 }));
 
@@ -46,6 +56,54 @@ describe('dashboard data pages render', () => {
     );
     expect(
       screen.getByRole('heading', { name: /metrics/i })
+    ).toBeInTheDocument();
+  });
+
+  it('signals', () => {
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <SignalsPage />
+      </QueryClientProvider>
+    );
+    expect(
+      screen.getByRole('heading', { name: /signals/i })
+    ).toBeInTheDocument();
+  });
+
+  it('mockup gallery', () => {
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <MockupGalleryPage />
+      </QueryClientProvider>
+    );
+    expect(
+      screen.getByRole('heading', { name: /mockup gallery/i })
+    ).toBeInTheDocument();
+  });
+
+  it('metrics charts', () => {
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <MetricsChartsPage />
+      </QueryClientProvider>
+    );
+    expect(
+      screen.getByRole('heading', { name: /metrics charts/i })
+    ).toBeInTheDocument();
+  });
+
+  it('optimization recommendations', () => {
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <OptimizationRecommendationsPage />
+      </QueryClientProvider>
+    );
+    expect(
+      screen.getByRole('heading', { name: /optimization recommendations/i })
     ).toBeInTheDocument();
   });
 });

--- a/frontend/admin-dashboard/e2e/new-pages.spec.ts
+++ b/frontend/admin-dashboard/e2e/new-pages.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { server } from './msw-server';
+
+test.beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+test.afterAll(() => server.close());
+test.afterEach(() => server.resetHandlers());
+
+test('visit new dashboard pages', async ({ page }) => {
+  await page.goto('/dashboard/signals');
+  await expect(page.getByRole('heading', { name: /signals/i })).toBeVisible();
+
+  await page.goto('/dashboard/mockup-gallery');
+  await expect(
+    page.getByRole('heading', { name: /mockup gallery/i })
+  ).toBeVisible();
+
+  await page.goto('/dashboard/metrics-charts');
+  await expect(
+    page.getByRole('heading', { name: /metrics charts/i })
+  ).toBeVisible();
+
+  await page.goto('/dashboard/optimization-recommendations');
+  await expect(
+    page.getByRole('heading', { name: /optimization recommendations/i })
+  ).toBeVisible();
+});

--- a/frontend/admin-dashboard/src/lib/trpc/hooks.ts
+++ b/frontend/admin-dashboard/src/lib/trpc/hooks.ts
@@ -58,6 +58,13 @@ export function useMetrics() {
   });
 }
 
+export function useMetricsSummary() {
+  return useQuery({
+    queryKey: ['metricsSummary'],
+    queryFn: () => trpc.metrics.summary(),
+  });
+}
+
 export function useAuditLogs(limit = 50, offset = 0) {
   return useQuery({
     queryKey: ['auditLogs', limit, offset],
@@ -69,6 +76,20 @@ export function useOptimizations() {
   return useQuery({
     queryKey: ['optimizations'],
     queryFn: () => trpc.optimizations.list(),
+  });
+}
+
+export function useOptimizationRecommendations() {
+  return useQuery({
+    queryKey: ['optimizationRecommendations'],
+    queryFn: () => trpc.recommendations.list(),
+  });
+}
+
+export function useMockups() {
+  return useQuery({
+    queryKey: ['mockups'],
+    queryFn: () => trpc.mockups.list(),
   });
 }
 

--- a/frontend/admin-dashboard/src/pages/dashboard/metrics-charts.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/metrics-charts.tsx
@@ -1,0 +1,43 @@
+// @flow
+import React from 'react';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
+import dynamic from 'next/dynamic';
+import type { GetStaticProps } from 'next';
+import { useTranslation } from 'react-i18next';
+import { useMetricsSummary } from '../../lib/trpc/hooks';
+
+const AnalyticsChart = dynamic(
+  () => import('../../components/AnalyticsChart'),
+  {
+    ssr: false,
+  }
+);
+const LatencyChart = dynamic(() => import('../../components/LatencyChart'), {
+  ssr: false,
+});
+
+function MetricsChartsPage() {
+  const { t } = useTranslation();
+  const { data, isLoading } = useMetricsSummary();
+
+  return (
+    <div className="space-y-4">
+      <h1>{t('metricsCharts')}</h1>
+      {isLoading || !data ? (
+        <div>{t('loading')}</div>
+      ) : (
+        <div className="space-y-2">
+          <pre>{JSON.stringify(data, null, 2)}</pre>
+          <AnalyticsChart />
+          <LatencyChart />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+  revalidate: 60,
+});
+export default withPageAuthRequired(MetricsChartsPage);

--- a/frontend/admin-dashboard/src/pages/dashboard/mockup-gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/mockup-gallery.tsx
@@ -1,0 +1,42 @@
+// @flow
+import React from 'react';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { GetStaticProps } from 'next';
+import { useTranslation } from 'react-i18next';
+import { useMockups } from '../../lib/trpc/hooks';
+
+function MockupGalleryPage() {
+  const { t } = useTranslation();
+  const { data: mockups, isLoading } = useMockups();
+
+  return (
+    <div>
+      <h1>{t('mockupGallery')}</h1>
+      {isLoading || !mockups ? (
+        <div>{t('loading')}</div>
+      ) : (
+        <div className="grid grid-cols-3 gap-2">
+          {mockups.map((m) => (
+            <Link key={m.id} href={`/dashboard/publish?mockupId=${m.id}`}>
+              <Image
+                src={m.imageUrl}
+                alt={m.id.toString()}
+                width={200}
+                height={200}
+                className="border"
+              />
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+  revalidate: 60,
+});
+export default withPageAuthRequired(MockupGalleryPage);

--- a/frontend/admin-dashboard/src/pages/dashboard/optimization-recommendations.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/optimization-recommendations.tsx
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
+import type { GetStaticProps } from 'next';
+import { useTranslation } from 'react-i18next';
+import { useOptimizationRecommendations } from '../../lib/trpc/hooks';
+
+function OptimizationRecommendationsPage() {
+  const { t } = useTranslation();
+  const { data: recs, isLoading } = useOptimizationRecommendations();
+
+  return (
+    <div className="space-y-2">
+      <h1>{t('optimizationRecommendations')}</h1>
+      {isLoading || !recs ? (
+        <div>{t('loading')}</div>
+      ) : (
+        <ul>
+          {recs.map((r, idx) => (
+            <li key={idx}>{r}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+  revalidate: 60,
+});
+export default withPageAuthRequired(OptimizationRecommendationsPage);

--- a/frontend/admin-dashboard/src/pages/dashboard/signals.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/signals.tsx
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
+import type { GetStaticProps } from 'next';
+import { useTranslation } from 'react-i18next';
+import { useSignals } from '../../lib/trpc/hooks';
+
+function SignalsPage() {
+  const { t } = useTranslation();
+  const { data: signals, isLoading } = useSignals();
+
+  return (
+    <div className="space-y-2">
+      <h1>{t('signals')}</h1>
+      {isLoading || !signals ? (
+        <div>{t('loading')}</div>
+      ) : (
+        <ul>
+          {signals.map((s) => (
+            <li key={s.id}>
+              {s.source}: {s.content}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+  revalidate: 60,
+});
+export default withPageAuthRequired(SignalsPage);

--- a/frontend/admin-dashboard/src/trpc.ts
+++ b/frontend/admin-dashboard/src/trpc.ts
@@ -153,6 +153,9 @@ export const trpc = {
     summary: () => call<Metric[]>('metrics.summary'),
     list: () => getText('/metrics'),
   },
+  recommendations: {
+    list: () => getJson<string[]>('/recommendations'),
+  },
   auditLogs: {
     list: (limit = 50, offset = 0) =>
       getJson<AuditLogResponse>(`/audit-logs?limit=${limit}&offset=${offset}`),


### PR DESCRIPTION
## Summary
- add Signals, Mockup Gallery, Metrics Charts, and Optimization Recommendations pages
- expose new trpc hooks for metrics summary, mockups and recommendations
- add Playwright e2e test for new pages
- update dashboard page tests to cover new pages

## Testing
- `npm run lint --silent` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test --silent --prefix frontend/admin-dashboard`
- `npm run test:e2e --silent` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f0c0c93708331bfc2d4b983581f0d