### PR TITLE
Add profiling helper script

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -33,6 +33,18 @@ The Dagster job `benchmark_score_job` executes
 `score_benchmarks` table. Grafana uses the PostgreSQL data source to visualize
 these benchmarks over time, allowing quick detection of regressions.
 
+## Capturing Profiling Data
+
+Use ``scripts/capture_profile.py`` to collect CPU profiling statistics for any
+Python module. The command saves data in ``cProfile`` format and prints the
+top 20 functions by cumulative time.
+
+```bash
+python scripts/capture_profile.py backend.app.main --output run.prof
+```
+The output file can be visualized with tools like ``snakeviz`` for deeper
+analysis.
+
 ## tRPC Response Caching
 
 The API Gateway now attaches ``ETag`` headers to tRPC responses. When a client

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -7,6 +7,7 @@ from .run_dagster_webserver import main as run_dagster_webserver
 from .rotate_logs import main as rotate_logs
 from .wait_for_services import main as wait_for_services
 from .setup_codex import main as setup_codex
+from .capture_profile import main as capture_profile
 
 __all__ = [
     "maintenance",
@@ -17,4 +18,5 @@ __all__ = [
     "rotate_logs",
     "wait_for_services",
     "setup_codex",
+    "capture_profile",
 ]

--- a/scripts/capture_profile.py
+++ b/scripts/capture_profile.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Capture runtime profiling data for a Python module."""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import pstats
+import runpy
+from pathlib import Path
+
+
+def profile_module(module: str, output: Path) -> None:
+    """Run ``module`` under ``cProfile`` and write stats to ``output``."""
+    profiler = cProfile.Profile()
+    profiler.enable()
+    try:
+        runpy.run_module(module, run_name="__main__")
+    finally:
+        profiler.disable()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        profiler.dump_stats(str(output))
+        stats = pstats.Stats(profiler)
+        stats.sort_stats(pstats.SortKey.CUMULATIVE)
+        stats.print_stats(20)
+
+
+def main() -> None:
+    """Parse arguments and profile the requested module."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("module", help="Python module to run, e.g. 'app.main'")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("profile.prof"),
+        help="Path to write cProfile data",
+    )
+    args = parser.parse_args()
+    profile_module(args.module, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper script to capture profiling data
- expose script through package initializer
- document how to run the profiler

## Testing
- `flake8 scripts/capture_profile.py scripts/__init__.py`
- `pydocstyle scripts/capture_profile.py`
- `docformatter --check scripts/capture_profile.py`
- `mypy --config-file pyproject.toml scripts/capture_profile.py` *(fails: Found 23 errors in 8 files)*
- `pytest -W error -vv` *(fails: connection refused for postgres)*
- `npm run lint` *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_687fdc28a1248331906af62eb81b265e