### PR TITLE
Implement privacy purge endpoint

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -54,6 +54,7 @@ tags_metadata = [
     {"name": "Publish", "description": "Manage publishing tasks."},
     {"name": "Protected", "description": "Endpoints requiring authentication."},
     {"name": "Flags", "description": "Query and modify feature flags."},
+    {"name": "Privacy", "description": "Handle deletion requests and PII purging."},
 ]
 
 SERVICE_NAME = os.getenv("SERVICE_NAME", "api-gateway")

--- a/backend/api-gateway/tests/test_privacy_endpoint.py
+++ b/backend/api-gateway/tests/test_privacy_endpoint.py
@@ -1,0 +1,43 @@
+"""Tests for the privacy purge endpoint."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared.db import Base, engine, session_scope  # noqa: E402
+from backend.shared.db.models import UserRole  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_module(module: object) -> None:
+    """Create tables for tests."""
+    Base.metadata.create_all(engine)
+    with session_scope() as session:
+        session.add(UserRole(username="admin", role="admin"))
+
+
+def teardown_module(module: object) -> None:
+    """Drop tables after tests."""
+    Base.metadata.drop_all(engine)
+
+
+async def _dummy_purge(limit=None):
+    return 5
+
+
+def test_purge_pii_endpoint(monkeypatch):
+    """Trigger PII purge and return count."""
+    monkeypatch.setattr("signal_ingestion.privacy.purge_pii_rows", _dummy_purge)
+    token = create_access_token({"sub": "admin"})
+    resp = client.delete(
+        "/privacy/signals?limit=2",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "purged": 5}

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -7,6 +7,9 @@ This project stores user generated signals and analytics metrics. To comply with
 Incoming signal data is sanitized by `signal_ingestion.privacy.purge_row`, which strips email addresses and phone numbers before a signal is persisted.
 Stored records can be cleaned retroactively via `signal_ingestion.privacy.purge_pii_rows`.
 The Dagster `privacy_purge_job` runs this routine once per week.
+Deletion requests can be sent to `DELETE /privacy/signals` on the API gateway.
+This endpoint calls `signal_ingestion.privacy.purge_pii_rows` and records an
+audit log entry for traceability.
 
 ## Data Retention
 
@@ -24,4 +27,5 @@ Entries remain for the number of seconds configured by `dedup_ttl` (default:
 
 1. Set the retention period in the environment if different from the default.
 2. Schedule periodic execution of the retention routine.
-3. Ensure documentation is built and published on every commit to main.
+3. Use the API gateway deletion endpoint when users request removal.
+4. Ensure documentation is built and published on every commit to main.


### PR DESCRIPTION
## Summary
- add `/privacy/signals` API route for purging PII
- include Privacy router in API Gateway
- document deletion request process
- test the new purge endpoint

## Testing
- `pip install -r requirements-dev.txt` *(failed: Could not find a version that satisfies the requirement scikit)*
- `pip install -r requirements.txt` *(failed: subprocess-exited-with-error)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pre-commit run --files backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py docs/privacy.md backend/api-gateway/tests/test_privacy_endpoint.py` *(failed: prompted for GitHub credentials)*
- `black backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_privacy_endpoint.py`
- `flake8 backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_privacy_endpoint.py`
- `mypy backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_privacy_endpoint.py` *(failed: found 57 errors)*

------
https://chatgpt.com/codex/tasks/task_b_687f0e07c5bc8331824e873fd9df709d