### PR TITLE
Enforce warnings as errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -W error --cov=. --cov-report=term --cov-report=xml --cov-fail-under=15
+filterwarnings = error

--- a/tests/test_listing_sync.py
+++ b/tests/test_listing_sync.py
@@ -10,9 +10,6 @@ monitoring_src = Path(__file__).resolve().parents[1] / "backend" / "monitoring" 
 sys.path.append(str(monitoring_src))
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import warnings
-
-warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 import pytest  # noqa: E402
 
@@ -23,11 +20,7 @@ from scripts import listing_sync  # noqa: E402
 
 def setup_module(module: object) -> None:
     """Create tables for tests."""
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        Base.metadata.create_all(engine)
+    Base.metadata.create_all(engine)
     with session_scope() as session:
         from datetime import datetime, UTC
 

--- a/tests/test_rotate_s3_keys.py
+++ b/tests/test_rotate_s3_keys.py
@@ -9,6 +9,10 @@ import boto3
 import pytest
 from moto import mock_aws
 
+pytestmark = pytest.mark.filterwarnings(
+    r"ignore:datetime\.datetime\.utcnow\(\) is deprecated"
+)
+
 from scripts.rotate_s3_keys import rotate
 
 


### PR DESCRIPTION
## Summary
- treat warnings as errors for pytest
- remove unused warning filters in listing sync tests
- filter external deprecation warning in rotate_s3_keys

## Testing
- `bash scripts/setup_codex.sh`
- `pytest tests/test_listing_sync.py tests/test_rotate_s3_keys.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687fdc176f5483318ad5dd2fa1e4f488