### PR TITLE
Wrap heavy dashboard charts with React.memo

### DIFF
--- a/frontend/admin-dashboard/src/components/AnalyticsChart.tsx
+++ b/frontend/admin-dashboard/src/components/AnalyticsChart.tsx
@@ -21,7 +21,7 @@ ChartJS.register(
   Legend
 );
 
-export function AnalyticsChart() {
+export const AnalyticsChart = React.memo(function AnalyticsChart() {
   const [range, setRange] = useState('24h');
   const { data } = useAnalyticsData(range);
 
@@ -58,4 +58,4 @@ export function AnalyticsChart() {
       />
     </div>
   );
-}
+});

--- a/frontend/admin-dashboard/src/components/LatencyChart.tsx
+++ b/frontend/admin-dashboard/src/components/LatencyChart.tsx
@@ -21,7 +21,7 @@ ChartJS.register(
   Legend
 );
 
-export function LatencyChart() {
+export const LatencyChart = React.memo(function LatencyChart() {
   const [range, setRange] = useState('24h');
   const { data } = useLatencyData(range);
 
@@ -58,4 +58,4 @@ export function LatencyChart() {
       />
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
- memoize `AnalyticsChart` and `LatencyChart` to avoid unnecessary rerenders

## Testing
- `./scripts/setup_codex.sh`
- `npm test` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_b_687fdc3307fc83319159128694e6b46c