### PR TITLE
Fix blocking screenshot in Selenium fallback

### DIFF
--- a/backend/marketplace-publisher/tests/test_api.py
+++ b/backend/marketplace-publisher/tests/test_api.py
@@ -27,8 +27,12 @@ def test_publish_and_progress(monkeypatch: Any, tmp_path: Path) -> None:
             assert metadata["price"] > 0
             return "1"
 
-    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()  # type: ignore[assignment]
-    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+
+    async def _noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    publisher._fallback.publish = _noop
 
     with TestClient(app) as client:
         design = tmp_path / "a.png"

--- a/backend/marketplace-publisher/tests/test_feature_flags.py
+++ b/backend/marketplace-publisher/tests/test_feature_flags.py
@@ -23,8 +23,12 @@ def test_society6_flag(monkeypatch: Any, tmp_path: Path) -> None:
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "1"
 
-    publisher.CLIENTS[Marketplace.society6] = DummyClient()  # type: ignore[assignment]
-    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+    publisher.CLIENTS[Marketplace.society6] = DummyClient()
+
+    async def _noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    publisher._fallback.publish = _noop
 
     with TestClient(app) as client:
         design = tmp_path / "a.png"
@@ -55,8 +59,12 @@ def test_zazzle_flag(monkeypatch: Any, tmp_path: Path) -> None:
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "1"
 
