### PR TITLE
Add shared httpx clients

### DIFF
--- a/backend/mockup-generation/tests/test_generator.py
+++ b/backend/mockup-generation/tests/test_generator.py
@@ -56,8 +56,13 @@ def restore_provider() -> Iterator[None]:
 @pytest.mark.asyncio()
 async def test_fallback_api_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fallback API should raise :class:`GenerationError` after retries."""
+
+    async def _sleep(*_: object) -> None:
+        return None
+
+    monkeypatch.setattr("mockup_generation.generator._async_client", None)
     monkeypatch.setattr("httpx.AsyncClient", lambda *a, **k: DummySession())
-    monkeypatch.setattr("asyncio.sleep", lambda *_: None)
+    monkeypatch.setattr("asyncio.sleep", _sleep)
     gen = MockupGenerator()
     with pytest.raises(GenerationError):
         await gen._fallback_api("prompt")
@@ -93,8 +98,13 @@ async def test_fallback_api_openai(monkeypatch: pytest.MonkeyPatch) -> None:
 
     settings.fallback_provider = "openai"
     settings.openai_api_key = "x"
+
+    async def _sleep(*_: object) -> None:
+        return None
+
+    monkeypatch.setattr("mockup_generation.generator._async_client", None)
     monkeypatch.setattr("httpx.AsyncClient", lambda *a, **k: Session())
-    monkeypatch.setattr("asyncio.sleep", lambda *_: None)
+    monkeypatch.setattr("asyncio.sleep", _sleep)
     gen = MockupGenerator()
     img = await gen._fallback_api("prompt")
     assert img.size == (1, 1)
@@ -132,8 +142,13 @@ async def test_fallback_api_stability(monkeypatch: pytest.MonkeyPatch) -> None:
 
     settings.fallback_provider = "stability"
     settings.stability_ai_api_key = "x"
+
+    async def _sleep(*_: object) -> None:
+        return None
+
+    monkeypatch.setattr("mockup_generation.generator._async_client", None)
     monkeypatch.setattr("httpx.AsyncClient", lambda *a, **k: Session())
-    monkeypatch.setattr("asyncio.sleep", lambda *_: None)
+    monkeypatch.setattr("asyncio.sleep", _sleep)
     gen = MockupGenerator()
     img = await gen._fallback_api("prompt")
     assert img.size == (1, 1)


### PR DESCRIPTION
## Summary
- share an `httpx.AsyncClient` instance in the mockup generator
- expose a shared async HTTP client in marketplace publisher
- update generator tests for the shared client

## Testing
- `python -m pytest -W error -vv backend/mockup-generation/tests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_687fd3ccc3b0833187455c470c47bdae