### PR TITLE
Enforce full coverage for scoring packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
           npm test
           npm run test:e2e
           docker compose -f docker-compose.dev.yml -f docker-compose.test.yml down
+      - name: Check package coverage
+        run: python scripts/check_package_coverage.py
       - name: Smoke test docker compose services
         run: ./scripts/smoke_compose.sh
       - name: Upload Python coverage

--- a/scripts/check_package_coverage.py
+++ b/scripts/check_package_coverage.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Check coverage for specific packages."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+
+def coverage_for_package(xml_path: Path, package: str) -> float:
+    """Return coverage percentage for a package."""
+    tree = ET.parse(xml_path)
+    total = covered = 0
+    package = package.rstrip("/")
+    for cls in tree.findall(".//class"):
+        filename = cls.get("filename", "")
+        if filename.startswith(package):
+            total += int(cls.get("lines-valid", "0"))
+            covered += int(cls.get("lines-covered", "0"))
+    if total == 0:
+        return 100.0
+    return 100.0 * covered / total
+
+
+def main() -> None:
+    """Entry point for package coverage check."""
+    xml = Path("coverage.xml")
+    if not xml.exists():
+        print("coverage.xml not found", file=sys.stderr)
+        sys.exit(1)
+
+    packages = ["backend/scoring-engine", "backend/mockup-generation"]
+    failed = False
+    for pkg in packages:
+        pct = coverage_for_package(xml, pkg)
+        if pct < 100.0:
+            print(f"{pkg} coverage {pct:.2f}% < 100%", file=sys.stderr)
+            failed = True
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to verify 100% coverage for `scoring_engine` and `mockup_generation`
- run the coverage check in CI tests workflow

## Testing
- `pytest -k "" -vv` *(fails: connection refused to Postgres)*

------
https://chatgpt.com/codex/tasks/task_b_687fdc1c6b7483319059c59ee0c3cb47