### PR TITLE
Add date range filtering for analytics exports

### DIFF
--- a/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
@@ -1,9 +1,9 @@
-"""add marketplace perf listing id index
+"""
+Add marketplace perf listing id index.
 
 Revision ID: 7544cf9b2fd7
 Revises: 0019
 Create Date: 2025-07-22 16:30:59.175652
-
 """
 
 from alembic import op

--- a/openapi/analytics.json
+++ b/openapi/analytics.json
@@ -1,438 +1,381 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "Analytics Service",
-    "version": "0.1.0"
-  },
-  "paths": {
-    "/ab_test_results/{ab_test_id}": {
-      "get": {
-        "summary": "Ab Test Results",
-        "description": "Return aggregated A/B test results.",
-        "operationId": "ab_test_results_ab_test_results__ab_test_id__get",
-        "parameters": [
-          {
-            "name": "ab_test_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Ab Test Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ABTestSummary"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ab_test_results/{ab_test_id}/export": {
-      "get": {
-        "summary": "Export Ab Test Results",
-        "description": "Return all A/B test result rows for ``ab_test_id`` as CSV.",
-        "operationId": "export_ab_test_results_ab_test_results__ab_test_id__export_get",
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "ab_test_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Ab Test Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/marketplace_metrics/{listing_id}": {
-      "get": {
-        "summary": "Marketplace Metrics",
-        "description": "Return aggregated metrics for a listing.",
-        "operationId": "marketplace_metrics_marketplace_metrics__listing_id__get",
-        "parameters": [
-          {
-            "name": "listing_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Listing Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MarketplaceSummary"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/marketplace_metrics/{listing_id}/export": {
-      "get": {
-        "summary": "Export Marketplace Metrics",
-        "description": "Return all marketplace metrics rows for ``listing_id`` as CSV.",
-        "operationId": "export_marketplace_metrics_marketplace_metrics__listing_id__export_get",
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "listing_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Listing Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/performance_metrics/{listing_id}/export": {
-      "get": {
-        "summary": "Export Performance Metrics",
-        "description": "Return all performance metrics rows for ``listing_id`` as CSV.",
-        "operationId": "export_performance_metrics_performance_metrics__listing_id__export_get",
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "listing_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Listing Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/low_performers": {
-      "get": {
-        "summary": "Low Performers",
-        "description": "Return listings with the lowest total revenue.",
-        "operationId": "low_performers_low_performers_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "title": "Limit",
-              "default": 10
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/LowPerformer"
-                  },
-                  "type": "array",
-                  "title": "Response Low Performers Low Performers Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "summary": "Health",
-        "description": "Return service liveness.",
-        "operationId": "health_health_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "type": "object",
-                  "title": "Response Health Health Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ready": {
-      "get": {
-        "summary": "Ready",
-        "description": "Return service readiness.",
-        "operationId": "ready_ready_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "type": "object",
-                  "title": "Response Ready Ready Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "ABTestSummary": {
-        "properties": {
-          "ab_test_id": {
-            "type": "integer",
-            "title": "Ab Test Id"
-          },
-          "conversions": {
-            "type": "integer",
-            "title": "Conversions"
-          },
-          "impressions": {
-            "type": "integer",
-            "title": "Impressions"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ab_test_id",
-          "conversions",
-          "impressions"
-        ],
-        "title": "ABTestSummary",
-        "description": "Summary of results for an A/B test."
-      },
-      "HTTPValidationError": {
-        "properties": {
-          "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
-            "type": "array",
-            "title": "Detail"
-          }
-        },
-        "type": "object",
-        "title": "HTTPValidationError"
-      },
-      "MarketplaceSummary": {
-        "properties": {
-          "listing_id": {
-            "type": "integer",
-            "title": "Listing Id"
-          },
-          "clicks": {
-            "type": "integer",
-            "title": "Clicks"
-          },
-          "purchases": {
-            "type": "integer",
-            "title": "Purchases"
-          },
-          "revenue": {
-            "type": "number",
-            "title": "Revenue"
-          }
-        },
-        "type": "object",
-        "required": [
-          "listing_id",
-          "clicks",
-          "purchases",
-          "revenue"
-        ],
-        "title": "MarketplaceSummary",
-        "description": "Aggregated metrics for a listing."
-      },
-      "LowPerformer": {
-        "properties": {
-          "listing_id": {
-            "type": "integer",
-            "title": "Listing Id"
-          },
-          "revenue": {
-            "type": "number",
-            "title": "Revenue"
-          }
-        },
-        "type": "object",
-        "required": [
-          "listing_id",
-          "revenue"
-        ],
-        "title": "LowPerformer",
-        "description": "Listing with the lowest revenue."
-      },
-      "ValidationError": {
-        "properties": {
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
+    "openapi": "3.1.0",
+    "info": {"title": "Analytics Service", "version": "0.1.0"},
+    "paths": {
+        "/ab_test_results/{ab_test_id}": {
+            "get": {
+                "summary": "Ab Test Results",
+                "description": "Return aggregated A/B test results.",
+                "operationId": "ab_test_results_ab_test_results__ab_test_id__get",
+                "parameters": [
+                    {
+                        "name": "ab_test_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {"type": "integer", "title": "Ab Test Id"},
+                    },
+                    {
+                        "name": "start",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "Start",
+                        },
+                    },
+                    {
+                        "name": "end",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "End",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ABTestSummary"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
                 },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Location"
-          },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          }
+            }
         },
-        "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError"
-      }
+        "/ab_test_results/{ab_test_id}/export": {
+            "get": {
+                "summary": "Export Ab Test Results",
+                "description": "Return all A/B test result rows for ``ab_test_id`` as CSV.",
+                "operationId": "export_ab_test_results_ab_test_results__ab_test_id__export_get",
+                "security": [{"HTTPBearer": []}],
+                "parameters": [
+                    {
+                        "name": "ab_test_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {"type": "integer", "title": "Ab Test Id"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/marketplace_metrics/{listing_id}": {
+            "get": {
+                "summary": "Marketplace Metrics",
+                "description": "Return aggregated metrics for a listing.",
+                "operationId": "marketplace_metrics_marketplace_metrics__listing_id__get",
+                "parameters": [
+                    {
+                        "name": "listing_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {"type": "integer", "title": "Listing Id"},
+                    },
+                    {
+                        "name": "start",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "Start",
+                        },
+                    },
+                    {
+                        "name": "end",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "End",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketplaceSummary"
+                                }
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/marketplace_metrics/{listing_id}/export": {
+            "get": {
+                "summary": "Export Marketplace Metrics",
+                "description": "Return all marketplace metrics rows for ``listing_id`` as CSV.",
+                "operationId": "export_marketplace_metrics_marketplace_metrics__listing_id__export_get",
+                "security": [{"HTTPBearer": []}],
+                "parameters": [
+                    {
+                        "name": "listing_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {"type": "integer", "title": "Listing Id"},
+                    },
+                    {
+                        "name": "start",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "Start",
+                        },
+                    },
+                    {
+                        "name": "end",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "End",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/performance_metrics/{listing_id}/export": {
+            "get": {
+                "summary": "Export Performance Metrics",
+                "description": "Return all performance metrics rows for ``listing_id`` as CSV.",
+                "operationId": "export_performance_metrics_performance_metrics__listing_id__export_get",
+                "security": [{"HTTPBearer": []}],
+                "parameters": [
+                    {
+                        "name": "listing_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {"type": "integer", "title": "Listing Id"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/low_performers": {
+            "get": {
+                "summary": "Low Performers",
+                "description": "Return listings with the lowest total revenue.",
+                "operationId": "low_performers_low_performers_get",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {"type": "integer", "title": "Limit", "default": 10},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/LowPerformer"
+                                    },
+                                    "type": "array",
+                                    "title": "Response Low Performers Low Performers Get",
+                                }
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/health": {
+            "get": {
+                "summary": "Health",
+                "description": "Return service liveness.",
+                "operationId": "health_health_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {"type": "string"},
+                                    "type": "object",
+                                    "title": "Response Health Health Get",
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
+        "/ready": {
+            "get": {
+                "summary": "Ready",
+                "description": "Return service readiness.",
+                "operationId": "ready_ready_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {"type": "string"},
+                                    "type": "object",
+                                    "title": "Response Ready Ready Get",
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
     },
-    "securitySchemes": {
-      "HTTPBearer": {
-        "type": "http",
-        "scheme": "bearer"
-      }
-    }
-  },
-  "x-spec-version": "f58f45c2f5a81524937d4df9b2c4931b88c96589159210eda06a7eddb46642cd"
+    "components": {
+        "schemas": {
+            "ABTestSummary": {
+                "properties": {
+                    "ab_test_id": {"type": "integer", "title": "Ab Test Id"},
+                    "conversions": {"type": "integer", "title": "Conversions"},
+                    "impressions": {"type": "integer", "title": "Impressions"},
+                },
+                "type": "object",
+                "required": ["ab_test_id", "conversions", "impressions"],
+                "title": "ABTestSummary",
+                "description": "Summary of results for an A/B test.",
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "detail": {
+                        "items": {"$ref": "#/components/schemas/ValidationError"},
+                        "type": "array",
+                        "title": "Detail",
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError",
+            },
+            "MarketplaceSummary": {
+                "properties": {
+                    "listing_id": {"type": "integer", "title": "Listing Id"},
+                    "clicks": {"type": "integer", "title": "Clicks"},
+                    "purchases": {"type": "integer", "title": "Purchases"},
+                    "revenue": {"type": "number", "title": "Revenue"},
+                },
+                "type": "object",
+                "required": ["listing_id", "clicks", "purchases", "revenue"],
+                "title": "MarketplaceSummary",
+                "description": "Aggregated metrics for a listing.",
+            },
+            "LowPerformer": {
+                "properties": {
+                    "listing_id": {"type": "integer", "title": "Listing Id"},
+                    "revenue": {"type": "number", "title": "Revenue"},
+                },
+                "type": "object",
+                "required": ["listing_id", "revenue"],
+                "title": "LowPerformer",
+                "description": "Listing with the lowest revenue.",
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                        "type": "array",
+                        "title": "Location",
+                    },
+                    "msg": {"type": "string", "title": "Message"},
+                    "type": {"type": "string", "title": "Error Type"},
+                },
+                "type": "object",
+                "required": ["loc", "msg", "type"],
+                "title": "ValidationError",
+            },
+        },
+        "securitySchemes": {"HTTPBearer": {"type": "http", "scheme": "bearer"}},
+    },
+    "x-spec-version": "f58f45c2f5a81524937d4df9b2c4931b88c96589159210eda06a7eddb46642cd",
 }


### PR DESCRIPTION
## Summary
- support `start` and `end` query parameters when exporting analytics data
- filter export queries by date range
- document the new parameters in the OpenAPI spec
- test date range filtering

## Testing
- `pytest tests/test_analytics.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687fdc119e5883319949c53bf908747f