### PR TITLE
Add gzip CSV streaming

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -21,6 +21,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
+from backend.shared.responses import gzip_iter
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
@@ -52,7 +53,7 @@ def _identify_user(request: Request) -> str:
     return cast(str, request.headers.get("X-User", request.client.host))
 
 
-@app.middleware("http")
+@app.middleware("http")  # type: ignore[misc]
 async def add_correlation_id(
     request: Request,
     call_next: Callable[[Request], Coroutine[None, None, Response]],
@@ -143,10 +144,11 @@ def export_ab_test_results(
                 yield (f"{r.timestamp.isoformat()},{r.conversions},{r.impressions}\n")
 
     return StreamingResponse(
-        _iter(),
+        gzip_iter(_iter()),
         media_type="text/csv",
         headers={
-            "Content-Disposition": f"attachment; filename=ab_test_{ab_test_id}.csv"
+            "Content-Disposition": f"attachment; filename=ab_test_{ab_test_id}.csv",
+            "Content-Encoding": "gzip",
         },
     )
 
@@ -213,10 +215,11 @@ def export_marketplace_metrics(
                 )
 
     return StreamingResponse(
-        _iter(),
+        gzip_iter(_iter()),
         media_type="text/csv",
         headers={
-            "Content-Disposition": f"attachment; filename=listing_{listing_id}.csv"
+            "Content-Disposition": f"attachment; filename=listing_{listing_id}.csv",
+            "Content-Encoding": "gzip",
         },
     )
 
@@ -243,10 +246,11 @@ def export_performance_metrics(
                 )
 
     return StreamingResponse(
-        _iter(),
+        gzip_iter(_iter()),
         media_type="text/csv",
         headers={
-            "Content-Disposition": f"attachment; filename=performance_{listing_id}.csv"
+            "Content-Disposition": f"attachment; filename=performance_{listing_id}.csv",
+            "Content-Encoding": "gzip",
         },
     )
 

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -9,7 +9,7 @@ from .feature_flags import initialize as init_feature_flags, is_enabled
 from .errors import add_error_handlers, add_flask_error_handlers
 from .currency import convert_price, start_rate_updater
 from .metrics import register_metrics
-from .responses import cache_header, json_cached
+from .responses import cache_header, json_cached, gzip_iter
 from .config import settings
 from .security import add_security_headers
 from .clip import load_clip, open_clip, torch
@@ -28,6 +28,7 @@ __all__ = [
     "register_metrics",
     "cache_header",
     "json_cached",
+    "gzip_iter",
     "settings",
     "add_security_headers",
     "load_clip",

--- a/backend/shared/responses.py
+++ b/backend/shared/responses.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from fastapi.responses import JSONResponse, Response
+import zlib
+from typing import Iterable
 
 CACHE_TTL_SECONDS = 60
 
@@ -17,3 +19,15 @@ def json_cached(
 ) -> JSONResponse:
     """Return ``JSONResponse`` with Cache-Control header."""
     return JSONResponse(content=payload, headers=cache_header(ttl))
+
+
+def gzip_iter(text_iter: Iterable[str]) -> Iterable[bytes]:
+    """Yield gzip-compressed bytes from an iterable of strings."""
+    compressor = zlib.compressobj(wbits=31)
+    for chunk in text_iter:
+        data = compressor.compress(chunk.encode())
+        if data:
+            yield data
+    data = compressor.flush()
+    if data:
+        yield data


### PR DESCRIPTION
## Summary
- compress CSV streaming in analytics endpoints
- add `gzip_iter` helper for compressed streaming
- expose `gzip_iter` in shared init
- adjust analytics tests for gzip

## Testing
- `mypy --config-file pyproject.toml --follow-imports skip --python-version 3.12 backend/shared/responses.py backend/analytics/api.py tests/test_analytics.py`
- `pytest tests/test_analytics.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687fdc11c75483319850b06e48dbf497