### PR TITLE
Expose DB pool size setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Default environment variables
 DATABASE_URL=postgresql://user:password@localhost:5432/desainz
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379/0
 SECRET_KEY=dev_secret_key
 AUTH0_DOMAIN=your-auth0-domain

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 # PostgreSQL connection string
 DATABASE_URL=postgresql://user:password@db:5432/backend_db
+DB_POOL_SIZE=5
 
 # Redis connection string
 REDIS_URL=redis://cache:6379/0

--- a/backend/analytics/.env.example
+++ b/backend/analytics/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/api-gateway/.env.example
+++ b/backend/api-gateway/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/feedback-loop/.env.example
+++ b/backend/feedback-loop/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/marketplace-publisher/.env.example
+++ b/backend/marketplace-publisher/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/mockup-generation/.env.example
+++ b/backend/mockup-generation/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 # Broker configuration
 CELERY_BROKER=redis

--- a/backend/monitoring/.env.example
+++ b/backend/monitoring/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/optimization/.env.example
+++ b/backend/optimization/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/orchestrator/.env.example
+++ b/backend/orchestrator/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/scoring-engine/.env.example
+++ b/backend/scoring-engine/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 METRICS_DB_URL=postgresql://postgres:postgres@localhost:5432/metrics
 

--- a/backend/service-template/.env.example
+++ b/backend/service-template/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/shared/.env.example
+++ b/backend/shared/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     kafka_bootstrap_servers: str = "localhost:9092"
     schema_registry_url: HttpUrl = HttpUrl("http://localhost:8081")
     redis_url: RedisDsn = RedisDsn("redis://localhost:6379/0")
+    db_pool_size: int = 5
     score_cache_ttl: int = 3600
     trending_ttl: int = 3600
     trending_max_keywords: int = 100
@@ -50,6 +51,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "trending_ttl",
         "trending_max_keywords",
         "trending_cache_ttl",
+        "db_pool_size",
     )  # type: ignore[misc]
     @classmethod
     def _positive(cls, value: int) -> int:

--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -78,11 +78,24 @@ def register_pool_metrics(engine_obj: Any) -> None:
     _update()
 
 
-engine = create_engine(DATABASE_URL, echo=False, future=True)
+_pool_size_env = os.getenv("DB_POOL_SIZE")
+_pool_size = int(_pool_size_env) if _pool_size_env else settings.db_pool_size
+
+engine = create_engine(
+    DATABASE_URL,
+    echo=False,
+    future=True,
+    pool_size=_pool_size,
+)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 register_pool_metrics(engine)
 
-async_engine = create_async_engine(ASYNC_DATABASE_URL, echo=False, future=True)
+async_engine = create_async_engine(
+    ASYNC_DATABASE_URL,
+    echo=False,
+    future=True,
+    pool_size=_pool_size,
+)
 AsyncSessionLocal = async_sessionmaker(async_engine, expire_on_commit=False)
 register_pool_metrics(async_engine)
 

--- a/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
@@ -1,9 +1,9 @@
-"""add marketplace perf listing id index
+"""
+Add marketplace perf listing id index.
 
 Revision ID: 7544cf9b2fd7
 Revises: 0019
 Create Date: 2025-07-22 16:30:59.175652
-
 """
 
 from alembic import op

--- a/backend/signal-ingestion/.env.example
+++ b/backend/signal-ingestion/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+DB_POOL_SIZE=5
 REDIS_URL=redis://localhost:6379
 
 # AI Services

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ See the blueprint environment variables section in `blueprints/DesignIdeaEngineC
 | Variable | Description |
 | --- | --- |
 | `DATABASE_URL` | Database connection string |
+| `DB_POOL_SIZE` | Size of the SQLAlchemy connection pool |
 | `REDIS_URL` | Redis connection string |
 | `SECRET_KEY` | Secret key for cryptographic signing |
 | `AUTH0_DOMAIN` | Domain of the Auth0 tenant used for authentication |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -66,6 +66,8 @@ Each service now reports connection pool usage via two gauges:
 - ``db_pool_in_use`` – currently checked out connections.
 
 Monitoring these values helps detect connection leaks and tune pool sizes.
+To change the pool size, set the ``DB_POOL_SIZE`` environment variable (or
+``db_pool_size`` setting) before starting services.
 
 ## CDN Configuration
 


### PR DESCRIPTION
## Summary
- add `db_pool_size` setting
- use `DB_POOL_SIZE` env variable in shared DB engine
- document the knob in config and performance docs
- propagate env example update across services

## Testing
- `flake8 backend/shared/config.py backend/shared/db/__init__.py`
- `pydocstyle backend/shared/config.py backend/shared/db/__init__.py`
- `docformatter --check backend/shared/config.py backend/shared/db/__init__.py`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `npm test` *(fails: Cannot find module '/workspace/dez-AInz/frontend/admin-dashboard/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_b_687fdc1414608331a98577bbea9213e6