### PR TITLE
Add RLS migrations

### DIFF
--- a/backend/shared/db/migrations/api_gateway/versions/0009_add_tokens_rls.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0009_add_tokens_rls.py
@@ -1,0 +1,78 @@
+"""Add RLS for token and model tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enable RLS for refresh_tokens, revoked_tokens and ai_models."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("ALTER TABLE refresh_tokens ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY refresh_tokens_is_self ON refresh_tokens
+        USING (username = current_setting('app.current_username')::text)
+        WITH CHECK (username = current_setting('app.current_username')::text)
+        """
+    )
+    op.execute("ALTER TABLE revoked_tokens ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY revoked_tokens_admin_only ON revoked_tokens
+        USING (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        WITH CHECK (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        """
+    )
+    op.execute("ALTER TABLE ai_models ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY ai_models_admin_only ON ai_models
+        USING (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        WITH CHECK (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove RLS from refresh_tokens, revoked_tokens and ai_models."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("DROP POLICY IF EXISTS ai_models_admin_only ON ai_models")
+    op.execute("ALTER TABLE ai_models DISABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS revoked_tokens_admin_only ON revoked_tokens")
+    op.execute("ALTER TABLE revoked_tokens DISABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS refresh_tokens_is_self ON refresh_tokens")
+    op.execute("ALTER TABLE refresh_tokens DISABLE ROW LEVEL SECURITY")

--- a/backend/shared/db/migrations/fedcba987654_merge_rls_heads.py
+++ b/backend/shared/db/migrations/fedcba987654_merge_rls_heads.py
@@ -1,0 +1,21 @@
+"""Merge heads after adding RLS policies."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "fedcba987654"
+down_revision = ("0017", "0009", "e07f77a52d6f", "0004", "0002", "abcdef123456")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the merge revision."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade merge revision."""
+    pass

--- a/backend/shared/db/migrations/marketplace_publisher/versions/e07f77a52d6f_add_rls_policies.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/e07f77a52d6f_add_rls_policies.py
@@ -1,0 +1,43 @@
+"""Enable RLS for marketplace publisher tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "e07f77a52d6f"
+down_revision = "e07f77a52d6e"
+branch_labels = None
+depends_on = None
+
+TABLES = ["publish_task", "webhook_event", "oauth_token"]
+
+
+def upgrade() -> None:
+    """Enable RLS on publisher tables."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    policy = (
+        "EXISTS (SELECT 1 FROM user_roles WHERE "
+        "username = current_setting('app.current_username')::text "
+        "AND role = 'admin')"
+    )
+    for table in TABLES:
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            f"""
+            CREATE POLICY {table}_admin_only ON {table}
+            USING ({policy})
+            WITH CHECK ({policy})
+            """
+        )
+
+
+def downgrade() -> None:
+    """Disable RLS on publisher tables."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for table in reversed(TABLES):
+        op.execute(f"DROP POLICY IF EXISTS {table}_admin_only ON {table}")
+        op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")

--- a/backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py
+++ b/backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py
@@ -1,0 +1,48 @@
+"""Enable RLS for generated_mockups table."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enable RLS on generated_mockups."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("ALTER TABLE generated_mockups ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY generated_mockups_admin_only ON generated_mockups
+        USING (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        WITH CHECK (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Disable RLS on generated_mockups."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute(
+        "DROP POLICY IF EXISTS generated_mockups_admin_only ON generated_mockups"
+    )
+    op.execute("ALTER TABLE generated_mockups DISABLE ROW LEVEL SECURITY")

--- a/backend/shared/db/migrations/scoring_engine/versions/0017_add_rls_to_tables.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0017_add_rls_to_tables.py
@@ -1,0 +1,57 @@
+"""Add RLS policies for remaining tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+TABLES = [
+    "mockups",
+    "listings",
+    "weights",
+    "ab_tests",
+    "ab_test_results",
+    "marketplace_metrics",
+    "marketplace_performance_metrics",
+    "ai_models",
+    "score_metrics",
+    "publish_latency_metrics",
+    "embeddings",
+    "generated_mockups",
+    "score_benchmarks",
+]
+
+
+def upgrade() -> None:
+    """Enable RLS on all remaining tables requiring protection."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    policy = (
+        "EXISTS (SELECT 1 FROM user_roles WHERE "
+        "username = current_setting('app.current_username')::text "
+        "AND role = 'admin')"
+    )
+    for table in TABLES:
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            f"""
+            CREATE POLICY {table}_admin_only ON {table}
+            USING ({policy})
+            WITH CHECK ({policy})
+            """
+        )
+
+
+def downgrade() -> None:
+    """Disable RLS on all remaining tables."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for table in reversed(TABLES):
+        op.execute(f"DROP POLICY IF EXISTS {table}_admin_only ON {table}")
+        op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")

--- a/backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py
+++ b/backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py
@@ -1,0 +1,46 @@
+"""Enable RLS for signals table."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enable RLS on signals."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("ALTER TABLE signals ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY signals_admin_only ON signals
+        USING (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        WITH CHECK (
+            EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE username = current_setting('app.current_username')::text
+                AND role = 'admin'
+            )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Disable RLS on signals."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("DROP POLICY IF EXISTS signals_admin_only ON signals")
+    op.execute("ALTER TABLE signals DISABLE ROW LEVEL SECURITY")

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -81,6 +81,13 @@ def _insert_row(session: Session, table_name: str) -> None:
             ),
             {"idea_id": idea_id},
         )
+    elif table_name == "refresh_tokens":
+        session.execute(
+            text(
+                "INSERT INTO refresh_tokens (token, username, expires_at) "
+                "VALUES ('t', 'alice', now())"
+            )
+        )
     else:  # pragma: no cover - safeguard for future tables
         raise ValueError(f"Unhandled RLS table {table_name}")
     session.commit()
@@ -88,7 +95,7 @@ def _insert_row(session: Session, table_name: str) -> None:
 
 @pytest.mark.parametrize(
     "table_name",
-    ["audit_logs", "ideas", "signals", "user_roles"],
+    ["audit_logs", "ideas", "signals", "user_roles", "refresh_tokens"],
 )
 def test_rls_enforcement(table_name: str) -> None:
     """Ensure users cannot view each other's rows."""
@@ -130,7 +137,7 @@ def test_identify_rls_tables() -> None:
     with engine.connect() as conn:
         tables = _rls_tables(conn)
 
-    expected = ["audit_logs", "ideas", "signals", "user_roles"]
+    expected = ["audit_logs", "ideas", "signals", "user_roles", "refresh_tokens"]
     assert set(tables) == set(expected)
 
     cleanup()


### PR DESCRIPTION
## Summary
- add row-level security migrations for each service
- merge heads after adding new migrations
- test new refresh_token RLS policy

## Testing
- `flake8 backend/shared/db/migrations tests/test_rls.py`
- `mypy --ignore-missing-imports backend/shared/db/migrations/api_gateway/versions/0009_add_tokens_rls.py backend/shared/db/migrations/scoring_engine/versions/0017_add_rls_to_tables.py backend/shared/db/migrations/marketplace_publisher/versions/e07f77a52d6f_add_rls_policies.py backend/shared/db/migrations/mockup_generation/versions/0002_add_rls_policies.py backend/shared/db/migrations/signal_ingestion/versions/0004_add_rls_policies.py backend/shared/db/migrations/fedcba987654_merge_rls_heads.py`
- `pytest tests/test_rls.py -W error -vv` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_b_687f8129d2008331be7212bd72edb6a3