### PR TITLE
Implement dashboard pagination

### DIFF
--- a/frontend/admin-dashboard/__tests__/trpc.test.ts
+++ b/frontend/admin-dashboard/__tests__/trpc.test.ts
@@ -42,7 +42,7 @@ describe('tRPC ping', () => {
 test('auditLogs.list fetches data', async () => {
   await trpc.auditLogs.list();
   expect(global.fetch).toHaveBeenCalledWith(
-    'http://localhost:8000/audit-logs?limit=50&offset=0'
+    'http://localhost:8000/audit-logs?page=1&limit=50'
   );
 });
 

--- a/frontend/admin-dashboard/src/components/PaginationControls.tsx
+++ b/frontend/admin-dashboard/src/components/PaginationControls.tsx
@@ -1,0 +1,42 @@
+// @flow
+import React from 'react';
+
+type Props = {
+  page: number;
+  total: number | null;
+  limit: number;
+  onPageChange: (newPage: number) => void;
+};
+
+export default function PaginationControls({
+  page,
+  total,
+  limit,
+  onPageChange,
+}: Props) {
+  const maxPage = total != null ? Math.ceil(total / limit) : null;
+  return (
+    <div className="flex items-center space-x-2">
+      <button
+        type="button"
+        className="px-2 py-1 border"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        Prev
+      </button>
+      <span>
+        Page {page}
+        {maxPage ? ` / ${maxPage}` : ''}
+      </span>
+      <button
+        type="button"
+        className="px-2 py-1 border"
+        disabled={maxPage != null && page >= maxPage}
+        onClick={() => onPageChange(page + 1)}
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/frontend/admin-dashboard/src/components/RolesList.tsx
+++ b/frontend/admin-dashboard/src/components/RolesList.tsx
@@ -1,30 +1,43 @@
 // @flow
 import React, { useEffect, useState } from 'react';
 import { fetchWithAuth } from '../hooks/useAuthFetch';
+import PaginationControls from './PaginationControls';
 
 interface Assignment {
   username: string;
   role: string;
 }
 
+const LIMIT = 20;
+
 export function RolesList() {
   const [roles, setRoles] = useState<Assignment[]>([]);
+  const [page, setPage] = useState(1);
+
   useEffect(() => {
     async function load() {
-      const resp = await fetchWithAuth('/roles');
+      const resp = await fetchWithAuth(`/roles?page=${page}&limit=${LIMIT}`);
       if (resp.ok) {
         setRoles(await resp.json());
       }
     }
     void load();
-  }, []);
+  }, [page]);
   return (
-    <ul aria-label="User roles">
-      {roles.map((r) => (
-        <li key={r.username}>
-          {r.username}: {r.role}
-        </li>
-      ))}
-    </ul>
+    <>
+      <ul aria-label="User roles">
+        {roles.map((r) => (
+          <li key={r.username}>
+            {r.username}: {r.role}
+          </li>
+        ))}
+      </ul>
+      <PaginationControls
+        page={page}
+        total={null}
+        limit={LIMIT}
+        onPageChange={setPage}
+      />
+    </>
   );
 }

--- a/frontend/admin-dashboard/src/lib/trpc/hooks.ts
+++ b/frontend/admin-dashboard/src/lib/trpc/hooks.ts
@@ -16,17 +16,17 @@ export function useAbTestSummary(abTestId: number) {
   });
 }
 
-export function useSignals() {
+export function useSignals(page: number = 1, limit: number = 20) {
   return useQuery({
-    queryKey: ['signals'],
-    queryFn: () => trpc.signals.list(),
+    queryKey: ['signals', page, limit],
+    queryFn: () => trpc.signals.list(page, limit),
   });
 }
 
-export function useGalleryItems() {
+export function useGalleryItems(page: number = 1, limit: number = 20) {
   return useQuery({
-    queryKey: ['gallery'],
-    queryFn: () => trpc.gallery.list(),
+    queryKey: ['gallery', page, limit],
+    queryFn: () => trpc.gallery.list(page, limit),
   });
 }
 
@@ -37,10 +37,10 @@ export function useHeatmap() {
   });
 }
 
