### PR TITLE
Add OpenAPI generation to CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,6 +29,8 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
           npm ci
           python -m pip install -e .
+      - name: Generate OpenAPI specs
+        run: python scripts/generate_openapi.py
       - name: Run linting
         run: make lint
       - name: Run tests

--- a/docs/openapi_specs.rst
+++ b/docs/openapi_specs.rst
@@ -2,7 +2,8 @@ OpenAPI Specifications
 ======================
 
 The following specifications describe each microservice's HTTP API. They are
-automatically generated using ``scripts/generate_openapi.py``.
+automatically generated using ``scripts/generate_openapi.py``. Each service
+exposes its schema at ``/openapi.json``.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Summary
- generate OpenAPI specs during CI
- stub external deps in the generator to avoid runtime issues
- document that services expose `/openapi.json`

## Testing
- `flake8 scripts/generate_openapi.py`
- `mypy --ignore-missing-imports scripts/generate_openapi.py` *(fails: found 39 errors)*
- `pytest -W error -vv` *(fails: 69 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687f9726467c8331b5938d81537ab149