### PR TITLE
Add automatic spot node maintenance

### DIFF
--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -22,6 +22,7 @@ from .ops import (
     sync_listing_states_op,
     purge_pii_rows_op,
     benchmark_score_op,
+    maintain_spot_nodes_op,
 )
 from .hooks import record_failure, record_success
 
@@ -127,3 +128,9 @@ def publishing_job() -> None:
 def feedback_update_job() -> None:
     """Job updating scoring weights from feedback data."""
     update_feedback()
+
+
+@job(hooks={record_success, record_failure}, op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]
+def maintain_spot_nodes_job() -> None:
+    """Job ensuring spot nodes are present."""
+    maintain_spot_nodes_op()

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -331,3 +331,19 @@ def update_feedback(context) -> None:  # type: ignore[no-untyped-def]
         context.log.warning("failed to update feedback weights: %s", exc)
     else:
         context.log.debug("updated weights: %s", weights)
+
+
+@op  # type: ignore[misc]
+def maintain_spot_nodes_op(context) -> None:  # type: ignore[no-untyped-def]
+    """Ensure the configured number of spot nodes are running."""
+    context.log.info("checking spot nodes")
+    from scripts.manage_spot_instances import maintain_nodes
+
+    ami = os.environ["SPOT_AMI_ID"]
+    itype = os.environ["SPOT_INSTANCE_TYPE"]
+    key = os.environ["SPOT_KEY_NAME"]
+    sg = os.environ["SPOT_SECURITY_GROUP"]
+    subnet = os.environ["SPOT_SUBNET_ID"]
+    label = os.environ.get("SPOT_LABEL", "node-role.kubernetes.io/spot=yes")
+    count = int(os.environ.get("SPOT_COUNT", "1"))
+    maintain_nodes(ami, itype, key, sg, subnet, label=label, count=count)

--- a/backend/orchestrator/orchestrator/schedules.py
+++ b/backend/orchestrator/orchestrator/schedules.py
@@ -13,22 +13,23 @@ from .jobs import (
     privacy_purge_job,
     idea_job,
     feedback_update_job,
+    maintain_spot_nodes_job,
 )
 
 
-@schedule(cron_schedule="0 0 * * *", job=backup_job, execution_timezone="UTC")
+@schedule(cron_schedule="0 0 * * *", job=backup_job, execution_timezone="UTC")  # type: ignore[misc]
 def daily_backup_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
     """Trigger ``backup_job`` every day."""
     return {}
 
 
-@schedule(cron_schedule="0 * * * *", job=cleanup_job, execution_timezone="UTC")
+@schedule(cron_schedule="0 * * * *", job=cleanup_job, execution_timezone="UTC")  # type: ignore[misc]
 def hourly_cleanup_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
     """Trigger ``cleanup_job`` every hour."""
     return {}
 
 
