### PR TITLE
Add pytest-postgresql to development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,3 +34,4 @@ openapi-schema-validator
 opentelemetry-exporter-otlp
 python-jose[cryptography]
 pytest-recording
+pytest-postgresql


### PR DESCRIPTION
## Summary
- include `pytest-postgresql` for Postgres test fixtures

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_687f87fe22fc83318fd41e900dd84a03