### PR TITLE
Optimize trending keyword trimming

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -17,7 +17,7 @@ from backend.shared.db import run_migrations_if_needed
 from .scheduler import create_scheduler
 from .ingestion import ingest
 from . import dedup
-from .trending import get_top_keywords
+from . import trending as trending_mod
 from .logging_config import configure_logging
 from .settings import settings
 from backend.shared.config import settings as shared_settings
@@ -124,7 +124,7 @@ async def ingest_signals(
 @app.get("/trending")
 async def trending(limit: int = 10) -> list[str]:
     """Return up to ``limit`` trending keywords."""
-    return get_top_keywords(limit)
+    return trending_mod.get_top_keywords(limit)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- use `ZREMRANGEBYSCORE` and `ZSCAN` in `trim_keywords`
- call `get_top_keywords` dynamically for easier testing
- avoid trace lookup failures in `_trace_id`

## Testing
- `mypy --follow-imports=skip backend/signal-ingestion/src/signal_ingestion/main.py`
- `mypy --follow-imports=skip backend/shared/errors.py`
- `mypy --follow-imports=skip backend/signal-ingestion/src/signal_ingestion/trending.py`
- `PYTHONPATH=backend/signal-ingestion/src pytest backend/signal-ingestion/tests/test_trending.py -W error -vv --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_b_687fcc015e288331a69dae4fc909c0db