### PR TITLE
Update GPU metrics docstring

### DIFF
--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -158,7 +158,13 @@ async def _acquire_gpu_lock(slot: int | None = None) -> AsyncRedisLock:
 
 @asynccontextmanager
 async def gpu_slot(slot: int | None = None) -> AsyncIterator[None]:
-    """Yield while holding a GPU slot lock."""
+    """
+    Yield while holding a GPU slot lock.
+
+    The ``GPU_SLOTS_IN_USE`` gauge is incremented whenever a slot is acquired
+    and decremented when released. Each successful acquisition also increments
+    the ``GPU_SLOT_ACQUIRE_TOTAL`` counter.
+    """
     lock = await _acquire_gpu_lock(slot)
     GPU_SLOTS_IN_USE.inc()
     GPU_SLOT_ACQUIRE_TOTAL.inc()


### PR DESCRIPTION
## Summary
- clarify GPU metric updates in gpu_slot context manager

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py`
- `pydocstyle backend/mockup-generation/mockup_generation/tasks.py`
- `black backend/mockup-generation/mockup_generation/tasks.py --check`
- `mypy backend/mockup-generation/mockup_generation/tasks.py` *(fails: 34 errors in 15 files)*
- `pytest -W error` *(fails: 104 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687fd3cd5d988331b47a63b5534701d5