### PR TITLE
Refactor PostgreSQL tests

### DIFF
--- a/backend/monitoring/tests/test_metrics_store.py
+++ b/backend/monitoring/tests/test_metrics_store.py
@@ -2,23 +2,12 @@
 
 from __future__ import annotations
 
-import shutil
-
-import psycopg2
 import pytest
-from pytest_postgresql import factories
 
 from backend.monitoring.src.monitoring.metrics_store import TimescaleMetricsStore
 
-# Create PostgreSQL fixtures using pytest-postgresql factory
-postgresql_proc = factories.postgresql_proc()
-postgresql = factories.postgresql("postgresql_proc")
 
-
-@pytest.mark.skipif(shutil.which("initdb") is None, reason="initdb not available")
-def test_create_continuous_aggregate(
-    postgresql: psycopg2.extensions.connection,
-) -> None:
+def test_create_continuous_aggregate(postgresql: object) -> None:
     """Ensure continuous aggregate view is created on PostgreSQL."""
     store = TimescaleMetricsStore(postgresql.info.dsn)
     store.create_hourly_continuous_aggregate()

--- a/backend/optimization/tests/test_materialized_view.py
+++ b/backend/optimization/tests/test_materialized_view.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import warnings
-import shutil
-import psycopg2
 import pytest
 from fastapi.testclient import TestClient
-from testing.postgresql import Postgresql
+from typing import Any
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -15,17 +13,12 @@ from backend.optimization import api as opt_api
 from backend.optimization.storage import MetricsStore
 
 
-@pytest.mark.skipif(shutil.which("initdb") is None, reason="initdb not available")
-def test_materialized_view_created() -> None:
+def test_materialized_view_created(postgresql: Any) -> None:
     """Ensure the hourly aggregate view exists after startup."""
-    with Postgresql() as pg:
-        url = pg.url()
-        opt_api.store = MetricsStore(url)
-        with TestClient(opt_api.app):
-            pass
-        with psycopg2.connect(url) as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT 1 FROM pg_matviews WHERE matviewname='metrics_hourly'"
-                )
-                assert cur.fetchone() is not None
+    url = postgresql.info.dsn
+    opt_api.store = MetricsStore(url)
+    with TestClient(opt_api.app):
+        pass
+    with postgresql.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_matviews WHERE matviewname='metrics_hourly'")
+        assert cur.fetchone() is not None

--- a/tests/stubs/kafka.py
+++ b/tests/stubs/kafka.py
@@ -1,0 +1,7 @@
+class KafkaProducer:
+    pass
+
+
+class KafkaConsumer:
+    def __iter__(self):
+        return iter([])

--- a/tests/stubs/pandas.py
+++ b/tests/stubs/pandas.py
@@ -1,0 +1,2 @@
+class DataFrame:
+    pass

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -2,11 +2,8 @@
 
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-import shutil
 
 import pytest
-import psycopg2
-from pytest_postgresql import factories
 
 import backend.monitoring.src.monitoring.metrics_store as metrics_store
 from backend.monitoring.src.monitoring.metrics_store import (
@@ -33,11 +30,6 @@ def test_metrics_insertion(tmp_path: Path) -> None:
     # create aggregate should not fail on SQLite
     store.create_hourly_continuous_aggregate()
     assert store.get_active_users(datetime.now(timezone.utc) - timedelta(hours=1)) == 1
-
-
-# PostgreSQL fixtures using pytest-postgresql
-postgresql_proc = factories.postgresql_proc()
-postgresql = factories.postgresql("postgresql_proc")
 
 
 def test_pool_used_for_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -74,10 +66,7 @@ def test_pool_used_for_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(store, TimescaleMetricsStore)
 
 
-@pytest.mark.skipif(shutil.which("initdb") is None, reason="initdb not available")
-def test_postgresql_metrics(
-    postgresql: psycopg2.extensions.connection,
-) -> None:
+def test_postgresql_metrics(postgresql: object) -> None:
     """Verify metrics operations work with PostgreSQL."""
     store = TimescaleMetricsStore(postgresql.info.dsn)
     metric = ScoreMetric(idea_id=2, timestamp=datetime.now(timezone.utc), score=0.9)


### PR DESCRIPTION
## Summary
- standardize to a single temporary PostgreSQL fixture
- refactor tests to use the new fixture
- add lightweight stubs for kafka and pandas

## Testing
- `flake8 tests/conftest.py tests/test_metrics_store.py backend/monitoring/tests/test_metrics_store.py backend/optimization/tests/test_materialized_view.py`
- `mypy --ignore-missing-imports tests/conftest.py tests/test_metrics_store.py backend/monitoring/tests/test_metrics_store.py backend/optimization/tests/test_materialized_view.py`
- `docformatter -i tests/conftest.py tests/test_metrics_store.py backend/monitoring/tests/test_metrics_store.py backend/optimization/tests/test_materialized_view.py`
- `pydocstyle tests/conftest.py tests/test_metrics_store.py backend/monitoring/tests/test_metrics_store.py backend/optimization/tests/test_materialized_view.py`
- `SKIP_HEAVY_DEPS=1 pytest tests/test_metrics_store.py backend/monitoring/tests/test_metrics_store.py backend/optimization/tests/test_materialized_view.py -W error -vv` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_b_687f87ff21908331a5489136d2a043ed