### PR TITLE
Add row-level security to all migrations

### DIFF
--- a/backend/shared/db/migrations/api_gateway/versions/0009_add_rls_policies.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0009_add_rls_policies.py
@@ -1,0 +1,65 @@
+"""Enable RLS on additional API Gateway tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enable RLS policies for API Gateway tables."""
+    op.add_column(
+        "revoked_tokens",
+        sa.Column("username", sa.String(length=50), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "ai_models",
+        sa.Column("username", sa.String(length=50), nullable=False, server_default=""),
+    )
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE revoked_tokens ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            """
+            CREATE POLICY revoked_tokens_is_self ON revoked_tokens
+            USING (username = current_setting('app.current_username')::text)
+            WITH CHECK (username = current_setting('app.current_username')::text)
+            """,
+        )
+        op.execute("ALTER TABLE ai_models ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            """
+            CREATE POLICY ai_models_is_self ON ai_models
+            USING (username = current_setting('app.current_username')::text)
+            WITH CHECK (username = current_setting('app.current_username')::text)
+            """,
+        )
+        op.execute("ALTER TABLE refresh_tokens ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            """
+            CREATE POLICY refresh_tokens_is_self ON refresh_tokens
+            USING (username = current_setting('app.current_username')::text)
+            WITH CHECK (username = current_setting('app.current_username')::text)
+            """,
+        )
+    op.alter_column("revoked_tokens", "username", server_default=None)
+    op.alter_column("ai_models", "username", server_default=None)
+
+
+def downgrade() -> None:
+    """Disable RLS policies for API Gateway tables."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP POLICY IF EXISTS refresh_tokens_is_self ON refresh_tokens")
+        op.execute("ALTER TABLE refresh_tokens DISABLE ROW LEVEL SECURITY")
+        op.execute("DROP POLICY IF EXISTS ai_models_is_self ON ai_models")
+        op.execute("ALTER TABLE ai_models DISABLE ROW LEVEL SECURITY")
+        op.execute("DROP POLICY IF EXISTS revoked_tokens_is_self ON revoked_tokens")
+        op.execute("ALTER TABLE revoked_tokens DISABLE ROW LEVEL SECURITY")
+    op.drop_column("ai_models", "username")
+    op.drop_column("revoked_tokens", "username")

--- a/backend/shared/db/migrations/marketplace_publisher/versions/f0123456789a_add_rls_policies.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/f0123456789a_add_rls_policies.py
@@ -1,0 +1,48 @@
+"""Enable RLS on marketplace publisher tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f0123456789a"
+down_revision = "e07f77a52d6e"
+branch_labels = None
+depends_on = None
+
+TABLES = ["publish_task", "webhook_event", "oauth_token"]
+
+
+def upgrade() -> None:
+    """Add username columns and enable RLS policies."""
+    for table in TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "username", sa.String(length=50), nullable=False, server_default=""
+            ),
+        )
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        for table in TABLES:
+            op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+            op.execute(
+                f"""
+                CREATE POLICY {table}_is_self ON {table}
+                USING (username = current_setting('app.current_username')::text)
+                WITH CHECK (username = current_setting('app.current_username')::text)
+                """
+            )
+    for table in TABLES:
+        op.alter_column(table, "username", server_default=None)
+
+
+def downgrade() -> None:
+    """Drop username columns and disable RLS."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        for table in TABLES:
+            op.execute(f"DROP POLICY IF EXISTS {table}_is_self ON {table}")
+            op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")
+    for table in TABLES:
+        op.drop_column(table, "username")

