### PR TITLE
Add IVFFlat embedding index

### DIFF
--- a/backend/shared/db/migrations/scoring_engine/versions/9d65e57e4cfe_add_ivfflat_embedding_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/9d65e57e4cfe_add_ivfflat_embedding_index.py
@@ -1,0 +1,31 @@
+"""Add IVFFlat index for embeddings."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "9d65e57e4cfe"
+down_revision = "063f6dbe017c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create IVFFlat index for embedding vector similarity."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.create_index(
+        "ix_embeddings_vector",
+        "embeddings",
+        ["embedding"],
+        postgresql_using="ivfflat",
+    )
+
+
+def downgrade() -> None:
+    """Drop IVFFlat index for embeddings."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.drop_index("ix_embeddings_vector", table_name="embeddings")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -159,6 +159,9 @@ class Embedding(Base):
     """Content embedding stored as a pgvector."""
 
     __tablename__ = "embeddings"
+    __table_args__ = (
+        Index("ix_embeddings_vector", "embedding", postgresql_using="ivfflat"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     source: Mapped[str] = mapped_column(String(50))

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -36,6 +36,16 @@ PostgreSQL. Then run the following once per database:
 
    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
+pgvector Extension
+------------------
+
+Vector similarity search relies on the `pgvector` extension. Enable it on each
+database before applying migrations:
+
+.. code-block:: sql
+
+   CREATE EXTENSION IF NOT EXISTS vector;
+
 HTTP Timeouts
 -------------
 


### PR DESCRIPTION
## Summary
- add ivfflat index on embeddings
- create alembic migration
- document pgvector extension requirement

## Testing
- `flake8 backend/shared/db/models.py`
- `mypy backend/shared/db/migrations/scoring_engine/versions/9d65e57e4cfe_add_ivfflat_embedding_index.py --ignore-missing-imports --follow-imports=skip`
- `pytest -q` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_b_687fcbfc873c8331bed98edcbecb02a2