### PR TITLE
Implement async uploads with aiobotocore

### DIFF
--- a/backend/mockup-generation/requirements.txt
+++ b/backend/mockup-generation/requirements.txt
@@ -8,3 +8,4 @@ jinja2
 diffusers
 transformers
 accelerate
+aiobotocore

--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import sys
 import asyncio
 import warnings
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 import pytest
 
 root = Path(__file__).resolve().parents[1]
@@ -37,7 +39,7 @@ def _call_generate_mockup(
     keywords: list[list[str]], output_dir: str, **kw: object
 ) -> object:
     dummy = types.SimpleNamespace(request=types.SimpleNamespace(delivery_info={}))
-    return asyncio.run(_orig_generate_mockup(dummy, keywords, output_dir, **kw))
+    return _orig_generate_mockup(dummy, keywords, output_dir, **kw)
 
 
 tasks.generate_mockup = _call_generate_mockup
@@ -46,16 +48,20 @@ uc_mod = sys.modules.setdefault("UnleashClient", types.ModuleType("UnleashClient
 uc_mod.UnleashClient = object
 ld_mod = sys.modules.setdefault("ldclient", types.ModuleType("ldclient"))
 ld_mod.LDClient = object
-prom_mod = sys.modules.setdefault(
-    "prometheus_client", types.ModuleType("prometheus_client")
-)
+prom_mod = types.ModuleType("prometheus_client")
+sys.modules["prometheus_client"] = prom_mod
 prom_mod.CONTENT_TYPE_LATEST = ""
 prom_mod.Counter = lambda *a, **k: types.SimpleNamespace(
     labels=lambda *_, **__: types.SimpleNamespace(inc=lambda *_, **__: None)
 )
+prom_mod.Gauge = lambda *a, **k: types.SimpleNamespace(
+    inc=lambda *_, **__: None,
+    dec=lambda *_, **__: None,
+)
 prom_mod.Histogram = lambda *a, **k: types.SimpleNamespace(
     labels=lambda *_, **__: types.SimpleNamespace(observe=lambda *_, **__: None)
 )
+prom_mod.REGISTRY = types.SimpleNamespace(register=lambda *a, **k: None)
 prom_mod.generate_latest = lambda *a, **k: b""
 sys.modules.setdefault("pgvector.sqlalchemy", types.ModuleType("pgvector.sqlalchemy"))
 sys.modules["pgvector.sqlalchemy"].Vector = object
@@ -68,8 +74,8 @@ class DummyClient:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, str]] = []
 
-    def upload_file(self, src: str, bucket: str, obj: str) -> None:
-        self.calls.append((src, bucket, obj))
+    async def put_object(self, Bucket: str, Key: str, Body: bytes | str) -> None:
+        self.calls.append((Bucket, Key, ""))
 
 
 class DummyGenerator:
@@ -78,7 +84,13 @@ class DummyGenerator:
     def __init__(self) -> None:
         self.cleaned = False
 
-    def generate(self, prompt: str, output: str, num_inference_steps: int = 30):
+    def generate(
+        self,
+        prompt: str,
+        output: str,
+        num_inference_steps: int = 30,
+        **_kw: object,
+    ) -> object:
         Path(output).write_text("x")
         return types.SimpleNamespace(image_path=output)
 
@@ -108,7 +120,12 @@ def test_generate_mockup_upload(
     gen = DummyGenerator()
     monkeypatch.setattr(tasks, "generator", gen)
     monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
-    monkeypatch.setattr(tasks, "_get_storage_client", lambda: DummyClient())
+
+    @asynccontextmanager
+    async def _client() -> AsyncIterator[DummyClient]:
+        yield DummyClient()
+
+    monkeypatch.setattr(tasks, "_get_storage_client", _client)
     monkeypatch.setattr(
         tasks,
         "redis_client",
@@ -119,6 +136,22 @@ def test_generate_mockup_upload(
                 release=lambda: None,
             )
         ),
+    )
+
+    class _Lock:
+        async def acquire(self, *args: object, **kwargs: object) -> bool:
+            return True
+
+        def locked(self) -> bool:
+            return False
+
+        async def release(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        tasks,
+        "async_redis_client",
+        types.SimpleNamespace(lock=lambda *a, **k: _Lock()),
     )
     monkeypatch.setattr(tasks, "remove_background", lambda img: img)
     monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)


### PR DESCRIPTION
## Summary
- switch mockup upload logic to aiobotocore async client
- add aiobotocore to mockup-generation requirements
- adjust tests for async storage client and async redis
- update fake prometheus modules

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_api_mockups.py backend/mockup-generation/tests/test_tasks_upload.py load_tests/test_gpu_concurrency.py`
- `pydocstyle backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_api_mockups.py backend/mockup-generation/tests/test_tasks_upload.py load_tests/test_gpu_concurrency.py`
- `pytest backend/mockup-generation/tests/test_tasks_upload.py backend/mockup-generation/tests/test_api_mockups.py load_tests/test_gpu_concurrency.py -q` *(fails: ImportError and DeprecationWarning)*

------
https://chatgpt.com/codex/tasks/task_b_687fcbf5a0ac8331853bdc4b47970635