### PR TITLE
Load CLIP model once

### DIFF
--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -12,6 +12,7 @@ from .metrics import register_metrics
 from .responses import cache_header, json_cached
 from .config import settings
 from .security import add_security_headers
+from .clip import load_clip, open_clip, torch
 
 __all__ = [
     "add_profiling",
@@ -29,4 +30,7 @@ __all__ = [
     "json_cached",
     "settings",
     "add_security_headers",
+    "load_clip",
+    "open_clip",
+    "torch",
 ]

--- a/backend/shared/clip.py
+++ b/backend/shared/clip.py
@@ -1,0 +1,45 @@
+"""
+Utilities for loading CLIP models.
+
+This module caches initialized CLIP models so workers can reuse the heavy
+weights without repeated startup cost. The underlying ``open_clip`` and
+``torch`` packages are imported lazily, remaining ``None`` when unavailable.
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Any, Callable, Dict, Tuple
+
+open_clip = None
+torch = None
+
+# Cache loaded models keyed by "model:pretrained"
+_models: Dict[str, Tuple[Any, Callable[[Any], Any], Callable[[Any], Any]]] = {}
+_lock = Lock()
+
+
+def load_clip(
+    model_name: str, pretrained: str = "openai"
+) -> Tuple[Any, Callable[[Any], Any], Callable[[Any], Any]] | None:
+    """Return a cached CLIP model, preprocess function and tokenizer."""
+    global open_clip, torch
+    if open_clip is None or torch is None:
+        try:  # pragma: no cover - optional heavy dependency
+            import open_clip as _open_clip
+            import torch as _torch
+        except Exception:  # pragma: no cover - fallback when open_clip unavailable
+            return None
+        open_clip = _open_clip
+        torch = _torch
+
+    key = f"{model_name}:{pretrained}"
+    with _lock:
+        if key not in _models:
+            model, _, preprocess = open_clip.create_model_and_transforms(
+                model_name, pretrained=pretrained
+            )
+            tokenizer = open_clip.get_tokenizer(model_name)
+            model.eval()
+            _models[key] = (model, preprocess, tokenizer)
+    return _models[key]

--- a/backend/signal-ingestion/src/signal_ingestion/embedding.py
+++ b/backend/signal-ingestion/src/signal_ingestion/embedding.py
@@ -3,46 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-from typing import List
-
-from typing import cast
+from typing import List, cast
 
 import numpy as np
 
-open_clip = None
-torch = None
-
-_model = None
-_tokenizer = None
-
-
-def _load_clip() -> None:
-    """Load CLIP model on first use."""
-    global _model, _tokenizer, open_clip, torch
-    if open_clip is None or torch is None:
-        try:  # pragma: no cover - optional heavy dependency
-            import open_clip as _open_clip
-            import torch as _torch
-        except Exception:  # pragma: no cover - fallback when open_clip unavailable
-            return
-        open_clip = _open_clip
-        torch = _torch
-
-    if _model is None:
-        _model, _, _ = open_clip.create_model_and_transforms(
-            "ViT-L-14", pretrained="openai"
-        )
-        _tokenizer = open_clip.get_tokenizer("ViT-L-14")
-        _model.eval()
-
-
-def _clip_embedding(text: str) -> List[float]:
-    assert open_clip is not None and torch is not None
-    assert _tokenizer is not None and _model is not None
-    tokens = _tokenizer([text])
-    with torch.no_grad():
-        vec = _model.encode_text(tokens)[0].float().cpu().numpy()
-    return cast(List[float], vec.tolist())
+from backend.shared.clip import load_clip, open_clip, torch
 
 
 def _fallback_embedding(text: str, dim: int = 768) -> List[float]:
@@ -53,12 +18,11 @@ def _fallback_embedding(text: str, dim: int = 768) -> List[float]:
 
 def generate_embedding(text: str) -> List[float]:
     """Return an embedding vector for ``text``."""
-    _load_clip()
-    if (
-        open_clip is not None
-        and torch is not None
-        and _model is not None
-        and _tokenizer is not None
-    ):
-        return _clip_embedding(text)
+    loaded = load_clip("ViT-L-14")
+    if loaded and open_clip is not None and torch is not None:
+        model, _preprocess, tokenizer = loaded
+        tokens = tokenizer([text])
+        with torch.no_grad():
+            vec = model.encode_text(tokens)[0].float().cpu().numpy()
+        return cast(List[float], vec.tolist())
     return _fallback_embedding(text)


### PR DESCRIPTION
## Summary
- centralize CLIP loading logic in `backend/shared/clip.py`
- import shared loader in embedding and post-processing modules
- export loader utilities from `backend.shared`

## Testing
- `flake8 backend/shared/clip.py backend/signal-ingestion/src/signal_ingestion/embedding.py backend/mockup-generation/mockup_generation/post_processor.py backend/shared/__init__.py`
- `pydocstyle backend/shared/clip.py backend/signal-ingestion/src/signal_ingestion/embedding.py backend/mockup-generation/mockup_generation/post_processor.py backend/shared/__init__.py`
- `mypy backend/shared/clip.py backend/signal-ingestion/src/signal_ingestion/embedding.py backend/mockup-generation/mockup_generation/post_processor.py --follow-imports=skip --ignore-missing-imports`
- `pytest backend/mockup-generation/tests/test_nsfw.py -W error` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687fcbfe62a483319e6e207606ebb0a9