### PR TITLE
Add ABTestResult index

### DIFF
--- a/backend/mockup-generation/tests/test_nsfw.py
+++ b/backend/mockup-generation/tests/test_nsfw.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import pytest
 from PIL import Image
 
 from mockup_generation.post_processor import ensure_not_nsfw
 
 
-@pytest.mark.skip("model heavy")
 def test_ensure_not_nsfw() -> None:
     """Smoke test for NSFW detection function."""
     img = Image.new("RGB", (32, 32), color="white")

--- a/backend/shared/db/migrations/scoring_engine/versions/0019_add_ab_test_result_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0019_add_ab_test_result_index.py
@@ -1,0 +1,37 @@
+"""Ensure index for AB test result ab_test_id."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create index for ab_test_id on ab_test_results if missing."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = [idx["name"] for idx in inspector.get_indexes("ab_test_results")]
+    if "ix_ab_test_results_ab_test_id" not in indexes:
+        op.create_index(
+            op.f("ix_ab_test_results_ab_test_id"),
+            "ab_test_results",
+            ["ab_test_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop the ab_test_results ab_test_id index if present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = [idx["name"] for idx in inspector.get_indexes("ab_test_results")]
+    if "ix_ab_test_results_ab_test_id" in indexes:
+        op.drop_index(
+            op.f("ix_ab_test_results_ab_test_id"),
+            table_name="ab_test_results",
+        )

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -111,6 +111,7 @@ class ABTestResult(Base):
     """Outcome metrics for an A/B test variant."""
 
     __tablename__ = "ab_test_results"
+    __table_args__ = (Index("ix_ab_test_results_ab_test_id", "ab_test_id"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     ab_test_id: Mapped[int] = mapped_column(ForeignKey("ab_tests.id"))


### PR DESCRIPTION
## Summary
- add ab_test_id index in `ABTestResult`
- migrate database to create the index
- enable NSFW test

## Testing
- `black backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0019_add_ab_test_result_index.py backend/mockup-generation/tests/test_nsfw.py`
- `flake8 backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0019_add_ab_test_result_index.py backend/mockup-generation/tests/test_nsfw.py`
- `mypy --config-file pyproject.toml backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0019_add_ab_test_result_index.py backend/mockup-generation/tests/test_nsfw.py --ignore-missing-imports` *(fails: Found 14 errors)*
- `PYTHONPATH=backend/mockup-generation pytest backend/mockup-generation/tests/test_nsfw.py tests/test_migrations.py tests/integration/test_alembic_heads.py -q` *(fails: 3 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_b_687faa46fa008331aff1755e4597ea27