### PR TITLE
Add temporary Postgres fixture

### DIFF
--- a/backend/monitoring/tests/test_metrics_store.py
+++ b/backend/monitoring/tests/test_metrics_store.py
@@ -2,20 +2,12 @@
 
 from __future__ import annotations
 
-import shutil
-
 import psycopg2
 import pytest
-from pytest_postgresql import factories
 
 from backend.monitoring.src.monitoring.metrics_store import TimescaleMetricsStore
 
-# Create PostgreSQL fixtures using pytest-postgresql factory
-postgresql_proc = factories.postgresql_proc()
-postgresql = factories.postgresql("postgresql_proc")
 
-
-@pytest.mark.skipif(shutil.which("initdb") is None, reason="initdb not available")
 def test_create_continuous_aggregate(
     postgresql: psycopg2.extensions.connection,
 ) -> None:

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -2,11 +2,9 @@
 
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-import shutil
 
 import pytest
 import psycopg2
-from pytest_postgresql import factories
 
 import backend.monitoring.src.monitoring.metrics_store as metrics_store
 from backend.monitoring.src.monitoring.metrics_store import (
@@ -33,11 +31,6 @@ def test_metrics_insertion(tmp_path: Path) -> None:
     # create aggregate should not fail on SQLite
     store.create_hourly_continuous_aggregate()
     assert store.get_active_users(datetime.now(timezone.utc) - timedelta(hours=1)) == 1
-
-
-# PostgreSQL fixtures using pytest-postgresql
-postgresql_proc = factories.postgresql_proc()
-postgresql = factories.postgresql("postgresql_proc")
 
 
 def test_pool_used_for_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -74,7 +67,6 @@ def test_pool_used_for_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(store, TimescaleMetricsStore)
 
 
-@pytest.mark.skipif(shutil.which("initdb") is None, reason="initdb not available")
 def test_postgresql_metrics(
     postgresql: psycopg2.extensions.connection,
 ) -> None:


### PR DESCRIPTION
## Summary
- provide a temporary PostgreSQL fixture
- use the fixture from metrics store tests
- truncate the metrics table through the fixture

## Testing
- `flake8 tests/conftest.py tests/test_resource_metrics_store.py tests/test_metrics_store.py backend/monitoring/tests/test_metrics_store.py`
- `mypy tests/conftest.py tests/test_resource_metrics_store.py tests/test_metrics_store.py backend/monitoring/tests/test_metrics_store.py --ignore-missing-imports` *(fails: Missing type parameters, unused ignore comments)*
- `pytest tests/test_resource_metrics_store.py::test_add_and_get_metrics -vv` *(fails: coverage under required minimum)*
- `pytest tests/test_metrics_store.py::test_postgresql_metrics -vv` *(fails: coverage under required minimum)*
- `pytest backend/monitoring/tests/test_metrics_store.py::test_create_continuous_aggregate -vv` *(fails: coverage under required minimum)*

------
https://chatgpt.com/codex/tasks/task_b_687f87fcd3708331a83e448f7e9dec17