### PR TITLE
Clean up requirements names

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,12 +2,12 @@ flake8
 black
 mypy
 pydocstyle
-flake8 - docstrings
+flake8-docstrings
 docformatter
 watchdog
 vcrpy
 pytest
-pytest - cov
+pytest-cov
 fakeredis
 tenacity
 responses
@@ -15,24 +15,22 @@ respx
 Pillow
 redis
 asyncpg
-scikit - learn
-pytest - asyncio
+scikit-learn
+pytest-asyncio
 aiosqlite
 typer
 locust
 pynvml
-
 UnleashClient
-launchdarkly - server - sdk
-
-pip - audit
-sphinxcontrib - openapi
-myst - parser
-sentry - sdk
+launchdarkly-server-sdk
+pip-audit
+sphinxcontrib-openapi
+myst-parser
+sentry-sdk
 Deprecated
 testing.postgresql
-sphinxcontrib - mermaid
-openapi - schema - validator
-opentelemetry - exporter - otlp
-python - jose[cryptography]
-pytest - recording
+sphinxcontrib-mermaid
+openapi-schema-validator
+opentelemetry-exporter-otlp
+python-jose[cryptography]
+pytest-recording

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,29 +3,29 @@ uvicorn
 pydantic
 pandas
 pytest
-pytest - cov
+pytest-cov
 requests
 tenacity
 httpx
-requests - mock
-kafka - python
+requests-mock
+kafka-python
 jsonschema
 dagster
-prometheus - client
+prometheus-client
 psutil
-opentelemetry - sdk
-opentelemetry - instrumentation - fastapi
-opentelemetry - instrumentation - flask
-opentelemetry - exporter - jaeger
+opentelemetry-sdk
+opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-flask
+opentelemetry-exporter-jaeger
 apscheduler
 pgvector
 watchtower
 watchdog
 Flask
-pydantic - settings
-psycopg2 - binary
+pydantic-settings
+psycopg2-binary
 UnleashClient
-launchdarkly - server - sdk
-sentry - sdk
+launchdarkly-server-sdk
+sentry-sdk
 Deprecated
 typer


### PR DESCRIPTION
## Summary
- remove spaces around package names in `requirements.txt`
- remove spaces around package names in `requirements-dev.txt`

## Testing
- `pip install -r requirements-dev.txt`

------
https://chatgpt.com/codex/tasks/task_b_687f862ae03883319bf6833ac5b1640d