### PR TITLE
Improve deployment workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -105,3 +105,34 @@ jobs:
           TAG: ${{ github.sha }}
           ENV: prod
         run: make helm-deploy REGISTRY=$REGISTRY TAG=$TAG ENV=$ENV
+
+  docs:
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt \
+            sphinx docformatter flake8 flake8-docstrings myst-parser sphinxcontrib-mermaid openapi-spec-validator
+      - name: Generate OpenAPI specs
+        run: python scripts/generate_openapi.py
+      - name: Validate OpenAPI specs
+        run: openapi-spec-validator openapi/*.json
+      - name: Build documentation
+        run: make -C docs html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_build/html
+      - name: Deploy documentation
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -26,4 +26,9 @@ jobs:
             scoring-engine marketplace-publisher feedback-loop
           registry: example
           tag: main
+      - name: Wait for health checks
+        run: |
+          ./scripts/check_k8s_health.sh staging \
+            orchestrator ai-mockup-generation data-storage signal-ingestion \
+            scoring-engine marketplace-publisher feedback-loop
 

--- a/scripts/check_k8s_health.sh
+++ b/scripts/check_k8s_health.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Wait for Kubernetes services to pass readiness checks.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <namespace> <service1> [service2 ...]" >&2
+  exit 1
+fi
+
+NAMESPACE="$1"
+shift
+SERVICES=("$@")
+
+TIMEOUT=${TIMEOUT:-60}
+
+for svc in "${SERVICES[@]}"; do
+  echo "Waiting for $svc in namespace $NAMESPACE"
+  port="$(kubectl get service "$svc" -n "$NAMESPACE" -o jsonpath='{.spec.ports[0].port}')"
+  local_port=$((RANDOM%30000 + 1025))
+  kubectl port-forward "service/$svc" "$local_port:$port" -n "$NAMESPACE" >/tmp/pf-$svc.log 2>&1 &
+  pf_pid=$!
+  start=$(date +%s)
+  until curl -fsS "http://localhost:$local_port/ready" >/dev/null 2>&1; do
+    if [[ $(($(date +%s) - start)) -ge $TIMEOUT ]]; then
+      echo "$svc failed readiness check"
+      kill "$pf_pid" || true
+      exit 1
+    fi
+    sleep 2
+  done
+  kill "$pf_pid"
+  echo "$svc is healthy"
+  rm -f "/tmp/pf-$svc.log"
+done
+
+echo "All services healthy"


### PR DESCRIPTION
## Summary
- add wait-for-health step in staging deploy job
- publish documentation from pipeline
- provide helper script to wait for Kubernetes health checks

## Testing
- `shellcheck scripts/check_k8s_health.sh`
- `pytest tests/test_monitoring.py -k health_ready_endpoints -W error -vv` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687f9364f1b483318922e834d6f342d5