--- a/backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py
+++ b/backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py
@@ -1,0 +1,41 @@
+"""Add RLS policy for generated_mockups."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enable RLS on generated_mockups."""
+    op.add_column(
+        "generated_mockups",
+        sa.Column("username", sa.String(length=50), nullable=False, server_default=""),
+    )
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE generated_mockups ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            """
+            CREATE POLICY generated_mockups_is_self ON generated_mockups
+            USING (username = current_setting('app.current_username')::text)
+            WITH CHECK (username = current_setting('app.current_username')::text)
+            """,
+        )
+    op.alter_column("generated_mockups", "username", server_default=None)
+
+
+def downgrade() -> None:
+    """Remove RLS from generated_mockups."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "DROP POLICY IF EXISTS generated_mockups_is_self ON generated_mockups"
+        )
+        op.execute("ALTER TABLE generated_mockups DISABLE ROW LEVEL SECURITY")
+    op.drop_column("generated_mockups", "username")

--- a/backend/shared/db/migrations/scoring_engine/versions/0017_add_additional_rls_policies.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0017_add_additional_rls_policies.py
@@ -1,0 +1,62 @@
+"""Enable RLS on additional scoring engine tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+TABLES = [
+    "mockups",
+    "listings",
+    "weights",
+    "ab_tests",
+    "ab_test_results",
+    "marketplace_metrics",
+    "ai_models",
+    "score_metrics",
+    "publish_latency_metrics",
+    "embeddings",
+    "generated_mockups",
+    "marketplace_performance_metrics",
+    "score_benchmarks",
+]
+
+
+def upgrade() -> None:
+    """Add username columns and enable RLS policies."""
+    for table in TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "username", sa.String(length=50), nullable=False, server_default=""
+            ),
+        )
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        for table in TABLES:
+            op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+            op.execute(
+                f"""
+                CREATE POLICY {table}_is_self ON {table}
+                USING (username = current_setting('app.current_username')::text)
+                WITH CHECK (username = current_setting('app.current_username')::text)
+                """
+            )
+    for table in TABLES:
+        op.alter_column(table, "username", server_default=None)
+
+
+def downgrade() -> None:
+    """Drop username columns and RLS policies."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        for table in TABLES:
+            op.execute(f"DROP POLICY IF EXISTS {table}_is_self ON {table}")
+            op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")
+    for table in TABLES:
+        op.drop_column(table, "username")

--- a/backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py
+++ b/backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py
@@ -1,0 +1,39 @@
+"""Enable RLS on signals table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add username column and enable RLS."""
+    op.add_column(
+        "signals",
+        sa.Column("username", sa.String(length=50), nullable=False, server_default=""),
+    )
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE signals ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            """
+            CREATE POLICY signals_is_self_ingest ON signals
+            USING (username = current_setting('app.current_username')::text)
+            WITH CHECK (username = current_setting('app.current_username')::text)
+            """,
+        )
+    op.alter_column("signals", "username", server_default=None)
+
+
+def downgrade() -> None:
+    """Remove RLS from signals table."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP POLICY IF EXISTS signals_is_self_ingest ON signals")
+        op.execute("ALTER TABLE signals DISABLE ROW LEVEL SECURITY")
+    op.drop_column("signals", "username")

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -48,6 +48,23 @@ def test_rls_enforcement() -> None:
             session.execute(
                 text(
                     """
+                    INSERT INTO refresh_tokens (token, username, expires_at)
+                    VALUES ('tok', 'alice', now())
+                    """
+                )
+            )
+            session.execute(
+                text(
+                    """
+                    INSERT INTO mockups (idea_id, image_url, created_at, username)
+                    VALUES (:idea_id, 'u', now(), 'alice')
+                    """
+                ),
+                {"idea_id": idea_id},
+            )
+            session.execute(
+                text(
+                    """
                     INSERT INTO signals (username, idea_id, timestamp, engagement_rate)
                     VALUES ('alice', :idea_id, now(), 1.0)
                     """
@@ -61,3 +78,7 @@ def test_rls_enforcement() -> None:
             assert session.execute(text("SELECT * FROM audit_logs")).fetchall() == []
             assert session.execute(text("SELECT * FROM ideas")).fetchall() == []
             assert session.execute(text("SELECT * FROM signals")).fetchall() == []
+            assert (
+                session.execute(text("SELECT * FROM refresh_tokens")).fetchall() == []
+            )
+            assert session.execute(text("SELECT * FROM mockups")).fetchall() == []


### PR DESCRIPTION
## Summary
- add RLS policies for generated mockups
- add RLS policies for API Gateway tables
- add RLS policies for scoring engine tables
- add RLS policies for marketplace publisher tables
- add RLS policies for signal ingestion table
- extend RLS tests

## Testing
- `flake8 tests/test_rls.py backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0009_add_rls_policies.py backend/shared/db/migrations/scoring_engine/versions/0017_add_additional_rls_policies.py backend/shared/db/migrations/marketplace_publisher/versions/f0123456789a_add_rls_policies.py backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py`
- `pydocstyle tests/test_rls.py backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0009_add_rls_policies.py backend/shared/db/migrations/scoring_engine/versions/0017_add_additional_rls_policies.py backend/shared/db/migrations/marketplace_publisher/versions/f0123456789a_add_rls_policies.py backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py`
- `docformatter --in-place backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0009_add_rls_policies.py backend/shared/db/migrations/scoring_engine/versions/0017_add_additional_rls_policies.py backend/shared/db/migrations/marketplace_publisher/versions/f0123456789a_add_rls_policies.py backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py tests/test_rls.py`
- `black tests/test_rls.py backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0009_add_rls_policies.py backend/shared/db/migrations/scoring_engine/versions/0017_add_additional_rls_policies.py backend/shared/db/migrations/marketplace_publisher/versions/f0123456789a_add_rls_policies.py backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py`
- `mypy tests/test_rls.py backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py backend/shared/db/migrations/api_gateway/versions/0009_add_rls_policies.py backend/shared/db/migrations/scoring_engine/versions/0017_add_additional_rls_policies.py backend/shared/db/migrations/marketplace_publisher/versions/f0123456789a_add_rls_policies.py backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py --ignore-missing-imports --config-file=/dev/null`
- `pytest tests/test_rls.py -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_b_687f797daa948331bc13ee6910a3f9fa