### PR TITLE
Add optional compiled novelty extension

### DIFF
--- a/backend/scoring-engine/scoring_engine/_novelty_ext.c
+++ b/backend/scoring-engine/scoring_engine/_novelty_ext.c
@@ -1,0 +1,51 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <numpy/arrayobject.h>
+#include <math.h>
+
+static PyObject *compute_novelty(PyObject *self, PyObject *args) {
+    PyArrayObject *embedding;
+    PyArrayObject *centroid;
+    if (!PyArg_ParseTuple(args, "O!O!", &PyArray_Type, &embedding, &PyArray_Type, &centroid)) {
+        return NULL;
+    }
+    if (PyArray_NDIM(embedding) != 1 || PyArray_NDIM(centroid) != 1) {
+        PyErr_SetString(PyExc_ValueError, "inputs must be 1-dimensional");
+        return NULL;
+    }
+    if (PyArray_DIM(embedding, 0) != PyArray_DIM(centroid, 0)) {
+        PyErr_SetString(PyExc_ValueError, "arrays must be of same length");
+        return NULL;
+    }
+    npy_intp size = PyArray_DIM(embedding, 0);
+    double *emb = (double *)PyArray_DATA(embedding);
+    double *cen = (double *)PyArray_DATA(centroid);
+    double dot = 0.0;
+    double norm_e = 0.0;
+    double norm_c = 0.0;
+    for (npy_intp i = 0; i < size; ++i) {
+        double e = emb[i];
+        double c = cen[i];
+        dot += e * c;
+        norm_e += e * e;
+        norm_c += c * c;
+    }
+    double norm = sqrt(norm_e) * sqrt(norm_c);
+    if (norm == 0.0) {
+        return PyFloat_FromDouble(0.0);
+    }
+    double result = 1.0 - dot / norm;
+    return PyFloat_FromDouble(result);
+}
+
+static PyMethodDef Methods[] = {
+    {"compute_novelty", compute_novelty, METH_VARARGS, "Compute novelty score."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT, "_novelty_ext", NULL, -1, Methods};
+
+PyMODINIT_FUNC PyInit__novelty_ext(void) {
+    import_array();
+    return PyModule_Create(&moduledef);
+}

--- a/backend/scoring-engine/scoring_engine/scoring.py
+++ b/backend/scoring-engine/scoring_engine/scoring.py
@@ -8,6 +8,11 @@ from typing import Iterable
 
 from numpy.typing import NDArray
 
+try:  # pragma: no cover - optional extension
+    from ._novelty_ext import compute_novelty as _compute_novelty_ext
+except Exception:  # pragma: no cover - fallback on pure Python
+    _compute_novelty_ext = None
+
 import numpy as np
 from sklearn.preprocessing import StandardScaler
 
@@ -56,7 +61,13 @@ def compute_engagement(current: float, median: float) -> float:
 def compute_novelty(
     embedding: NDArray[np.floating], centroid: NDArray[np.floating]
 ) -> float:
-    """One minus cosine similarity to centroid."""
+    """
+    Return novelty score using cosine distance.
+
+    If an optimized extension is available, it will be used automatically.
+    """
+    if _compute_novelty_ext is not None:
+        return float(_compute_novelty_ext(embedding, centroid))
     dot = float(np.dot(embedding, centroid))
     norm = float(np.linalg.norm(embedding) * np.linalg.norm(centroid))
     if norm == 0:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
 """Package and distribute the desAInz application."""
 
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
+import numpy
 
-setup(name="desAInz", version="0.1", packages=find_packages())
+ext_modules = [
+    Extension(
+        "scoring_engine._novelty_ext",
+        ["backend/scoring-engine/scoring_engine/_novelty_ext.c"],
+        include_dirs=[numpy.get_include()],
+    )
+]
+
+setup(name="desAInz", version="0.1", packages=find_packages(), ext_modules=ext_modules)


### PR DESCRIPTION
## Summary
- add optional `_novelty_ext` C extension for fast novelty calculations
- automatically fall back to pure Python `compute_novelty`
- include extension build in `setup.py`

## Testing
- `flake8 backend/scoring-engine/scoring_engine/scoring.py setup.py`
- `pydocstyle backend/scoring-engine/scoring_engine/scoring.py`
- `docformatter --check backend/scoring-engine/scoring.py setup.py` *(fails: file listed)*
- `docformatter -i backend/scoring-engine/scoring_engine/scoring.py setup.py`
- `black backend/scoring-engine/scoring_engine/scoring.py setup.py`
- `mypy backend/scoring-engine/scoring_engine/scoring.py --ignore-missing-imports` *(fails: unrelated errors)*
- `pytest backend/scoring-engine/tests/test_scoring.py::test_calculate_score_simple -vv` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_687fdc269ca48331b9d34b1b10f5cf5f