### PR TITLE
Integrate Auth0 and JWT verification

### DIFF
--- a/frontend/__tests__/auth.test.tsx
+++ b/frontend/__tests__/auth.test.tsx
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import login from '../admin-dashboard/src/pages/api/auth/login';
+import logout from '../admin-dashboard/src/pages/api/auth/logout';
+import callback from '../admin-dashboard/src/pages/api/auth/callback';
+import { auth0 } from '../admin-dashboard/src/lib/auth0';
+
+jest.mock('../admin-dashboard/src/lib/auth0', () => ({
+  auth0: {
+    handleLogin: jest.fn(async () => {}),
+    handleLogout: jest.fn(async () => {}),
+    handleCallback: jest.fn(async () => {}),
+  },
+}));
+
+describe('auth routes', () => {
+  const req = {} as NextApiRequest;
+  const res = {} as NextApiResponse;
+
+  it('calls handleLogin', async () => {
+    await login(req, res);
+    expect(auth0.handleLogin).toHaveBeenCalledWith(req, res);
+  });
+
+  it('calls handleLogout', async () => {
+    await logout(req, res);
+    expect(auth0.handleLogout).toHaveBeenCalledWith(req, res);
+  });
+
+  it('calls handleCallback', async () => {
+    await callback(req, res);
+    expect(auth0.handleCallback).toHaveBeenCalledWith(req, res);
+  });
+});

--- a/frontend/admin-dashboard/middleware.ts
+++ b/frontend/admin-dashboard/middleware.ts
@@ -1,4 +1,6 @@
-export { default } from 'next-auth/middleware';
+import { withMiddlewareAuthRequired } from '@auth0/nextjs-auth0/edge';
+
+export default withMiddlewareAuthRequired();
 
 export const config = {
   matcher: ['/dashboard/:path*'],

--- a/frontend/admin-dashboard/src/lib/auth0.ts
+++ b/frontend/admin-dashboard/src/lib/auth0.ts
@@ -1,4 +1,10 @@
 // @flow
 import { Auth0Client } from '@auth0/nextjs-auth0/server';
 
-export const auth0 = new Auth0Client();
+export const auth0 = new Auth0Client({
+  domain: process.env.AUTH0_DOMAIN ?? '',
+  clientId: process.env.AUTH0_CLIENT_ID ?? '',
+  clientSecret: process.env.AUTH0_CLIENT_SECRET ?? '',
+  secret: process.env.AUTH0_SECRET ?? 'insecure',
+  baseURL: process.env.APP_BASE_URL ?? 'http://localhost:3000',
+});


### PR DESCRIPTION
## Summary
- configure Auth0 client options
- secure edge middleware using Auth0
- verify JWTs via shared helper in API gateway
- update revoked token test
- add integration test for Auth0 routes

## Testing
- `npm test`
- `python -m pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687f0dde8fc48331af4ce5374656f3c2