### PR TITLE
Implement pagination endpoints

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -173,8 +173,10 @@ def marketplace_metrics(listing_id: int) -> MarketplaceSummary:
 
 
 @app.get("/low_performers")  # type: ignore[misc]
-def low_performers(limit: int = 10) -> list[LowPerformer]:
+def low_performers(limit: int = 10, page: int = 0) -> list[LowPerformer]:
     """Return listings with the lowest total revenue."""
+
+    offset = page * limit
     with SessionLocal() as session:
         rows = (
             session.query(
@@ -185,6 +187,7 @@ def low_performers(limit: int = 10) -> list[LowPerformer]:
             )
             .group_by(models.MarketplaceMetric.listing_id)
             .order_by("rev")
+            .offset(offset)
             .limit(limit)
             .all()
         )

--- a/backend/api-gateway/tests/test_roles.py
+++ b/backend/api-gateway/tests/test_roles.py
@@ -36,6 +36,6 @@ def test_assign_and_list_roles() -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
-    resp = client.get("/roles", headers={"Authorization": f"Bearer {token}"})
+    resp = client.get("/roles?limit=50&page=0", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
     assert {"username": "user1", "role": "editor"} in resp.json()

--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -286,10 +286,10 @@ def test_analytics_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
             return None
 
         async def get(self, url: str) -> httpx.Response:
-            assert url.endswith("/low_performers?limit=5")
+            assert url.endswith("/low_performers?limit=5&page=0")
             return httpx.Response(200, json=[{"id": 1}])
 
     monkeypatch.setattr(httpx, "AsyncClient", MockClient)
-    resp = client.get("/analytics/low_performers?limit=5")
+    resp = client.get("/analytics/low_performers?limit=5&page=0")
     assert resp.status_code == 200
     assert resp.json() == [{"id": 1}]

--- a/backend/api-gateway/tests/test_trending.py
+++ b/backend/api-gateway/tests/test_trending.py
@@ -19,15 +19,15 @@ client = TestClient(main_module.app)
 
 def test_trending_keywords(monkeypatch: pytest.MonkeyPatch) -> None:
     """Return mocked popular keywords."""
-    monkeypatch.setattr(routes, "get_trending", lambda limit=10: ["foo", "bar"])
-    resp = client.get("/trending?limit=2")
+    monkeypatch.setattr(routes, "get_trending", lambda limit=10, page=0: ["foo", "bar"])
+    resp = client.get("/trending?limit=2&page=0")
     assert resp.status_code == 200
     assert resp.json() == ["foo", "bar"]
 
 
 def test_trending_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Return empty list when no keywords available."""
-    monkeypatch.setattr(routes, "get_trending", lambda limit=10: [])
+    monkeypatch.setattr(routes, "get_trending", lambda limit=10, page=0: [])
     resp = client.get("/trending")
     assert resp.status_code == 200
     assert resp.json() == []

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -160,6 +160,8 @@ async def generate(payload: GeneratePayload) -> dict[str, list[str]]:
 
 
 @app.get("/mockups")
-async def get_mockups() -> list[dict[str, object]]:
+async def get_mockups(limit: int = 100, page: int = 0) -> list[dict[str, object]]:
     """Return recently generated mockups."""
-    return [m.__dict__ for m in list_generated_mockups()]
+
+    offset = page * limit
+    return [m.__dict__ for m in list_generated_mockups(limit, offset)]

--- a/backend/mockup-generation/mockup_generation/model_repository.py
+++ b/backend/mockup-generation/mockup_generation/model_repository.py
@@ -146,10 +146,17 @@ def save_generated_mockup(
         return int(obj.id)
 
 
-def list_generated_mockups() -> List[GeneratedMockupInfo]:
-    """Return all stored generation parameter entries."""
+def list_generated_mockups(
+    limit: int = 100, offset: int = 0
+) -> List[GeneratedMockupInfo]:
+    """Return stored generation parameter entries using pagination."""
+
     with session_scope() as session:
-        rows: Iterable[GeneratedMockup] = session.scalars(select(GeneratedMockup)).all()
+        rows: Iterable[GeneratedMockup] = (
+            session.execute(select(GeneratedMockup).limit(limit).offset(offset))
+            .scalars()
+            .all()
+        )
         return [
             GeneratedMockupInfo(
                 id=row.id,

--- a/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
@@ -1,4 +1,4 @@
-"""add marketplace perf listing id index
+"""Add marketplace perf listing id index.
 
 Revision ID: 7544cf9b2fd7
 Revises: 0019

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -122,9 +122,10 @@ async def ingest_signals(
 
 
 @app.get("/trending")
-async def trending(limit: int = 10) -> list[str]:
-    """Return up to ``limit`` trending keywords."""
-    return trending_mod.get_top_keywords(limit)
+async def trending(limit: int = 10, page: int = 0) -> list[str]:
+    """Return a paginated list of trending keywords."""
+
+    return trending_mod.get_top_keywords(limit, page)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/signal-ingestion/src/signal_ingestion/trending.py
+++ b/backend/signal-ingestion/src/signal_ingestion/trending.py
@@ -41,20 +41,17 @@ def store_keywords(keywords: Iterable[str]) -> None:
     pipe.execute()
 
 
-def get_trending(limit: int = 10) -> list[str]:
-    """
-    Return up to ``limit`` most popular keywords.
+def get_trending(limit: int = 10, page: int = 0) -> list[str]:
+    """Return a page of trending keywords ordered by popularity."""
 
-    Results are cached in Redis for a short period of time to avoid repeatedly scanning
-    the sorted set on each request.
-    """
     client = get_sync_client()
-    cache_key = f"{TRENDING_CACHE_PREFIX}{limit}"
+    cache_key = f"{TRENDING_CACHE_PREFIX}{limit}:{page}"
     cached = sync_get(cache_key, client)
     if cached:
         return cast(list[str], json.loads(cached))
 
-    words = client.zrevrange(TRENDING_KEY, 0, limit - 1)
+    start = page * limit
+    words = client.zrevrange(TRENDING_KEY, start, start + limit - 1)
     result = [w.decode("utf-8") if isinstance(w, bytes) else w for w in words]
     sync_set(
         cache_key, json.dumps(result), ttl=settings.trending_cache_ttl, client=client
@@ -62,9 +59,10 @@ def get_trending(limit: int = 10) -> list[str]:
     return result
 
 
-def get_top_keywords(limit: int) -> list[str]:
+def get_top_keywords(limit: int, page: int = 0) -> list[str]:
     """Return the top ``limit`` keywords ordered by popularity."""
-    return get_trending(limit)
+
+    return get_trending(limit, page)
 
 
 def trim_keywords(max_size: int) -> None:

--- a/frontend/admin-dashboard/__tests__/trpc.test.ts
+++ b/frontend/admin-dashboard/__tests__/trpc.test.ts
@@ -8,6 +8,12 @@ beforeEach(() => {
         json: async () => ({ total: 1, items: [] }),
       }) as unknown as Response;
     }
+    if (url.includes('/publish-tasks')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [],
+      }) as unknown as Response;
+    }
     if (url.includes('/optimizations')) {
       return Promise.resolve({
         ok: true,
@@ -42,7 +48,7 @@ describe('tRPC ping', () => {
 test('auditLogs.list fetches data', async () => {
   await trpc.auditLogs.list();
   expect(global.fetch).toHaveBeenCalledWith(
-    'http://localhost:8000/audit-logs?limit=50&offset=0'
+    'http://localhost:8000/audit-logs?limit=50&page=0'
   );
 });
 
@@ -56,4 +62,11 @@ test('optimizations.list fetches data', async () => {
 test('metrics.list fetches data', async () => {
   await trpc.metrics.list();
   expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/metrics');
+});
+
+test('publishTasks.list fetches data', async () => {
+  await trpc.publishTasks.list();
+  expect(global.fetch).toHaveBeenCalledWith(
+    'http://localhost:8000/publish-tasks?limit=50&page=0'
+  );
 });

--- a/frontend/admin-dashboard/e2e/msw-server.ts
+++ b/frontend/admin-dashboard/e2e/msw-server.ts
@@ -16,8 +16,8 @@ export const handlers = [
       })
     )
   ),
-  rest.post('http://localhost:8000/trpc/publishTasks.list', (_req, res, ctx) =>
-    res(ctx.json({ result: [] }))
+  rest.get('http://localhost:8000/publish-tasks', (_req, res, ctx) =>
+    res(ctx.json([]))
   ),
 ];
 

--- a/frontend/admin-dashboard/src/components/RolesList.tsx
+++ b/frontend/admin-dashboard/src/components/RolesList.tsx
@@ -7,17 +7,17 @@ interface Assignment {
   role: string;
 }
 
-export function RolesList() {
+export function RolesList({ limit = 50, page = 0 }: { limit?: number; page?: number }) {
   const [roles, setRoles] = useState<Assignment[]>([]);
   useEffect(() => {
     async function load() {
-      const resp = await fetchWithAuth('/roles');
+      const resp = await fetchWithAuth(`/roles?limit=${limit}&page=${page}`);
       if (resp.ok) {
         setRoles(await resp.json());
       }
     }
     void load();
-  }, []);
+  }, [limit, page]);
   return (
     <ul aria-label="User roles">
       {roles.map((r) => (

--- a/frontend/admin-dashboard/src/lib/trpc/hooks.ts
+++ b/frontend/admin-dashboard/src/lib/trpc/hooks.ts
@@ -2,10 +2,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { trpc } from '../../trpc';
 
-export function useTrendingKeywords(limit: number = 10) {
+export function useTrendingKeywords(limit: number = 10, page: number = 0) {
   return useQuery({
-    queryKey: ['trending', limit],
-    queryFn: () => trpc.trending.list(limit),
+    queryKey: ['trending', limit, page],
+    queryFn: () => trpc.trending.list(limit, page),
   });
 }
 
@@ -37,10 +37,10 @@ export function useHeatmap() {
   });
 }
 
-export function usePublishTasks() {
+export function usePublishTasks(limit = 50, page = 0) {
   return useQuery({
-    queryKey: ['publishTasks'],
-    queryFn: () => trpc.publishTasks.list(),
+    queryKey: ['publishTasks', limit, page],
+    queryFn: () => trpc.publishTasks.list(limit, page),
   });
 }
 
@@ -65,10 +65,10 @@ export function useMetricsSummary() {
   });
 }
 
-export function useAuditLogs(limit = 50, offset = 0) {
+export function useAuditLogs(limit = 50, page = 0) {
   return useQuery({
-    queryKey: ['auditLogs', limit, offset],
-    queryFn: () => trpc.auditLogs.list(limit, offset),
+    queryKey: ['auditLogs', limit, page],
+    queryFn: () => trpc.auditLogs.list(limit, page),
   });
 }
 
@@ -86,10 +86,10 @@ export function useOptimizationRecommendations() {
   });
 }
 
-export function useMockups() {
+export function useMockups(limit = 100, page = 0) {
   return useQuery({
-    queryKey: ['mockups'],
-    queryFn: () => trpc.mockups.list(),
+    queryKey: ['mockups', limit, page],
+    queryFn: () => trpc.mockups.list(limit, page),
   });
 }
 

--- a/frontend/admin-dashboard/src/pages/dashboard/audit-logs.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/audit-logs.tsx
@@ -4,10 +4,13 @@ import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import { useAuditLogs } from '../../lib/trpc/hooks';
+import { useState } from 'react';
 
 function AuditLogsPage() {
   const { t } = useTranslation();
-  const { data, isLoading } = useAuditLogs();
+  const [page, setPage] = useState(0);
+  const limit = 50;
+  const { data, isLoading } = useAuditLogs(limit, page);
 
   return (
     <div className="space-y-2">
@@ -23,6 +26,19 @@ function AuditLogsPage() {
           ))}
         </ul>
       )}
+      <div className="space-x-2">
+        <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0}>
+          Prev
+        </button>
+        <button
+          onClick={() =>
+            setPage(page + 1)
+          }
+          disabled={data ? (page + 1) * limit >= data.total : false}
+        >
+          Next
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/mockup-gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/mockup-gallery.tsx
@@ -6,10 +6,13 @@ import Link from 'next/link';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import { useMockups } from '../../lib/trpc/hooks';
+import { useState } from 'react';
 
 function MockupGalleryPage() {
   const { t } = useTranslation();
-  const { data: mockups, isLoading } = useMockups();
+  const [page, setPage] = useState(0);
+  const limit = 100;
+  const { data: mockups, isLoading } = useMockups(limit, page);
 
   return (
     <div>
@@ -31,6 +34,12 @@ function MockupGalleryPage() {
           ))}
         </div>
       )}
+      <div className="space-x-2">
+        <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0}>
+          Prev
+        </button>
+        <button onClick={() => setPage(page + 1)}>Next</button>
+      </div>
     </div>
   );
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import { useTranslation } from 'react-i18next';
 import { usePublishTasks } from '../../lib/trpc/hooks';
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 
 function PublishPage() {
   const { t } = useTranslation();
-  const { data: tasks, isLoading } = usePublishTasks();
+  const [page, setPage] = useState(0);
+  const limit = 50;
+  const { data: tasks, isLoading } = usePublishTasks(limit, page);
   const { query } = useRouter();
   const mockupId = query.mockupId as string | undefined;
 
@@ -28,6 +31,12 @@ function PublishPage() {
           ))}
         </ul>
       )}
+      <div className="space-x-2">
+        <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0}>
+          Prev
+        </button>
+        <button onClick={() => setPage(page + 1)}>Next</button>
+      </div>
     </div>
   );
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
@@ -4,15 +4,24 @@ import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import dynamic from 'next/dynamic';
+import { useState } from 'react';
 
 const RolesList = dynamic(() => import('../../components/RolesList'));
 
 function RolesPage() {
   const { t } = useTranslation();
+  const [page, setPage] = useState(0);
+  const limit = 50;
   return (
     <div>
       <h1>{t('roles')}</h1>
-      <RolesList />
+      <RolesList limit={limit} page={page} />
+      <div className="space-x-2">
+        <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0}>
+          Prev
+        </button>
+        <button onClick={() => setPage(page + 1)}>Next</button>
+      </div>
     </div>
   );
 }

--- a/frontend/admin-dashboard/src/trpc.ts
+++ b/frontend/admin-dashboard/src/trpc.ts
@@ -131,7 +131,8 @@ export const trpc = {
     list: () => call<Idea[]>('ideas.list'),
   },
   mockups: {
-    list: () => call<Mockup[]>('mockups.list'),
+    list: (limit = 100, page = 0) =>
+      getJson<Mockup[]>(`/mockups?limit=${limit}&page=${page}`),
   },
   heatmap: {
     list: () => call<HeatmapEntry[]>('heatmap.list'),
@@ -140,7 +141,8 @@ export const trpc = {
     list: () => call<GalleryItem[]>('gallery.list'),
   },
   publishTasks: {
-    list: () => call<PublishTask[]>('publishTasks.list'),
+    list: (limit = 50, page = 0) =>
+      getJson<PublishTask[]>(`/publish-tasks?limit=${limit}&page=${page}`),
   },
   approvals: {
     approve: (runId: string) => post(`/approvals/${encodeURIComponent(runId)}`),
@@ -157,14 +159,15 @@ export const trpc = {
     list: () => getJson<string[]>('/recommendations'),
   },
   auditLogs: {
-    list: (limit = 50, offset = 0) =>
-      getJson<AuditLogResponse>(`/audit-logs?limit=${limit}&offset=${offset}`),
+    list: (limit = 50, page = 0) =>
+      getJson<AuditLogResponse>(`/audit-logs?limit=${limit}&page=${page}`),
   },
   optimizations: {
     list: () => getJson<string[]>('/optimizations'),
   },
   trending: {
-    list: (limit = 10) => getJson<string[]>(`/trending?limit=${limit}`),
+    list: (limit = 10, page = 0) =>
+      getJson<string[]>(`/trending?limit=${limit}&page=${page}`),
   },
   abTests: {
     summary: (id: number) => getJson<ABTestSummary>(`/ab_test_results/${id}`),


### PR DESCRIPTION
## Summary
- add pagination to trending keywords API
- paginate mockup listings
- add paginated low performers endpoint
- extend API gateway to accept page parameters
- support paginated views in admin dashboard

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/main.py backend/signal-ingestion/src/signal_ingestion/trending.py backend/analytics/api.py backend/mockup-generation/mockup_generation/api.py backend/mockup-generation/mockup_generation/model_repository.py backend/api-gateway/src/api_gateway/routes.py backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/main.py backend/signal-ingestion/src/signal_ingestion/trending.py backend/analytics/api.py backend/mockup-generation/mockup_generation/api.py backend/mockup-generation/mockup_generation/model_repository.py backend/api-gateway/src/api_gateway/routes.py backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py`
- `python -m pytest -W error -vv` *(failed: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687fdc37032c833196186005c9be54b7