### PR TITLE
Add index to marketplace metrics

### DIFF
--- a/backend/shared/db/migrations/scoring_engine/versions/0018_add_marketplace_metric_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0018_add_marketplace_metric_index.py
@@ -1,0 +1,37 @@
+"""Ensure index for marketplace metrics listing_id."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create index for listing_id on marketplace_metrics if missing."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = [idx["name"] for idx in inspector.get_indexes("marketplace_metrics")]
+    if "ix_marketplace_metrics_listing_id" not in indexes:
+        op.create_index(
+            op.f("ix_marketplace_metrics_listing_id"),
+            "marketplace_metrics",
+            ["listing_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop the marketplace_metrics listing_id index if present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = [idx["name"] for idx in inspector.get_indexes("marketplace_metrics")]
+    if "ix_marketplace_metrics_listing_id" in indexes:
+        op.drop_index(
+            op.f("ix_marketplace_metrics_listing_id"),
+            table_name="marketplace_metrics",
+        )

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -6,7 +6,16 @@ from datetime import datetime
 
 from typing import Any
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, JSON
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    JSON,
+    Index,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from pgvector.sqlalchemy import Vector
 
@@ -116,6 +125,7 @@ class MarketplaceMetric(Base):
     """Aggregated metrics for a marketplace listing."""
 
     __tablename__ = "marketplace_metrics"
+    __table_args__ = (Index("ix_marketplace_metrics_listing_id", "listing_id"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     listing_id: Mapped[int] = mapped_column(ForeignKey("listings.id"))


### PR DESCRIPTION
## Summary
- ensure MarketplaceMetric model declares listing_id index
- add Alembic migration 0018 to enforce the index

## Testing
- `flake8 backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0018_add_marketplace_metric_index.py`
- `mypy backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0018_add_marketplace_metric_index.py --ignore-missing-imports --check-untyped-defs --disallow-untyped-defs --follow-imports=skip`
- `pydocstyle backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0018_add_marketplace_metric_index.py`
- `pytest tests/test_migrations.py::test_migrations -vv` *(fails: NotImplementedError for ALTER on SQLite)*

------
https://chatgpt.com/codex/tasks/task_b_687fa7d214188331a5ec374a2e7e6221