-@schedule(
+@schedule(  # type: ignore[misc]
     cron_schedule="30 6 * * *", job=analyze_query_plans_job, execution_timezone="UTC"
 )
 def daily_query_plan_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
@@ -36,13 +37,13 @@ def daily_query_plan_schedule(_context: ScheduleEvaluationContext) -> dict[str, 
     return {}
 
 
-@schedule(cron_schedule="5 0 * * *", job=daily_summary_job, execution_timezone="UTC")
+@schedule(cron_schedule="5 0 * * *", job=daily_summary_job, execution_timezone="UTC")  # type: ignore[misc]
 def daily_summary_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
     """Trigger ``daily_summary_job`` every day."""
     return {}
 
 
-@schedule(cron_schedule="0 0 1 * *", job=rotate_secrets_job, execution_timezone="UTC")
+@schedule(cron_schedule="0 0 1 * *", job=rotate_secrets_job, execution_timezone="UTC")  # type: ignore[misc]
 def monthly_secret_rotation_schedule(
     _context: ScheduleEvaluationContext,
 ) -> dict[str, object]:
@@ -50,7 +51,7 @@ def monthly_secret_rotation_schedule(
     return {}
 
 
-@schedule(cron_schedule="0 1 1 * *", job=rotate_s3_keys_job, execution_timezone="UTC")
+@schedule(cron_schedule="0 1 1 * *", job=rotate_s3_keys_job, execution_timezone="UTC")  # type: ignore[misc]
 def rotate_s3_keys_schedule(
     _context: ScheduleEvaluationContext,
 ) -> dict[str, object]:
@@ -58,7 +59,7 @@ def rotate_s3_keys_schedule(
     return {}
 
 
-@schedule(cron_schedule="0 2 * * *", job=sync_listings_job, execution_timezone="UTC")
+@schedule(cron_schedule="0 2 * * *", job=sync_listings_job, execution_timezone="UTC")  # type: ignore[misc]
 def daily_listing_sync_schedule(
     _context: ScheduleEvaluationContext,
 ) -> dict[str, object]:
@@ -66,7 +67,7 @@ def daily_listing_sync_schedule(
     return {}
 
 
-@schedule(cron_schedule="0 0 * * 0", job=privacy_purge_job, execution_timezone="UTC")
+@schedule(cron_schedule="0 0 * * 0", job=privacy_purge_job, execution_timezone="UTC")  # type: ignore[misc]
 def weekly_privacy_purge_schedule(
     _context: ScheduleEvaluationContext,
 ) -> dict[str, object]:
@@ -74,15 +75,25 @@ def weekly_privacy_purge_schedule(
     return {}
 
 
-@schedule(cron_schedule="15 * * * *", job=idea_job, execution_timezone="UTC")
+@schedule(cron_schedule="15 * * * *", job=idea_job, execution_timezone="UTC")  # type: ignore[misc]
 def hourly_idea_schedule(_context: ScheduleEvaluationContext) -> dict[str, object]:
     """Run ``idea_job`` every hour."""
     return {}
 
 
-@schedule(cron_schedule="0 3 * * *", job=feedback_update_job, execution_timezone="UTC")
+@schedule(cron_schedule="0 3 * * *", job=feedback_update_job, execution_timezone="UTC")  # type: ignore[misc]
 def daily_feedback_update_schedule(
     _context: ScheduleEvaluationContext,
 ) -> dict[str, object]:
     """Update feedback weights once per day."""
+    return {}
+
+
+@schedule(  # type: ignore[misc]
+    cron_schedule="*/10 * * * *", job=maintain_spot_nodes_job, execution_timezone="UTC"
+)
+def maintain_spot_nodes_schedule(
+    _context: ScheduleEvaluationContext,
+) -> dict[str, object]:
+    """Check spot nodes every ten minutes."""
     return {}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -19,8 +19,8 @@ The API Gateway exposes `/approvals` for fetching pending runs and
 
 ## Spot Instances
 
-Use `scripts/manage_spot_instances.py` to request and release AWS spot nodes. A
-typical workflow to add a worker is:
+Use `scripts/manage_spot_instances.py` to request, release, or maintain AWS spot
+nodes. A typical workflow to add a worker is:
 
 ```bash
 python scripts/manage_spot_instances.py request \
@@ -39,7 +39,19 @@ python scripts/manage_spot_instances.py release i-0abcd1234ef567890
 ```
 
 Workers will checkpoint tasks using Celery's statedb so another node can resume
-processing when a spot instance is reclaimed.
+processing when a spot instance is reclaimed. To keep ``N`` workers running at
+all times execute the ``maintain`` command, which is scheduled every ten
+minutes by the orchestrator:
+
+```bash
+python scripts/manage_spot_instances.py maintain \
+  --ami-id ami-12345678 \
+  --instance-type g4dn.xlarge \
+  --key-name kube-key \
+  --security-group sg-12345678 \
+  --subnet-id subnet-12345678 \
+  --count 2
+```
 
 ## Quota Handling
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -51,8 +51,8 @@ Python utilities
      - Scheduled cleanup tasks executed by Dagster.
      - ``python scripts/maintenance.py``
    * - ``manage_spot_instances.py``
-     - Request or release AWS spot nodes.
-     - ``python scripts/manage_spot_instances.py request``
+     - Manage AWS spot nodes.
+     - ``python scripts/manage_spot_instances.py maintain --count 2``
    * - ``register_schemas.py``
      - Upload JSON schemas to the registry.
      - ``python scripts/register_schemas.py``

--- a/scripts/manage_spot_instances.py
+++ b/scripts/manage_spot_instances.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import time
+from typing import Iterable
 
 import boto3
 
@@ -38,7 +39,7 @@ def request_instance(
             }
         ],
     )
-    return resp["Instances"][0]["InstanceId"]
+    return str(resp["Instances"][0]["InstanceId"])
 
 
 def label_node(instance_id: str, label: str) -> None:
@@ -63,6 +64,60 @@ def release_instance(instance_id: str) -> None:
     ec2.terminate_instances(InstanceIds=[instance_id])
 
 
+def _list_instances(label: str) -> list[str]:
+    """Return IDs of running or pending instances matching the label."""
+    ec2 = boto3.client("ec2")
+    key, value = label.split("=")
+    resp = ec2.describe_instances(
+        Filters=[
+            {"Name": f"tag:{key}", "Values": [value]},
+            {"Name": "instance-state-name", "Values": ["pending", "running"]},
+        ]
+    )
+    ids: list[str] = []
+    for res in resp.get("Reservations", []):
+        for inst in res.get("Instances", []):
+            ids.append(inst["InstanceId"])
+    return ids
+
+
+def _ready_nodes(label: str) -> Iterable[str]:
+    """Yield Kubernetes node names with the given label that are Ready."""
+    cmd = ["kubectl", "get", "nodes", "-l", label, "--no-headers"]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == "Ready":
+            yield parts[0]
+
+
+def maintain_nodes(
+    ami_id: str,
+    instance_type: str,
+    key_name: str,
+    security_group: str,
+    subnet_id: str,
+    *,
+    label: str = "node-role.kubernetes.io/spot=yes",
+    count: int = 1,
+) -> None:
+    """Ensure ``count`` spot nodes are available."""
+    ready = list(_ready_nodes(label))
+    missing = count - len(ready)
+    if missing <= 0:
+        return
+    for _ in range(missing):
+        instance_id = request_instance(
+            ami_id,
+            instance_type,
+            key_name,
+            security_group,
+            subnet_id,
+            label=label,
+        )
+        label_node(instance_id, label)
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -78,6 +133,15 @@ def parse_args() -> argparse.Namespace:
 
     rel = sub.add_parser("release")
     rel.add_argument("instance_id")
+
+    maint = sub.add_parser("maintain")
+    maint.add_argument("--ami-id", required=True)
+    maint.add_argument("--instance-type", required=True)
+    maint.add_argument("--key-name", required=True)
+    maint.add_argument("--security-group", required=True)
+    maint.add_argument("--subnet-id", required=True)
+    maint.add_argument("--label", default="node-role.kubernetes.io/spot=yes")
+    maint.add_argument("--count", type=int, default=1)
     return parser.parse_args()
 
 
@@ -97,6 +161,16 @@ def main() -> None:
         print(instance_id)
     elif args.cmd == "release":
         release_instance(args.instance_id)
+    elif args.cmd == "maintain":
+        maintain_nodes(
+            args.ami_id,
+            args.instance_type,
+            args.key_name,
+            args.security_group,
+            args.subnet_id,
+            label=args.label,
+            count=args.count,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure Kubernetes spot nodes are labelled, monitored, and replaced via `manage_spot_instances.py`
- expose new `maintain_spot_nodes_op` with job and schedule in the orchestrator
- document spot node maintenance in operations guide and scripts reference

## Testing
- `python -m mypy scripts/manage_spot_instances.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/jobs.py backend/orchestrator/orchestrator/schedules.py --ignore-missing-imports --follow-imports=skip`
- `SKIP_OPENAPI=1 SKIP_APIDOC=1 python -m sphinx -W -b html docs docs/_build/html`
- `python -m pytest -W error -vv` *(fails: connection refused to localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_b_687f99b5e5e88331876be980cbb9a013