### PR TITLE
Implement Redis caching for trending list

### DIFF
--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     score_cache_ttl: int = 3600
     trending_ttl: int = 3600
     trending_max_keywords: int = 100
+    trending_cache_ttl: int = 30
     s3_endpoint: str | None = None
     s3_access_key: str | None = None
     s3_secret_key: str | None = None
@@ -44,7 +45,12 @@ class Settings(BaseSettings):  # type: ignore[misc]
             return [v.strip() for v in value.split(",") if v.strip()]
         return value
 
-    @field_validator("score_cache_ttl", "trending_ttl", "trending_max_keywords")  # type: ignore[misc]
+    @field_validator(
+        "score_cache_ttl",
+        "trending_ttl",
+        "trending_max_keywords",
+        "trending_cache_ttl",
+    )  # type: ignore[misc]
     @classmethod
     def _positive(cls, value: int) -> int:
         if value <= 0:

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -14,6 +14,9 @@ from typing import Iterable
 from openapi_schema_validator import OAS30Validator
 
 import types
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- add short-lived Redis cache in `get_trending`
- configure `trending_cache_ttl` setting
- test caching logic
- fix type hints in `generate_openapi.py`

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/trending.py backend/shared/config.py backend/signal-ingestion/tests/test_trending.py scripts/generate_openapi.py`
- `docformatter --check backend/signal-ingestion/src/signal_ingestion/trending.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/trending.py backend/shared/config.py --ignore-missing-imports --explicit-package-bases` *(fails: untyped decorator in other modules)*
- `pytest -W error -vv` *(fails to collect tests: missing modules and services)*
- `npm test --silent` *(fails: cannot find Jest module)*

------
https://chatgpt.com/codex/tasks/task_b_687fd3c620a4833190ccb058a5e22210