### PR TITLE
Add migration head check

### DIFF
--- a/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
@@ -1,4 +1,4 @@
-"""add marketplace perf listing id index
+"""Add marketplace perf listing id index.
 
 Revision ID: 7544cf9b2fd7
 Revises: 0019

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -56,6 +56,8 @@ alembic -c backend/shared/db/alembic_scoring_engine.ini merge \
 The new revision should live in ``backend/shared/db/migrations`` and replace
 ``example_merge_revision.py``. After committing the merge file, run
 ``scripts/validate_migrations.sh`` to confirm that only a single head exists.
+This script invokes ``scripts/check_heads.py`` which inspects every Alembic
+configuration and fails if more than one head is found.
 
 ## Verifying Migrations
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -17,9 +17,9 @@ Python utilities
    * - ``analyze_query_plans.py``
      - Inspect ``pg_stat_statements`` and suggest indexes.
      - ``python scripts/analyze_query_plans.py``
-  * - ``apply_s3_lifecycle.py``
-    - Configure bucket lifecycle rules.
-    - ``python scripts/apply_s3_lifecycle.py <bucket> [storage-class]``
+   * - ``apply_s3_lifecycle.py``
+     - Configure bucket lifecycle rules.
+     - ``python scripts/apply_s3_lifecycle.py <bucket> [storage-class]``
    * - ``approve_job.py``
      - Approve Dagster runs from the approval service.
      - ``python scripts/approve_job.py <run_id>``
@@ -152,9 +152,15 @@ automatic rollback::
 
    ./scripts/sync_staging_secrets.sh
 
-``validate_migrations.sh`` ensures Alembic has a single head::
+``validate_migrations.sh`` ensures Alembic has a single head by calling
+``check_heads.py``::
 
    ./scripts/validate_migrations.sh
+
+``check_heads.py`` can be run directly to validate specific Alembic
+configuration files::
+
+   python scripts/check_heads.py backend/shared/db/alembic_api_gateway.ini
 
 ``wait-for-services.sh`` waits until local services are ready::
 

--- a/scripts/check_heads.py
+++ b/scripts/check_heads.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Verify Alembic environments have a single head."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from backend.shared.db import ensure_single_head
+
+
+def main() -> None:
+    """Validate all provided Alembic config files."""
+    parser = argparse.ArgumentParser(description="Validate Alembic heads")
+    parser.add_argument(
+        "configs",
+        nargs="*",
+        help="Alembic config files",
+    )
+    args = parser.parse_args()
+
+    if args.configs:
+        configs = args.configs
+    else:
+        configs = [str(p) for p in Path("backend/shared/db").glob("alembic_*.ini")]
+
+    for cfg in configs:
+        ensure_single_head(cfg)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/validate_migrations.sh
+++ b/scripts/validate_migrations.sh
@@ -3,11 +3,4 @@
 
 set -euo pipefail
 
-HEADS=$(alembic -c backend/shared/db/alembic.ini heads | wc -l)
-if [ "$HEADS" -ne 1 ]; then
-  echo "Multiple migration heads detected:" >&2
-  alembic -c backend/shared/db/alembic.ini heads >&2
-  exit 1
-fi
-
-alembic -c backend/shared/db/alembic.ini heads
+python scripts/check_heads.py "$@"


### PR DESCRIPTION
## Summary
- ensure Alembic heads are verified before running migrations
- create `scripts/check_heads.py` and simplify `validate_migrations.sh`
- document head checking process
- fix flake8 error in migration docstring

## Testing
- `python scripts/setup_codex.py` *(fails: returned non-zero exit status 1)*
- `python -m pytest -W error -vv` *(fails: 70 errors during collection)*
- `npm test` *(fails: Cannot find module jest.js)*
- `flake8`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: found 205 errors)*
- `docformatter --check --recursive docs`
- `pydocstyle docs`


------
https://chatgpt.com/codex/tasks/task_b_687fdc1675d4833193b0e333a6977914