-    publisher.CLIENTS[Marketplace.zazzle] = DummyClient()  # type: ignore[assignment]
-    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+    publisher.CLIENTS[Marketplace.zazzle] = DummyClient()
+
+    async def _noop2(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    publisher._fallback.publish = _noop2
 
     with TestClient(app) as client:
         design = tmp_path / "a.png"

--- a/backend/marketplace-publisher/tests/test_policy_failures.py
+++ b/backend/marketplace-publisher/tests/test_policy_failures.py
@@ -28,7 +28,7 @@ async def test_publish_trademark_failure(
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "ok"
 
-    publisher.CLIENTS[db.Marketplace.redbubble] = DummyClient()  # type: ignore[assignment]
+    publisher.CLIENTS[db.Marketplace.redbubble] = DummyClient()
     monkeypatch.setattr(publisher, "is_trademarked", lambda term: True)
     monkeypatch.setattr(publisher, "ensure_not_nsfw", lambda img: None)
 
@@ -65,7 +65,7 @@ async def test_publish_nsfw_failure(
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "ok"
 
-    publisher.CLIENTS[db.Marketplace.redbubble] = DummyClient()  # type: ignore[assignment]
+    publisher.CLIENTS[db.Marketplace.redbubble] = DummyClient()
     monkeypatch.setattr(publisher, "is_trademarked", lambda term: False)
 
     def raise_nsfw(img: Any) -> None:  # noqa: ANN001
@@ -104,8 +104,12 @@ def test_api_trademark_failure(monkeypatch: Any, tmp_path: Path) -> None:
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "ok"
 
-    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()  # type: ignore[assignment]
-    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+
+    async def _noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    publisher._fallback.publish = _noop
     monkeypatch.setattr(publisher, "is_trademarked", lambda term: True)
     monkeypatch.setattr(publisher, "ensure_not_nsfw", lambda img: None)
 
@@ -137,8 +141,12 @@ def test_api_nsfw_failure(monkeypatch: Any, tmp_path: Path) -> None:
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "ok"
 
-    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()  # type: ignore[assignment]
-    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+
+    async def _noop2(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    publisher._fallback.publish = _noop2
     monkeypatch.setattr(publisher, "is_trademarked", lambda term: False)
 
     def raise_nsfw(img: Any) -> None:  # noqa: ANN001

--- a/backend/marketplace-publisher/tests/test_rate_limit.py
+++ b/backend/marketplace-publisher/tests/test_rate_limit.py
@@ -23,8 +23,12 @@ def test_rate_limit_exceeded(monkeypatch: Any, tmp_path: Path) -> None:
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "1"
 
-    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()  # type: ignore[assignment]
-    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+
+    async def _noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    publisher._fallback.publish = _noop
 
     with TestClient(app) as client:
         design = tmp_path / "a.png"

--- a/backend/marketplace-publisher/tests/test_selenium_fallback.py
+++ b/backend/marketplace-publisher/tests/test_selenium_fallback.py
@@ -84,7 +84,8 @@ def _write_rules(tmp_path: Path, url: str, bad: bool = False) -> Path:
     return path
 
 
-def test_publish_failure_produces_artifacts(
+@pytest.mark.asyncio()
+async def test_publish_failure_produces_artifacts(
     marketplace_form_server: str, tmp_path: Path
 ) -> None:
     """Verify screenshots and logs are created when publishing fails."""
@@ -94,6 +95,6 @@ def test_publish_failure_produces_artifacts(
     design.write_text("img")
     fallback = SeleniumFallback(screenshot_dir=tmp_path)
     with pytest.raises(Exception):
-        fallback.publish(Marketplace.redbubble, design, {"title": "t"})
+        await fallback.publish(Marketplace.redbubble, design, {"title": "t"})
     assert list(tmp_path.glob("*.png"))
     assert list(tmp_path.glob("*.log"))

--- a/backend/marketplace-publisher/tests/test_validation.py
+++ b/backend/marketplace-publisher/tests/test_validation.py
@@ -23,8 +23,12 @@ def test_invalid_dimensions(monkeypatch: Any, tmp_path: Path) -> None:
         def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
             return "1"
 
-    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()  # type: ignore[assignment]
-    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+
+    async def _noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    publisher._fallback.publish = _noop
 
     with TestClient(app) as client:
         design = tmp_path / "bad.png"

--- a/tests/test_selenium_e2e.py
+++ b/tests/test_selenium_e2e.py
@@ -63,7 +63,8 @@ def _write_page(tmp_path: Path) -> Path:
     return page
 
 
-def test_selenium_publish_success(tmp_path: Path) -> None:
+@pytest.mark.asyncio()
+async def test_selenium_publish_success(tmp_path: Path) -> None:
     """Publishing with valid selectors should not create screenshots."""
     page = _write_page(tmp_path)
     rules_path = _write_rules(tmp_path, page)
@@ -71,11 +72,12 @@ def test_selenium_publish_success(tmp_path: Path) -> None:
     design = tmp_path / "design.png"
     design.write_text("img")
     fallback = SeleniumFallback(screenshot_dir=tmp_path)
-    fallback.publish(Marketplace.redbubble, design, {"title": "t"})
+    await fallback.publish(Marketplace.redbubble, design, {"title": "t"})
     assert not list(tmp_path.glob("*.png"))
 
 
-def test_selenium_publish_failure_with_screenshot(tmp_path: Path) -> None:
+@pytest.mark.asyncio()
+async def test_selenium_publish_failure_with_screenshot(tmp_path: Path) -> None:
     """Failures should store a screenshot in the specified directory."""
     page = _write_page(tmp_path)
     rules_path = _write_rules(tmp_path, page, bad=True)
@@ -84,6 +86,6 @@ def test_selenium_publish_failure_with_screenshot(tmp_path: Path) -> None:
     design.write_text("img")
     fallback = SeleniumFallback(screenshot_dir=tmp_path)
     with pytest.raises(Exception):
-        fallback.publish(Marketplace.redbubble, design, {"title": "t"})
+        await fallback.publish(Marketplace.redbubble, design, {"title": "t"})
     assert list(tmp_path.glob("*.png"))
     assert list(tmp_path.glob("*.log"))


### PR DESCRIPTION
## Summary
- avoid event loop blocking by running Selenium screenshot capture in a thread
- update Selenium fallback tests to use async publish API

## Testing
- `pytest backend/marketplace-publisher/tests/test_selenium_fallback.py::test_publish_failure_produces_artifacts -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_b_687fd3daab248331b53c27ac24a075c0