### PR TITLE
Add pydantic-settings & document dependency install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 ./scripts/setup_codex.sh
 ```
 
+## Installing dependencies
+
+Install Python and Node requirements before running tests or building the
+documentation.
+
+```bash
+python -m pip install -r requirements.txt -r requirements-dev.txt
+npm ci --legacy-peer-deps
+```
+
+Build the HTML documentation locally with:
+
+```bash
+make -C docs html
+```
+
 
 ## Development helpers
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,29 @@ The `scripts` directory provides helper scripts for setting up storage and CDN r
 - Base Kubernetes manifests can be found in `infrastructure/k8s` with instructions for
   customizing them for local Minikube testing.
   Each script performs basic sanity checks and is safe to run multiple times.
-  Re-running them will validate the existing resources and skip changes when not needed.
-  This document merges the original project summary, system architecture, deployment guide, implementation plan and all earlier blueprint versions into one reference.
+Re-running them will validate the existing resources and skip changes when not needed.
+This document merges the original project summary, system architecture, deployment guide, implementation plan and all earlier blueprint versions into one reference.
+
+## Installing dependencies
+
+Use pip and npm to install the packages required for running tests and building the documentation.
+
+```bash
+python -m pip install -r requirements.txt -r requirements-dev.txt
+npm ci --legacy-peer-deps
+```
+
+Build the HTML documentation with:
+
+```bash
+make -C docs html
+```
+
+Execute the full test suite using:
+
+```bash
+make test
+```
 
 Example lifecycle rule for AWS S3 buckets:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,9 +21,11 @@ aiosqlite
 typer
 locust
 pynvml
+pydantic-settings
 UnleashClient
 launchdarkly-server-sdk
 pip-audit
+sphinx
 sphinxcontrib-openapi
 myst-parser
 sentry-sdk


### PR DESCRIPTION
## Summary
- add missing dev dependencies
- document installing requirements
- explain how to build docs and run tests

## Testing
- `python -m pip install -r requirements.txt -r requirements-dev.txt`
- `npm ci --legacy-peer-deps`
- `SKIP_APIDOC=1 SKIP_OPENAPI=1 make -C docs html SPHINXBUILD="python -m sphinx"`
- `pytest -W error -vv` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687f88239a78833195b63f656e85b09a