-export function usePublishTasks() {
+export function usePublishTasks(page: number = 1, limit: number = 20) {
   return useQuery({
-    queryKey: ['publishTasks'],
-    queryFn: () => trpc.publishTasks.list(),
+    queryKey: ['publishTasks', page, limit],
+    queryFn: () => trpc.publishTasks.list(page, limit),
   });
 }
 
@@ -65,10 +65,10 @@ export function useMetricsSummary() {
   });
 }
 
-export function useAuditLogs(limit = 50, offset = 0) {
+export function useAuditLogs(page: number = 1, limit: number = 50) {
   return useQuery({
-    queryKey: ['auditLogs', limit, offset],
-    queryFn: () => trpc.auditLogs.list(limit, offset),
+    queryKey: ['auditLogs', page, limit],
+    queryFn: () => trpc.auditLogs.list(page, limit),
   });
 }
 
@@ -86,10 +86,10 @@ export function useOptimizationRecommendations() {
   });
 }
 
-export function useMockups() {
+export function useMockups(page: number = 1, limit: number = 20) {
   return useQuery({
-    queryKey: ['mockups'],
-    queryFn: () => trpc.mockups.list(),
+    queryKey: ['mockups', page, limit],
+    queryFn: () => trpc.mockups.list(page, limit),
   });
 }
 

--- a/frontend/admin-dashboard/src/pages/dashboard/audit-logs.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/audit-logs.tsx
@@ -1,13 +1,17 @@
 // @flow
-import React from 'react';
+import React, { useState } from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import { useAuditLogs } from '../../lib/trpc/hooks';
+import PaginationControls from '../../components/PaginationControls';
+
+const LIMIT = 20;
 
 function AuditLogsPage() {
   const { t } = useTranslation();
-  const { data, isLoading } = useAuditLogs();
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useAuditLogs(page, LIMIT);
 
   return (
     <div className="space-y-2">
@@ -15,13 +19,21 @@ function AuditLogsPage() {
       {isLoading || !data ? (
         <div>{t('loading')}</div>
       ) : (
-        <ul>
-          {data.items.map((log) => (
-            <li
-              key={log.id}
-            >{`${log.timestamp} ${log.username} ${log.action}`}</li>
-          ))}
-        </ul>
+        <>
+          <ul>
+            {data.items.map((log) => (
+              <li
+                key={log.id}
+              >{`${log.timestamp} ${log.username} ${log.action}`}</li>
+            ))}
+          </ul>
+          <PaginationControls
+            page={page}
+            total={data.total}
+            limit={LIMIT}
+            onPageChange={setPage}
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
@@ -1,35 +1,50 @@
 // @flow
-import React from 'react';
+import React, { useState } from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import Image from 'next/image';
 import Link from 'next/link';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import { useGalleryItems } from '../../lib/trpc/hooks';
+import PaginationControls from '../../components/PaginationControls';
+
+const LIMIT = 20;
 
 function GalleryPage() {
   const { t } = useTranslation();
-  const { data: items, isLoading } = useGalleryItems();
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useGalleryItems(page, LIMIT);
 
   return (
     <div>
       <h1>{t('gallery')}</h1>
-      {isLoading || !items ? (
+      {isLoading || !data ? (
         <div>{t('loading')}</div>
       ) : (
-        <div className="grid grid-cols-3 gap-2">
-          {items.map((item) => (
-            <Link key={item.id} href={`/dashboard/publish?mockupId=${item.id}`}>
-              <Image
-                src={item.imageUrl}
-                alt={item.title}
-                width={200}
-                height={200}
-                className="border"
-              />
-            </Link>
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-3 gap-2">
+            {data.items.map((item) => (
+              <Link
+                key={item.id}
+                href={`/dashboard/publish?mockupId=${item.id}`}
+              >
+                <Image
+                  src={item.imageUrl}
+                  alt={item.title}
+                  width={200}
+                  height={200}
+                  className="border"
+                />
+              </Link>
+            ))}
+          </div>
+          <PaginationControls
+            page={page}
+            total={data.total}
+            limit={LIMIT}
+            onPageChange={setPage}
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/admin-dashboard/src/pages/dashboard/low-performers.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/low-performers.tsx
@@ -2,20 +2,26 @@
 import React, { useEffect, useState } from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import { useTranslation } from 'react-i18next';
+import PaginationControls from '../../components/PaginationControls';
 
 interface Performer {
   listing_id: number;
   revenue: number;
 }
 
+const LIMIT = 20;
+
 function LowPerformersPage() {
   const { t } = useTranslation();
   const [items, setItems] = useState<Performer[]>([]);
+  const [page, setPage] = useState(1);
   const base = process.env.NEXT_PUBLIC_ANALYTICS_URL ?? 'http://localhost:8000';
   useEffect(() => {
     async function fetchData() {
       try {
-        const res = await fetch(`${base}/low_performers`);
+        const res = await fetch(
+          `${base}/low_performers?limit=${LIMIT}&page=${page}`
+        );
         if (res.ok) {
           setItems(await res.json());
         }
@@ -24,7 +30,7 @@ function LowPerformersPage() {
       }
     }
     void fetchData();
-  }, [base]);
+  }, [base, page]);
 
   return (
     <div className="space-y-2">
@@ -36,6 +42,12 @@ function LowPerformersPage() {
           </li>
         ))}
       </ul>
+      <PaginationControls
+        page={page}
+        total={null}
+        limit={LIMIT}
+        onPageChange={setPage}
+      />
     </div>
   );
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/mockup-gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/mockup-gallery.tsx
@@ -1,35 +1,47 @@
 // @flow
-import React from 'react';
+import React, { useState } from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import Image from 'next/image';
 import Link from 'next/link';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import { useMockups } from '../../lib/trpc/hooks';
+import PaginationControls from '../../components/PaginationControls';
+
+const LIMIT = 20;
 
 function MockupGalleryPage() {
   const { t } = useTranslation();
-  const { data: mockups, isLoading } = useMockups();
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useMockups(page, LIMIT);
 
   return (
     <div>
       <h1>{t('mockupGallery')}</h1>
-      {isLoading || !mockups ? (
+      {isLoading || !data ? (
         <div>{t('loading')}</div>
       ) : (
-        <div className="grid grid-cols-3 gap-2">
-          {mockups.map((m) => (
-            <Link key={m.id} href={`/dashboard/publish?mockupId=${m.id}`}>
-              <Image
-                src={m.imageUrl}
-                alt={m.id.toString()}
-                width={200}
-                height={200}
-                className="border"
-              />
-            </Link>
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-3 gap-2">
+            {data.items.map((m) => (
+              <Link key={m.id} href={`/dashboard/publish?mockupId=${m.id}`}>
+                <Image
+                  src={m.imageUrl}
+                  alt={m.id.toString()}
+                  width={200}
+                  height={200}
+                  className="border"
+                />
+              </Link>
+            ))}
+          </div>
+          <PaginationControls
+            page={page}
+            total={data.total}
+            limit={LIMIT}
+            onPageChange={setPage}
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/admin-dashboard/src/pages/dashboard/signals.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/signals.tsx
@@ -1,13 +1,17 @@
 // @flow
-import React from 'react';
+import React, { useState } from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import { useSignals } from '../../lib/trpc/hooks';
+import PaginationControls from '../../components/PaginationControls';
+
+const LIMIT = 20;
 
 function SignalsPage() {
   const { t } = useTranslation();
-  const { data: signals, isLoading } = useSignals();
+  const [page, setPage] = useState(1);
+  const { data: signals, isLoading } = useSignals(page, LIMIT);
 
   return (
     <div className="space-y-2">
@@ -15,13 +19,21 @@ function SignalsPage() {
       {isLoading || !signals ? (
         <div>{t('loading')}</div>
       ) : (
-        <ul>
-          {signals.map((s) => (
-            <li key={s.id}>
-              {s.source}: {s.content}
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul>
+            {signals.items.map((s) => (
+              <li key={s.id}>
+                {s.source}: {s.content}
+              </li>
+            ))}
+          </ul>
+          <PaginationControls
+            page={page}
+            total={signals.total}
+            limit={LIMIT}
+            onPageChange={setPage}
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/admin-dashboard/src/trpc.ts
+++ b/frontend/admin-dashboard/src/trpc.ts
@@ -125,22 +125,26 @@ export const trpc = {
     mutate: () => call<{ message: string; user: string }>('ping'),
   },
   signals: {
-    list: () => call<Signal[]>('signals.list'),
+    list: (page = 1, limit = 20) =>
+      call<Signal[]>('signals.list', { page, limit }),
   },
   ideas: {
     list: () => call<Idea[]>('ideas.list'),
   },
   mockups: {
-    list: () => call<Mockup[]>('mockups.list'),
+    list: (page = 1, limit = 20) =>
+      call<Mockup[]>('mockups.list', { page, limit }),
   },
   heatmap: {
     list: () => call<HeatmapEntry[]>('heatmap.list'),
   },
   gallery: {
-    list: () => call<GalleryItem[]>('gallery.list'),
+    list: (page = 1, limit = 20) =>
+      call<GalleryItem[]>('gallery.list', { page, limit }),
   },
   publishTasks: {
-    list: () => call<PublishTask[]>('publishTasks.list'),
+    list: (page = 1, limit = 20) =>
+      call<PublishTask[]>('publishTasks.list', { page, limit }),
   },
   approvals: {
     approve: (runId: string) => post(`/approvals/${encodeURIComponent(runId)}`),
@@ -157,8 +161,8 @@ export const trpc = {
     list: () => getJson<string[]>('/recommendations'),
   },
   auditLogs: {
-    list: (limit = 50, offset = 0) =>
-      getJson<AuditLogResponse>(`/audit-logs?limit=${limit}&offset=${offset}`),
+    list: (page = 1, limit = 50) =>
+      getJson<AuditLogResponse>(`/audit-logs?page=${page}&limit=${limit}`),
   },
   optimizations: {
     list: () => getJson<string[]>('/optimizations'),


### PR DESCRIPTION
## Summary
- add pagination controls component
- support page/limit params in tRPC client hooks
- paginate audit log, signals, gallery, mockups and roles pages
- add pagination params to API routes for roles, audit logs, and low performers
- update tests for new query format

## Testing
- `flake8 backend/api-gateway/src/api_gateway/routes.py`
- `pydocstyle backend/api-gateway/src/api_gateway/routes.py`
- `docformatter --in-place backend/api-gateway/src/api_gateway/routes.py`
- `npx eslint src/components/PaginationControls.tsx src/lib/trpc/hooks.ts src/trpc.ts src/pages/dashboard/audit-logs.tsx src/pages/dashboard/signals.tsx src/pages/dashboard/gallery.tsx src/pages/dashboard/mockup-gallery.tsx src/components/RolesList.tsx src/pages/dashboard/low-performers.tsx`
- `npx prettier src/components/PaginationControls.tsx src/lib/trpc/hooks.ts src/trpc.ts src/pages/dashboard/audit-logs.tsx src/pages/dashboard/signals.tsx src/pages/dashboard/gallery.tsx src/pages/dashboard/mockup-gallery.tsx src/components/RolesList.tsx src/pages/dashboard/low-performers.tsx --write`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687fdfef5de4833199724a5910c9116d