### PR TITLE
Remove mypy ignore and fix types

### DIFF
--- a/backend/optimization/storage.py
+++ b/backend/optimization/storage.py
@@ -6,7 +6,7 @@ import os
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Iterator, List
+from typing import Iterator, List, Tuple
 
 import psycopg2
 from urllib.parse import urlparse
@@ -159,7 +159,9 @@ class MetricsStore:
                     rows = cur.fetchall()
         return self._rows_to_metrics(rows)
 
-    def _rows_to_metrics(self, rows: list[tuple]) -> List[ResourceMetric]:
+    def _rows_to_metrics(
+        self, rows: list[Tuple[str | datetime, float, float, float | None]]
+    ) -> List[ResourceMetric]:
         """Convert database rows to :class:`ResourceMetric` objects."""
         result: List[ResourceMetric] = []
         for ts, cpu, memory, disk in rows:

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -6,7 +6,7 @@ from pydantic import AnyUrl, Field, HttpUrl, RedisDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):  # type: ignore[misc]
+class Settings(BaseSettings):
     """Centralized configuration for backend services."""
 
     model_config = SettingsConfigDict(
@@ -37,7 +37,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     hsts: str | None = None
     allow_status_unauthenticated: bool = True
 
-    @field_validator("allowed_origins", mode="before")  # type: ignore[misc]
+    @field_validator("allowed_origins", mode="before")
     @classmethod
     def _split_origins(cls, value: str | list[str]) -> list[str]:
         """Parse comma separated origins from environment variables."""
@@ -50,7 +50,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "trending_ttl",
         "trending_max_keywords",
         "trending_cache_ttl",
-    )  # type: ignore[misc]
+    )
     @classmethod
     def _positive(cls, value: int) -> int:
         if value <= 0:

--- a/backend/shared/security.py
+++ b/backend/shared/security.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Coroutine
+from typing import Any, Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi import HTTPException
@@ -16,7 +16,7 @@ def add_security_headers(app: FastAPI) -> None:
 
     async def _set_headers(
         request: Request,
-        call_next: Callable[[Request], Coroutine[None, None, Response]],
+        call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         response = await call_next(request)
         response.headers.setdefault("X-Content-Type-Options", "nosniff")

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from flask import Flask
 from opentelemetry import trace
+
 # The exporter classes are imported lazily within ``configure_tracing`` to avoid
 # heavy dependencies and noisy warnings during package import.
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -25,12 +26,15 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
         OTLPSpanExporter as OTLPHTTPSpanExporter,
     )
+
     resource = Resource.create({"service.name": service_name})
     provider = TracerProvider(resource=resource)
     endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
     protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
     if protocol == "grpc":
-        exporter = OTLPGrpcSpanExporter(endpoint=endpoint)
+        exporter: OTLPGrpcSpanExporter | OTLPHTTPSpanExporter = OTLPGrpcSpanExporter(
+            endpoint=endpoint
+        )
     else:
         exporter = OTLPHTTPSpanExporter(endpoint=endpoint)
     processor = BatchSpanProcessor(exporter)
@@ -40,4 +44,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)
+        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]


### PR DESCRIPTION
## Summary
- drop `mypy: ignore-errors` from optimization API
- tighten types for metrics storage and currency utils
- improve Sentry configuration and feature flag utilities
- refactor metrics and error handling helpers
- update tracing and security helpers
- add missing type hints and minor fixes

## Testing
- `flake8 backend/optimization/api.py backend/shared/currency.py backend/shared/sentry.py backend/optimization/storage.py backend/shared/profiling.py backend/shared/feature_flags.py backend/shared/errors.py backend/shared/metrics.py backend/shared/tracing.py backend/shared/security.py`
- `pydocstyle backend/optimization/api.py backend/shared/currency.py backend/shared/sentry.py backend/optimization/storage.py backend/shared/profiling.py backend/shared/feature_flags.py backend/shared/errors.py backend/shared/metrics.py backend/shared/tracing.py backend/shared/security.py`
- `docformatter -r -i backend/optimization/api.py backend/shared/currency.py backend/shared/sentry.py backend/optimization/storage.py backend/shared/profiling.py backend/shared/feature_flags.py backend/shared/errors.py backend/shared/metrics.py backend/shared/tracing.py backend/shared/security.py`
- `mypy backend/optimization/api.py`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'ldclient.config')*

------
https://chatgpt.com/codex/tasks/task_b_687fdc1c593483318c462f84ce5248e5