### PR TITLE
Switch fallback API to async httpx

### DIFF
--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -118,10 +118,14 @@ async def test_full_flow(
         self.pipeline = DummyPipe()
 
     monkeypatch.setattr(MockupGenerator, "load", fake_load)
+
+    async def _fallback(_: str) -> SimpleNamespace:  # pragma: no cover
+        return SimpleNamespace(save=lambda pth: Path(pth).touch())
+
     monkeypatch.setattr(
         MockupGenerator,
         "_fallback_api",
-        staticmethod(lambda p: SimpleNamespace(save=lambda pth: Path(pth).touch())),
+        staticmethod(_fallback),
     )
 
     import signal_ingestion.dedup as dedup

--- a/tests/integration/test_pipeline_metrics.py
+++ b/tests/integration/test_pipeline_metrics.py
@@ -117,10 +117,14 @@ async def test_pipeline_with_metrics(
         self.pipeline = None
 
     monkeypatch.setattr(MockupGenerator, "load", fake_load)
+
+    async def _fallback(_: str) -> SimpleNamespace:  # pragma: no cover
+        return SimpleNamespace(save=lambda pth: Path(pth).touch())
+
     monkeypatch.setattr(
         MockupGenerator,
         "_fallback_api",
-        staticmethod(lambda p: SimpleNamespace(save=lambda pth: Path(pth).touch())),
+        staticmethod(_fallback),
     )
 
     store = set()

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -69,7 +69,7 @@ async def test_end_to_end(
     def fake_load(self) -> None:  # pragma: no cover
         self.pipeline = None
 
-    def fallback(prompt: str) -> Image.Image:  # pragma: no cover
+    async def fallback(prompt: str) -> Image.Image:  # pragma: no cover
         return Image.new("RGB", (1, 1), color="white")
 
     monkeypatch.setattr(MockupGenerator, "load", fake_load)


### PR DESCRIPTION
## Summary
- refactor `MockupGenerator._fallback_api` to use `httpx.AsyncClient`
- retry with `asyncio.sleep`
- update call sites and tests for async behavior

## Testing
- `flake8 backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator.py tests/integration/test_workflow.py tests/integration/test_full_flow.py tests/integration/test_pipeline_metrics.py`
- `docformatter --check backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator.py tests/integration/test_workflow.py tests/integration/test_full_flow.py tests/integration/test_pipeline_metrics.py`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'kafka')*

------
https://chatgpt.com/codex/tasks/task_b_687fc80c8d788331835943526ce59939