### PR TITLE
Fix Prettier ignore and reformat docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 openapi/*.json
 docs/**
+!docs/**/*.md
 .vscode/**
 CHANGELOG.md
 README.md

--- a/docs/admin_dashboard_trpc.md
+++ b/docs/admin_dashboard_trpc.md
@@ -14,4 +14,3 @@ The dashboard uses a custom Tailwind setup defined in `tailwind.config.ts`. The 
 extends the default palette with a `brand` color and sets the sans and mono font
 families from CSS variables. This ensures consistent colors and fonts across all
 components.
-

--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -59,4 +59,3 @@ Check that all Pods are running and inspect logs using `kubectl get pods` and
 3. **Create an ingress controller** if using AKS and configure TLS.
 
 These high-level steps give an overview of deploying the application on each cloud platform. Refer to the provider documentation for production hardening guidance.
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,63 +9,62 @@ Kubernetes secrets under `/run/secrets` and loaded automatically by the
 application settings classes.
 See the blueprint environment variables section in `blueprints/DesignIdeaEngineCompleteBlueprint.md` for a complete example of the `.env` layout for each service.
 
-
-| Variable | Description |
-| --- | --- |
-| `DATABASE_URL` | Database connection string |
-| `DB_POOL_SIZE` | Size of the SQLAlchemy connection pool |
-| `REDIS_URL` | Redis connection string |
-| `SECRET_KEY` | Secret key for cryptographic signing |
-| `AUTH0_DOMAIN` | Domain of the Auth0 tenant used for authentication |
-| `AUTH0_CLIENT_ID` | Client identifier issued by Auth0 |
-| `OPENAI_API_KEY` | OpenAI API authentication token used for image and listing generation |
-| `STABILITY_AI_API_KEY` | Stability AI API token |
-| `FALLBACK_PROVIDER` | `stability` or `dall-e` |
-| `HUGGINGFACE_TOKEN` | Hugging Face API token for Claude-based listing generation |
-| `S3_ENDPOINT` | URL of the object storage service |
-| `S3_ACCESS_KEY` | Object storage access key |
-| `S3_SECRET_KEY` | Object storage secret key |
-| `S3_BUCKET` | Bucket name for storing assets |
-| `S3_BASE_URL` | Public base URL for accessing stored objects |
-| `KAFKA_BOOTSTRAP_SERVERS` | Kafka broker list |
-| `SCHEMA_REGISTRY_URL` | Schema Registry endpoint |
-| `SCHEMA_REGISTRY_TOKEN` | Authentication token for the schema registry |
-| `LOG_LEVEL` | Logging verbosity |
-| `APPROVAL_SERVICE_URL` | Base URL of the manual approval service |
-| `ALLOWED_ORIGINS` | Comma separated whitelist of origins for CORS |
-| `ALLOW_STATUS_UNAUTHENTICATED` | Set to `false` to require an API key for `/ready` |
-| `WEIGHTS_TOKEN` | Token required for updating scoring weights |
-| `ENABLED_ADAPTERS` | Comma separated list of ingestion adapters to run; if unset all adapters are used |
-| `PAGERDUTY_ROUTING_KEY` | Integration key for sending PagerDuty incidents |
-| `ENABLE_PAGERDUTY` | Set to `true` to enable PagerDuty notifications |
-| `SLA_ALERT_COOLDOWN_MINUTES` | Minimum minutes between SLA alerts |
-| `DEDUP_ERROR_RATE` | Probability of false positives in the Bloom filter |
-| `DEDUP_CAPACITY` | Estimated maximum number of entries in the Bloom filter |
-| `DEDUP_TTL` | Time-to-live in seconds for deduplication keys |
-| `PUBLISHER_METRICS_INTERVAL_MINUTES` | Interval for fetching publisher metrics |
-| `WEIGHT_UPDATE_INTERVAL_MINUTES` | Interval for updating scoring weights |
-| `HTTP_RETRIES` | Number of retry attempts for outgoing HTTP calls |
-| `SENTRY_DSN` | Sentry Data Source Name for error reporting |
-| `METRICS_DB_URL` | TimescaleDB connection string for storing metrics |
-| `API_GATEWAY_WS_INTERVAL_MS` | WebSocket polling interval for API Gateway |
-| `CELERY_BROKER` | Celery broker backend (e.g., `redis`) |
-| `REDIS_HOST` | Redis host for Celery |
-| `REDIS_PORT` | Redis port for Celery |
-| `REDIS_DB` | Redis database index for Celery |
-| `RABBITMQ_HOST` | RabbitMQ host for Celery |
-| `RABBITMQ_PORT` | RabbitMQ port |
-| `RABBITMQ_USER` | RabbitMQ username |
-| `RABBITMQ_PASSWORD` | RabbitMQ password |
-| `INSTAGRAM_TOKEN` | Instagram Graph API token |
-| `INSTAGRAM_USER_ID` | Instagram user id to fetch posts from |
-| `INSTAGRAM_FETCH_LIMIT` | Number of Instagram posts to retrieve |
-| `REDDIT_USER_AGENT` | User agent string for Reddit API |
-| `REDDIT_FETCH_LIMIT` | Number of Reddit posts to retrieve |
-| `YOUTUBE_API_KEY` | YouTube Data API key |
-| `YOUTUBE_FETCH_LIMIT` | Number of YouTube videos to retrieve |
-| `TIKTOK_VIDEO_URLS` | Comma separated list of TikTok video URLs |
-| `TIKTOK_FETCH_LIMIT` | Number of TikTok videos to retrieve |
-| `NOSTALGIA_QUERY` | Search query for Nostalgia data |
-| `NOSTALGIA_FETCH_LIMIT` | Number of Nostalgia items to retrieve |
-| `EVENTS_COUNTRY_CODE` | Event API country code |
-| `EVENTS_FETCH_LIMIT` | Number of events to retrieve |
+| Variable                             | Description                                                                       |
+| ------------------------------------ | --------------------------------------------------------------------------------- |
+| `DATABASE_URL`                       | Database connection string                                                        |
+| `DB_POOL_SIZE`                       | Size of the SQLAlchemy connection pool                                            |
+| `REDIS_URL`                          | Redis connection string                                                           |
+| `SECRET_KEY`                         | Secret key for cryptographic signing                                              |
+| `AUTH0_DOMAIN`                       | Domain of the Auth0 tenant used for authentication                                |
+| `AUTH0_CLIENT_ID`                    | Client identifier issued by Auth0                                                 |
+| `OPENAI_API_KEY`                     | OpenAI API authentication token used for image and listing generation             |
+| `STABILITY_AI_API_KEY`               | Stability AI API token                                                            |
+| `FALLBACK_PROVIDER`                  | `stability` or `dall-e`                                                           |
+| `HUGGINGFACE_TOKEN`                  | Hugging Face API token for Claude-based listing generation                        |
+| `S3_ENDPOINT`                        | URL of the object storage service                                                 |
+| `S3_ACCESS_KEY`                      | Object storage access key                                                         |
+| `S3_SECRET_KEY`                      | Object storage secret key                                                         |
+| `S3_BUCKET`                          | Bucket name for storing assets                                                    |
+| `S3_BASE_URL`                        | Public base URL for accessing stored objects                                      |
+| `KAFKA_BOOTSTRAP_SERVERS`            | Kafka broker list                                                                 |
+| `SCHEMA_REGISTRY_URL`                | Schema Registry endpoint                                                          |
+| `SCHEMA_REGISTRY_TOKEN`              | Authentication token for the schema registry                                      |
+| `LOG_LEVEL`                          | Logging verbosity                                                                 |
+| `APPROVAL_SERVICE_URL`               | Base URL of the manual approval service                                           |
+| `ALLOWED_ORIGINS`                    | Comma separated whitelist of origins for CORS                                     |
+| `ALLOW_STATUS_UNAUTHENTICATED`       | Set to `false` to require an API key for `/ready`                                 |
+| `WEIGHTS_TOKEN`                      | Token required for updating scoring weights                                       |
+| `ENABLED_ADAPTERS`                   | Comma separated list of ingestion adapters to run; if unset all adapters are used |
+| `PAGERDUTY_ROUTING_KEY`              | Integration key for sending PagerDuty incidents                                   |
+| `ENABLE_PAGERDUTY`                   | Set to `true` to enable PagerDuty notifications                                   |
+| `SLA_ALERT_COOLDOWN_MINUTES`         | Minimum minutes between SLA alerts                                                |
+| `DEDUP_ERROR_RATE`                   | Probability of false positives in the Bloom filter                                |
+| `DEDUP_CAPACITY`                     | Estimated maximum number of entries in the Bloom filter                           |
+| `DEDUP_TTL`                          | Time-to-live in seconds for deduplication keys                                    |
+| `PUBLISHER_METRICS_INTERVAL_MINUTES` | Interval for fetching publisher metrics                                           |
+| `WEIGHT_UPDATE_INTERVAL_MINUTES`     | Interval for updating scoring weights                                             |
+| `HTTP_RETRIES`                       | Number of retry attempts for outgoing HTTP calls                                  |
+| `SENTRY_DSN`                         | Sentry Data Source Name for error reporting                                       |
+| `METRICS_DB_URL`                     | TimescaleDB connection string for storing metrics                                 |
+| `API_GATEWAY_WS_INTERVAL_MS`         | WebSocket polling interval for API Gateway                                        |
+| `CELERY_BROKER`                      | Celery broker backend (e.g., `redis`)                                             |
+| `REDIS_HOST`                         | Redis host for Celery                                                             |
+| `REDIS_PORT`                         | Redis port for Celery                                                             |
+| `REDIS_DB`                           | Redis database index for Celery                                                   |
+| `RABBITMQ_HOST`                      | RabbitMQ host for Celery                                                          |
+| `RABBITMQ_PORT`                      | RabbitMQ port                                                                     |
+| `RABBITMQ_USER`                      | RabbitMQ username                                                                 |
+| `RABBITMQ_PASSWORD`                  | RabbitMQ password                                                                 |
+| `INSTAGRAM_TOKEN`                    | Instagram Graph API token                                                         |
+| `INSTAGRAM_USER_ID`                  | Instagram user id to fetch posts from                                             |
+| `INSTAGRAM_FETCH_LIMIT`              | Number of Instagram posts to retrieve                                             |
+| `REDDIT_USER_AGENT`                  | User agent string for Reddit API                                                  |
+| `REDDIT_FETCH_LIMIT`                 | Number of Reddit posts to retrieve                                                |
+| `YOUTUBE_API_KEY`                    | YouTube Data API key                                                              |
+| `YOUTUBE_FETCH_LIMIT`                | Number of YouTube videos to retrieve                                              |
+| `TIKTOK_VIDEO_URLS`                  | Comma separated list of TikTok video URLs                                         |
+| `TIKTOK_FETCH_LIMIT`                 | Number of TikTok videos to retrieve                                               |
+| `NOSTALGIA_QUERY`                    | Search query for Nostalgia data                                                   |
+| `NOSTALGIA_FETCH_LIMIT`              | Number of Nostalgia items to retrieve                                             |
+| `EVENTS_COUNTRY_CODE`                | Event API country code                                                            |
+| `EVENTS_FETCH_LIMIT`                 | Number of events to retrieve                                                      |

--- a/docs/daily_summary.md
+++ b/docs/daily_summary.md
@@ -6,8 +6,8 @@
 - **mockup_success_rate** – ratio of generated mockups to ideas
 - **marketplace_stats** – count of successful listings per marketplace
 
-``generate_daily_summary`` accepts an optional ``session_provider`` parameter for
-tests. By default it uses ``backend.shared.db.session_scope``.
+`generate_daily_summary` accepts an optional `session_provider` parameter for
+tests. By default it uses `backend.shared.db.session_scope`.
 
 Run the script manually or schedule it via cron:
 
@@ -16,8 +16,8 @@ Run the script manually or schedule it via cron:
 ```
 
 The script writes the summary to the path defined by the
-``DAILY_SUMMARY_FILE`` environment variable which defaults to
-``daily_summary.json``:
+`DAILY_SUMMARY_FILE` environment variable which defaults to
+`daily_summary.json`:
 
 ```bash
 DAILY_SUMMARY_FILE=/var/reports/summary.json ./scripts/daily_summary.py

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,9 +4,9 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
 
 ## Prerequisites
 
-* Docker Engine with the Buildx plugin installed
-* QEMU emulation binaries for cross-platform builds
-* `docker buildx` configured as the default builder
+- Docker Engine with the Buildx plugin installed
+- QEMU emulation binaries for cross-platform builds
+- `docker buildx` configured as the default builder
 
 ## Docker Compose
 
@@ -16,11 +16,13 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
    ```bash
    docker-compose up -d
    ```
+
 3. Register schemas once all containers are healthy:
 
    ```bash
    python scripts/register_schemas.py
    ```
+
 4. Initialize the object storage bucket used by the services:
 
    ```bash
@@ -36,6 +38,7 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
    ```bash
    kubectl apply -k infrastructure/k8s/base
    ```
+
 2. Provide environment variables via ConfigMaps and mount sensitive values using Kubernetes Secrets. The applications automatically load secrets from `/run/secrets`. A starting template is available at `infrastructure/k8s/examples/secrets.yaml`.
 
    Create the secret using Helm:
@@ -44,6 +47,7 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
    helm upgrade --install shared-secret infrastructure/k8s/examples \
      -f infrastructure/k8s/examples/secrets.yaml
    ```
+
 3. Configure ingress and TLS termination for external access. An ingress controller such as NGINX is recommended.
 4. Deploy individual services using the Helm charts in `infrastructure/helm`. Each chart exposes
    values for the container image tag, environment variables and optional horizontal pod
@@ -73,16 +77,16 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
      -f infrastructure/helm/monitoring/values.yaml
    ```
 
-  Production deployments use the corresponding `values-production.yaml` files under
-  each chart directory.
+Production deployments use the corresponding `values-production.yaml` files under
+each chart directory.
 
-   Charts define default liveness and readiness probes and mount the secret
-   referenced via `secretName` at `/run/secrets`. Resource requests, limits and
-   autoscaling parameters can be tweaked in the values files.
+Charts define default liveness and readiness probes and mount the secret
+referenced via `secretName` at `/run/secrets`. Resource requests, limits and
+autoscaling parameters can be tweaked in the values files.
 
-   The `ai-mockup-generation` chart uses the `gpu_queue_length` metric to scale GPU
-   workers. Set `hpa.enabled` to `true` and configure `hpa.gpuQueueAverageValue` in
-   `values.yaml` to enable automatic scaling based on pending tasks.
+The `ai-mockup-generation` chart uses the `gpu_queue_length` metric to scale GPU
+workers. Set `hpa.enabled` to `true` and configure `hpa.gpuQueueAverageValue` in
+`values.yaml` to enable automatic scaling based on pending tasks.
 
 5. Schedule GPU workloads by assigning the `gpu` node pool using a `nodeSelector` and
    `tolerations`. Enable GPU limits in the chart values:
@@ -125,6 +129,7 @@ section of the project blueprint for recommendations on multi-cloud deployments.
    docker tag desainz:latest <account>.dkr.ecr.<region>.amazonaws.com/desainz:latest
    docker push <account>.dkr.ecr.<region>.amazonaws.com/desainz:latest
    ```
+
 2. Deploy using ECS or EKS. Mount secrets from AWS Secrets Manager as environment variables or files.
 
 ### GCP
@@ -136,6 +141,7 @@ section of the project blueprint for recommendations on multi-cloud deployments.
    ./scripts/build-images.sh
    docker push gcr.io/<project>/desainz
    ```
+
 2. Deploy to Cloud Run or GKE. Use GCP Secret Manager to supply sensitive values.
 
 ### Azure
@@ -149,6 +155,7 @@ section of the project blueprint for recommendations on multi-cloud deployments.
    docker tag desainz:latest desainz.azurecr.io/desainz:latest
    docker push desainz.azurecr.io/desainz:latest
    ```
+
 2. Run containers in Azure Container Instances or AKS. Mount secrets from Azure Key Vault using CSI drivers.
 
 All deployments share the same environment variables. Ensure that values for credentials, API keys and connection strings are stored securely using the secret management solution of your platform.
@@ -183,7 +190,7 @@ update the service selector and scale down the newer deployment:
 The `deploy.sh` script can also orchestrate a gradual rollout. It scales the new
 deployment up one replica at a time while scaling the old deployment down. The
 service selector is temporarily widened to include both colors so traffic is
-split between them. After each step ``scripts/check_k8s_health.sh`` verifies that
+split between them. After each step `scripts/check_k8s_health.sh` verifies that
 the service is healthy. If any check fails, the script restores the previous
 state and exits with a non-zero status.
 

--- a/docs/error_triage.md
+++ b/docs/error_triage.md
@@ -9,4 +9,3 @@ Unhandled exceptions from backend services are sent to Sentry when `SENTRY_DSN` 
 5. Resolve or ignore the issue once it has been addressed.
 
 For local testing you can export `SENTRY_DSN` and run any service; captured errors will appear in your project shortly after triggering them.
-

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -7,7 +7,7 @@ Experimental features are toggled using [LaunchDarkly](https://launchdarkly.com/
 1. Provide a `LAUNCHDARKLY_SDK_KEY` to fetch flags from LaunchDarkly.
 2. Set `FEATURE_FLAGS` to a JSON mapping of flag names to booleans for simple environment-based toggles.
 3. Set `FEATURE_FLAGS_REDIS_URL` to read and write overrides from Redis, ensuring values persist across restarts.
-4. Results are cached for ``FEATURE_FLAGS_CACHE_TTL`` seconds (default ``30``).
+4. Results are cached for `FEATURE_FLAGS_CACHE_TTL` seconds (default `30`).
 
 ## Disabling a flag
 
@@ -23,12 +23,12 @@ API and gated UI links.
 ## API Management
 
 Feature flags can be managed through the API Gateway. The following endpoints
-require an authenticated user with the ``admin`` role:
+require an authenticated user with the `admin` role:
 
-* ``GET /feature-flags`` - list all known flags and their current values.
-* ``POST /feature-flags/{name}`` - set the provided flag to the ``enabled``
+- `GET /feature-flags` - list all known flags and their current values.
+- `POST /feature-flags/{name}` - set the provided flag to the `enabled`
   state in the request body.
 
 The admin dashboard provides a simple interface built from the components in
-``frontend/admin-dashboard/src/components/FeatureFlags`` which consume these
+`frontend/admin-dashboard/src/components/FeatureFlags` which consume these
 endpoints.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -22,39 +22,39 @@ Kubernetes manifests under `infrastructure/k8s/`.
 
 ### Database
 
-- **PostgreSQL 15 with pgvector** – see the ``postgres`` service in
+- **PostgreSQL 15 with pgvector** – see the `postgres` service in
   [`../docker-compose.yml`](../docker-compose.yml). Connection details are
   templated in [`../infrastructure/k8s/base/configmap.yaml`](../infrastructure/k8s/base/configmap.yaml).
-- **Redis** for caching and as a Celery broker – defined as ``redis`` in the
+- **Redis** for caching and as a Celery broker – defined as `redis` in the
   compose files.
-- **MinIO** object storage – provided by the ``minio`` service.
+- **MinIO** object storage – provided by the `minio` service.
 
 ### Message Broker
 
-- **Kafka** with **Zookeeper** and **Schema Registry** – see the ``kafka``,
-  ``zookeeper`` and ``schema-registry`` services in `docker-compose.yml`. The
+- **Kafka** with **Zookeeper** and **Schema Registry** – see the `kafka`,
+  `zookeeper` and `schema-registry` services in `docker-compose.yml`. The
   manifests in `infrastructure/k8s/base/` reference the external broker via
   environment variables.
 
 ### AI Components
 
 - **OpenAI GPT‑4** and **Stable Diffusion XL** – used by the
-  ``mockup-generation`` service defined in [`../docker-compose.yml`](../docker-compose.yml)
+  `mockup-generation` service defined in [`../docker-compose.yml`](../docker-compose.yml)
   and [`../infrastructure/k8s/base/ai-mockup-generation-deployment.yaml`](../infrastructure/k8s/base/ai-mockup-generation-deployment.yaml).
-- **Scoring Engine** – container named ``scoring-engine`` in the compose file
+- **Scoring Engine** – container named `scoring-engine` in the compose file
   with a matching deployment manifest.
 
 ### CI/CD
 
- - **GitHub Actions** – workflows under `../.github/workflows` run linting,
-   testing and deployment.
+- **GitHub Actions** – workflows under `../.github/workflows` run linting,
+  testing and deployment.
 - **Helm** and **Kustomize** – `pipeline.yml` deploys the manifests from
   `infrastructure/k8s/` using Helm.
 
 ### Monitoring
 
-- **Prometheus**, **Grafana** and **Loki** – available through the ``prometheus``,
-  ``grafana`` and ``loki`` services in [`../docker-compose.yml`](../docker-compose.yml)
+- **Prometheus**, **Grafana** and **Loki** – available through the `prometheus`,
+  `grafana` and `loki` services in [`../docker-compose.yml`](../docker-compose.yml)
   and corresponding manifests in `infrastructure/k8s/base/`.
-- **OpenTelemetry Collector** – the ``otel-collector`` service in
+- **OpenTelemetry Collector** – the `otel-collector` service in
   [`../docker-compose.tracing.yml`](../docker-compose.tracing.yml) aggregates traces from all services.

--- a/docs/logs_with_loki.md
+++ b/docs/logs_with_loki.md
@@ -1,21 +1,21 @@
 # Log Aggregation with Loki
 
 The monitoring service and all backend applications can send structured log
-messages to a Loki instance. Set the ``LOKI_URL`` environment variable to the
-Loki HTTP endpoint (e.g. ``http://loki:3100``) and each service will push JSON
-logs containing ``correlation_id`` and ``user`` fields. Docker Compose and the
-Kubernetes base manifests include a Loki service listening on port ``3100``.
-The Helm chart for the monitoring service exposes a ``loki_url`` value which is
-templated into the ``LOKI_URL`` environment variable of the container. Update
-``values.yaml`` or the ``all-services`` chart to point at your own Loki instance
+messages to a Loki instance. Set the `LOKI_URL` environment variable to the
+Loki HTTP endpoint (e.g. `http://loki:3100`) and each service will push JSON
+logs containing `correlation_id` and `user` fields. Docker Compose and the
+Kubernetes base manifests include a Loki service listening on port `3100`.
+The Helm chart for the monitoring service exposes a `loki_url` value which is
+templated into the `LOKI_URL` environment variable of the container. Update
+`values.yaml` or the `all-services` chart to point at your own Loki instance
 if needed.
 
-An ``otel-collector`` container is available in all Docker Compose
+An `otel-collector` container is available in all Docker Compose
 configurations. Services send traces to this collector by setting the
-``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable to
-``http://otel-collector:4318``. The communication protocol can be adjusted with
-``OTEL_EXPORTER_OTLP_PROTOCOL`` which defaults to ``http/protobuf``. Both HTTP
-``4318`` and gRPC ``4317`` ports are exposed by the collector.
+`OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to
+`http://otel-collector:4318`. The communication protocol can be adjusted with
+`OTEL_EXPORTER_OTLP_PROTOCOL` which defaults to `http/protobuf`. Both HTTP
+`4318` and gRPC `4317` ports are exposed by the collector.
 
 ## Local Testing
 

--- a/docs/marketplace_file_sizes.md
+++ b/docs/marketplace_file_sizes.md
@@ -2,9 +2,8 @@
 
 The following table lists recommended maximum file sizes for mockup uploads. These values mirror the validation rules configured in `backend/marketplace-publisher`.
 
-| Marketplace | Recommended Max File Size |
-|-------------|--------------------------|
-| Redbubble   | 10 MB |
-| Amazon Merch| 25 MB |
-| Etsy        | 20 MB |
-
+| Marketplace  | Recommended Max File Size |
+| ------------ | ------------------------- |
+| Redbubble    | 10 MB                     |
+| Amazon Merch | 25 MB                     |
+| Etsy         | 20 MB                     |

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -39,7 +39,7 @@ Commit the resulting merge file so that the migration chain has a single head.
 
 ## Generating a Merge Revision
 
-Use the ``heads`` command to inspect whether multiple heads exist:
+Use the `heads` command to inspect whether multiple heads exist:
 
 ```bash
 alembic -c backend/shared/db/alembic_scoring_engine.ini heads
@@ -53,9 +53,9 @@ alembic -c backend/shared/db/alembic_scoring_engine.ini merge \
   -m "merge heads" HEADS
 ```
 
-The new revision should live in ``backend/shared/db/migrations`` and replace
-``example_merge_revision.py``. After committing the merge file, run
-``scripts/validate_migrations.sh`` to confirm that only a single head exists
+The new revision should live in `backend/shared/db/migrations` and replace
+`example_merge_revision.py`. After committing the merge file, run
+`scripts/validate_migrations.sh` to confirm that only a single head exists
 and that no divergent branches remain.
 
 ## Verifying Migrations
@@ -69,7 +69,6 @@ pytest tests/test_migrations.py
 
 ## Automatic Migrations
 
-Every FastAPI service runs ``alembic upgrade head`` on startup to apply any
+Every FastAPI service runs `alembic upgrade head` on startup to apply any
 pending migrations before initializing resources. Set the environment variable
-``SKIP_MIGRATIONS=1`` to bypass this step during tests.
-
+`SKIP_MIGRATIONS=1` to bypass this step during tests.

--- a/docs/mockup_generation.md
+++ b/docs/mockup_generation.md
@@ -4,7 +4,7 @@ The mockup generation service runs inside CUDA-enabled containers. Each
 Celery worker is pinned to a specific GPU using the `GPU_WORKER_INDEX`
 environment variable. Workers listen on dedicated queues `gpu-<index>`
 so Kubernetes can scale them independently. Tasks can target a specific
-GPU by passing ``gpu_index`` to the ``/generate`` endpoint, which will
+GPU by passing `gpu_index` to the `/generate` endpoint, which will
 route them to the corresponding queue.
 
 ```bash
@@ -26,4 +26,4 @@ An example HPA manifest lives in `infrastructure/k8s/examples/gpu-worker-hpa.yam
 and scales the `mockup-generation` deployment according to queue length.
 
 The metadata generation service uses OpenAI's GPT‑4 model by default. The
-model can be changed by setting the ``OPENAI_MODEL`` environment variable.
+model can be changed by setting the `OPENAI_MODEL` environment variable.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -24,8 +24,8 @@ services:
   otel-collector:
     image: otel/opentelemetry-collector:latest
     ports:
-      - "4317:4317"
-      - "4318:4318"
+      - '4317:4317'
+      - '4318:4318'
 ```
 
 Run:
@@ -55,31 +55,31 @@ Dashboards include:
 Prometheus is configured through `docker/prometheus/prometheus.yml`. Each service exposes metrics on `/metrics` and the file defines one scrape job per service:
 
 ```yaml
-    scrape_configs:
-      - job_name: 'monitoring'
-        static_configs:
-          - targets: ['monitoring:8000']
-      - job_name: 'api-gateway'
-        static_configs:
-          - targets: ['api-gateway:8000']
-      - job_name: 'mockup-generation'
-        static_configs:
-          - targets: ['mockup-generation:8000']
-      - job_name: 'scoring-engine'
-        static_configs:
-          - targets: ['scoring-engine:5002']
-      - job_name: 'marketplace-publisher'
-        static_configs:
-          - targets: ['marketplace-publisher:8000']
-      - job_name: 'signal-ingestion'
-        static_configs:
-          - targets: ['signal-ingestion:8000']
-      - job_name: 'feedback-loop'
-        static_configs:
-          - targets: ['feedback-loop:8000']
-      - job_name: 'orchestrator'
-        static_configs:
-          - targets: ['orchestrator:3000']
+scrape_configs:
+  - job_name: 'monitoring'
+    static_configs:
+      - targets: ['monitoring:8000']
+  - job_name: 'api-gateway'
+    static_configs:
+      - targets: ['api-gateway:8000']
+  - job_name: 'mockup-generation'
+    static_configs:
+      - targets: ['mockup-generation:8000']
+  - job_name: 'scoring-engine'
+    static_configs:
+      - targets: ['scoring-engine:5002']
+  - job_name: 'marketplace-publisher'
+    static_configs:
+      - targets: ['marketplace-publisher:8000']
+  - job_name: 'signal-ingestion'
+    static_configs:
+      - targets: ['signal-ingestion:8000']
+  - job_name: 'feedback-loop'
+    static_configs:
+      - targets: ['feedback-loop:8000']
+  - job_name: 'orchestrator'
+    static_configs:
+      - targets: ['orchestrator:3000']
 ```
 
 ## PagerDuty Alerts

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -8,7 +8,6 @@ Application logs are written to the directory defined by the `LOG_DIR` environme
 
 A cron job executes `scripts/rotate_logs.py` daily at 01:00. The job moves log files into `LOG_DIR/archive` with a timestamp suffix and removes archives older than seven days. The cronjob definition can be found in `infrastructure/k8s/base/cronjobs/logrotate.yaml` and the Docker image used is built from `docker/logrotate`.
 
-
 ## Moderator Workflow
 
 Moderators approve content generation runs from the Admin Dashboard.
@@ -39,8 +38,8 @@ python scripts/manage_spot_instances.py release i-0abcd1234ef567890
 ```
 
 Workers will checkpoint tasks using Celery's statedb so another node can resume
-processing when a spot instance is reclaimed. To keep ``N`` workers running at
-all times execute the ``maintain`` command, which is scheduled every ten
+processing when a spot instance is reclaimed. To keep `N` workers running at
+all times execute the `maintain` command, which is scheduled every ten
 minutes by the orchestrator:
 
 ```bash
@@ -55,15 +54,15 @@ python scripts/manage_spot_instances.py maintain \
 
 ## Quota Handling
 
-The signal ingestion service caches HTTP ``ETag`` headers in Redis. When a
+The signal ingestion service caches HTTP `ETag` headers in Redis. When a
 resource has not changed, the adapter sends the cached value using the
-``If-None-Match`` header and skips further processing when receiving a
-``304 Not Modified`` response. This reduces bandwidth usage and helps stay
+`If-None-Match` header and skips further processing when receiving a
+`304 Not Modified` response. This reduces bandwidth usage and helps stay
 within third-party API quotas.
 
 ## Command Line Interface
 
-``scripts/cli.py`` exposes operational helpers using subcommands.
+`scripts/cli.py` exposes operational helpers using subcommands.
 
 ### Ingest
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -9,13 +9,14 @@ Recent profiling efforts added a lightweight middleware which logs request durat
 During analysis the `analytics` service showed slow responses when aggregating metrics. SQL queries were updated to use database-side aggregation via `SUM` instead of loading entire tables into memory.
 
 ## Next Steps
+
 - Monitor logs for high latency endpoints
 - Investigate database indexes for frequently queried columns
 
 ## Scoring Engine Caching
 
-The ``/score`` endpoint now uses Redis with configurable expiration.
-Running ``scripts/benchmark_score.py`` against a local instance showed the
+The `/score` endpoint now uses Redis with configurable expiration.
+Running `scripts/benchmark_score.py` against a local instance showed the
 following times for 100 requests:
 
 ```
@@ -35,21 +36,22 @@ these benchmarks over time, allowing quick detection of regressions.
 
 ## Capturing Profiling Data
 
-Use ``scripts/capture_profile.py`` to collect CPU profiling statistics for any
-Python module. The command saves data in ``cProfile`` format and prints the
+Use `scripts/capture_profile.py` to collect CPU profiling statistics for any
+Python module. The command saves data in `cProfile` format and prints the
 top 20 functions by cumulative time.
 
 ```bash
 python scripts/capture_profile.py backend.app.main --output run.prof
 ```
-The output file can be visualized with tools like ``snakeviz`` for deeper
+
+The output file can be visualized with tools like `snakeviz` for deeper
 analysis.
 
 ## tRPC Response Caching
 
-The API Gateway now attaches ``ETag`` headers to tRPC responses. When a client
-sends ``If-None-Match`` with a previously returned value, the gateway responds
-with ``304 Not Modified`` and an empty body. This avoids transferring identical
+The API Gateway now attaches `ETag` headers to tRPC responses. When a client
+sends `If-None-Match` with a previously returned value, the gateway responds
+with `304 Not Modified` and an empty body. This avoids transferring identical
 payloads and improves perceived latency when data has not changed.
 
 ## Scaling Strategy
@@ -57,7 +59,7 @@ payloads and improves perceived latency when data has not changed.
 Production workloads run under Kubernetes with [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).
 Each service scales between two and five replicas based on CPU and memory usage.
 The `signal-ingestion` deployment also reacts to queue pressure using a custom
-`celery_queue_length` metric.  When the average queue length exceeds 30 pending
+`celery_queue_length` metric. When the average queue length exceeds 30 pending
 tasks, additional workers are spawned automatically.
 
 ## GPU Slot Metrics
@@ -65,26 +67,26 @@ tasks, additional workers are spawned automatically.
 GPU-bound workloads now expose lock usage information through Prometheus.
 The context manager `tasks.gpu_slot` updates two metrics:
 
-- ``gpu_slots_in_use`` – a gauge tracking the number of acquired GPU locks.
-- ``gpu_slot_acquire_total`` – a counter incremented whenever a slot is obtained.
+- `gpu_slots_in_use` – a gauge tracking the number of acquired GPU locks.
+- `gpu_slot_acquire_total` – a counter incremented whenever a slot is obtained.
 
-These metrics appear alongside existing ones on the ``/metrics`` endpoint.
+These metrics appear alongside existing ones on the `/metrics` endpoint.
 
 ## Database Connection Metrics
 
 Each service now reports connection pool usage via two gauges:
 
-- ``db_pool_size`` – total size of the SQLAlchemy connection pool.
-- ``db_pool_in_use`` – currently checked out connections.
+- `db_pool_size` – total size of the SQLAlchemy connection pool.
+- `db_pool_in_use` – currently checked out connections.
 
 Monitoring these values helps detect connection leaks and tune pool sizes.
-To change the pool size, set the ``DB_POOL_SIZE`` environment variable (or
-``db_pool_size`` setting) before starting services.
+To change the pool size, set the `DB_POOL_SIZE` environment variable (or
+`db_pool_size` setting) before starting services.
 
 ## CDN Configuration
 
 Static assets are distributed through a CloudFront CDN for low latency delivery.
-The helper script ``scripts/configure_cdn.sh`` provisions a distribution with a
+The helper script `scripts/configure_cdn.sh` provisions a distribution with a
 default TTL of one hour and HTTPS enforced. Refer to the script for exact
 settings.
 
@@ -99,4 +101,4 @@ aws configure
 ```
 
 The command prints a distribution ID which is later required when running
-``scripts/invalidate_cache.sh``.
+`scripts/invalidate_cache.sh`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,4 +46,3 @@ You can stop the stack with:
 ```bash
 docker-compose down
 ```
-

--- a/docs/security.md
+++ b/docs/security.md
@@ -29,42 +29,42 @@ This project relies on environment variables for configuration.
 
 Auth0 manages the signing keys for issued tokens. Rotation of these keys is
 handled automatically by Auth0 and requires no action from the services. During
-tests or local development, a static ``SECRET_KEY`` is still used and should be
+tests or local development, a static `SECRET_KEY` is still used and should be
 rotated periodically following the usual secret rotation procedure.
 
 ### Automated rotation
 
-The ``scripts/rotate_secrets.py`` helper generates new random tokens and patches
-the corresponding Kubernetes secrets using ``kubectl``. A Dagster job executes
-this script once per month. The ``monthly_secret_rotation_schedule`` defined in
-``backend.orchestrator.orchestrator.schedules`` triggers the job on the first
+The `scripts/rotate_secrets.py` helper generates new random tokens and patches
+the corresponding Kubernetes secrets using `kubectl`. A Dagster job executes
+this script once per month. The `monthly_secret_rotation_schedule` defined in
+`backend.orchestrator.orchestrator.schedules` triggers the job on the first
 day of every month at midnight UTC. The run waits for approval via the
-``/approvals`` API before applying rotations and sends a Slack notification when
+`/approvals` API before applying rotations and sends a Slack notification when
 complete.
 
 ### S3 access key rotation
 
-``scripts/rotate_s3_keys.py`` creates new access keys for the configured IAM
+`scripts/rotate_s3_keys.py` creates new access keys for the configured IAM
 user and updates the Kubernetes secret used by the services. The Dagster
-``rotate_s3_keys_job`` runs monthly. The IAM role executing the script must have
+`rotate_s3_keys_job` runs monthly. The IAM role executing the script must have
 the following permissions:
 
-- ``iam:CreateAccessKey``
-- ``iam:ListAccessKeys``
-- ``iam:DeleteAccessKey``
+- `iam:CreateAccessKey`
+- `iam:ListAccessKeys`
+- `iam:DeleteAccessKey`
 
 ## Marketplace webhook signatures
 
-Incoming callbacks to the marketplace publisher include an ``X-Signature``
+Incoming callbacks to the marketplace publisher include an `X-Signature`
 header. The value is an HMAC SHA-256 digest of the raw request body using a
-secret unique to each marketplace. Secrets are stored under ``secrets/`` and are
-loaded by the settings module from ``/run/secrets`` in production. Requests
-without a valid signature are rejected with ``403 Forbidden``.
+secret unique to each marketplace. Secrets are stored under `secrets/` and are
+loaded by the settings module from `/run/secrets` in production. Requests
+without a valid signature are rejected with `403 Forbidden`.
 
 ## Health endpoints
 
-Each service exposes ``/health`` and ``/ready`` for liveness and readiness
-checks. ``/health`` is always public. Access to ``/ready`` can be restricted by
-setting the ``ALLOW_STATUS_UNAUTHENTICATED`` environment variable to ``false``.
-When disabled, clients must include an ``X-API-Key`` header. This allows public
+Each service exposes `/health` and `/ready` for liveness and readiness
+checks. `/health` is always public. Access to `/ready` can be restricted by
+setting the `ALLOW_STATUS_UNAUTHENTICATED` environment variable to `false`.
+When disabled, clients must include an `X-API-Key` header. This allows public
 liveness checks while keeping readiness information private.


### PR DESCRIPTION
## Summary
- allow docs Markdown in Prettier
- run Prettier on docs

## Testing
- `npx prettier "docs/**/*.md" -w`
- `make lint` *(fails: mypy errors)*
- `pytest -n auto -W error -vv` *(fails: ModuleNotFoundError: ldclient.config)*

------
https://chatgpt.com/codex/tasks/task_b_687fe3a7c248833198c5d2fd75fe8136