### PR TITLE
Add monitoring docs and PagerDuty hooks

### DIFF
--- a/backend/monitoring/src/monitoring/pagerduty.py
+++ b/backend/monitoring/src/monitoring/pagerduty.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from .settings import settings
-
 import requests
+
 from backend.shared.http import request_with_retry
+from .settings import settings
 
 PAGERDUTY_URL = "https://events.pagerduty.com/v2/enqueue"
 
 
-def trigger_sla_violation(duration_hours: float) -> None:
-    """Send a PagerDuty alert for SLA breach if routing key configured."""
+def _send_event(summary: str, severity: str, source: str) -> None:
+    """Send an event to PagerDuty if integration is enabled."""
+
     if not settings.enable_pagerduty:
         return
     routing_key = os.environ.get("PAGERDUTY_ROUTING_KEY")
@@ -24,34 +25,32 @@ def trigger_sla_violation(duration_hours: float) -> None:
         "routing_key": routing_key,
         "event_action": "trigger",
         "payload": {
-            "summary": f"Signal-to-publish time {duration_hours:.2f}h exceeded SLA",
-            "severity": "error",
-            "source": "desAInz monitoring",
+            "summary": summary,
+            "severity": severity,
+            "source": source,
         },
     }
     try:
         request_with_retry("POST", PAGERDUTY_URL, json=payload, timeout=5)
     except requests.RequestException:
         pass
+
+
+def trigger_sla_violation(duration_hours: float) -> None:
+    """Send an alert when the SLA threshold is breached."""
+
+    _send_event(
+        summary=f"Signal-to-publish time {duration_hours:.2f}h exceeded SLA",
+        severity="error",
+        source="desAInz monitoring",
+    )
 
 
 def notify_listing_issue(listing_id: int, state: str) -> None:
     """Alert administrators that ``listing_id`` needs attention."""
-    if not settings.enable_pagerduty:
-        return
-    routing_key = os.environ.get("PAGERDUTY_ROUTING_KEY")
-    if not routing_key:
-        return
-    payload: dict[str, Any] = {
-        "routing_key": routing_key,
-        "event_action": "trigger",
-        "payload": {
-            "summary": f"Listing {listing_id} is {state}",
-            "severity": "warning",
-            "source": "desAInz listing sync",
-        },
-    }
-    try:
-        request_with_retry("POST", PAGERDUTY_URL, json=payload, timeout=5)
-    except requests.RequestException:
-        pass
+
+    _send_event(
+        summary=f"Listing {listing_id} is {state}",
+        severity="warning",
+        source="desAInz listing sync",
+    )

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -2,15 +2,24 @@ scrape_configs:
   - job_name: 'monitoring'
     static_configs:
       - targets: ['monitoring:8000']
-  - job_name: 'services'
+  - job_name: 'api-gateway'
     static_configs:
-      - targets:
-          - 'api-gateway:8000'
-          - 'analytics:8000'
-          - 'optimization:8000'
-          - 'service-template:8000'
-          - 'signal-ingestion:8000'
-          - 'feedback-loop:8000'
-          - 'marketplace-publisher:8000'
-          - 'mockup-generation:8000'
-          - 'scoring-engine:5002'
+      - targets: ['api-gateway:8000']
+  - job_name: 'mockup-generation'
+    static_configs:
+      - targets: ['mockup-generation:8000']
+  - job_name: 'scoring-engine'
+    static_configs:
+      - targets: ['scoring-engine:5002']
+  - job_name: 'marketplace-publisher'
+    static_configs:
+      - targets: ['marketplace-publisher:8000']
+  - job_name: 'signal-ingestion'
+    static_configs:
+      - targets: ['signal-ingestion:8000']
+  - job_name: 'feedback-loop'
+    static_configs:
+      - targets: ['feedback-loop:8000']
+  - job_name: 'orchestrator'
+    static_configs:
+      - targets: ['orchestrator:3000']

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -48,3 +48,40 @@ Dashboards include:
 - `queue_length.json`
 - `resource_usage.json`
 - `optimization.json`
+- `service_health.json`
+
+## Prometheus Scrape Configuration
+
+Prometheus is configured through `docker/prometheus/prometheus.yml`. Each service exposes metrics on `/metrics` and the file defines one scrape job per service:
+
+```yaml
+    scrape_configs:
+      - job_name: 'monitoring'
+        static_configs:
+          - targets: ['monitoring:8000']
+      - job_name: 'api-gateway'
+        static_configs:
+          - targets: ['api-gateway:8000']
+      - job_name: 'mockup-generation'
+        static_configs:
+          - targets: ['mockup-generation:8000']
+      - job_name: 'scoring-engine'
+        static_configs:
+          - targets: ['scoring-engine:5002']
+      - job_name: 'marketplace-publisher'
+        static_configs:
+          - targets: ['marketplace-publisher:8000']
+      - job_name: 'signal-ingestion'
+        static_configs:
+          - targets: ['signal-ingestion:8000']
+      - job_name: 'feedback-loop'
+        static_configs:
+          - targets: ['feedback-loop:8000']
+      - job_name: 'orchestrator'
+        static_configs:
+          - targets: ['orchestrator:3000']
+```
+
+## PagerDuty Alerts
+
+Set `PAGERDUTY_ROUTING_KEY` and `ENABLE_PAGERDUTY=true` in the environment to enable alerting. The monitoring service triggers alerts when the average publish latency breaches the configured SLA and when listing synchronization detects issues.

--- a/infrastructure/grafana/dashboards/service_health.json
+++ b/infrastructure/grafana/dashboards/service_health.json
@@ -1,0 +1,15 @@
+{
+  "title": "Service Health",
+  "datasource": "Prometheus",
+  "schemaVersion": 30,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "targets": [
+        {"expr": "rate(process_cpu_seconds_total[1m])", "refId": "A"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- define Prometheus scrape configs per service
- add sample Grafana dashboard for service health
- extend PagerDuty alert helpers
- document monitoring setup

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `npm install --legacy-peer-deps`
- `pytest` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_b_687f99b1623483318b5039cfa180bdd4