### PR TITLE
Add docformatter check during Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,14 @@ if TYPE_CHECKING:  # pragma: no cover
 def _run_linters(app: "Sphinx") -> None:
     """Run docformatter and flake8-docstrings before building docs."""
     docs_dir = os.path.dirname(os.path.abspath(__file__))
-    subprocess.check_call(["docformatter", "--in-place", "--recursive", docs_dir])
+    result = subprocess.run(
+        ["docformatter", "--check", "--recursive", docs_dir],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(result.stdout)
+        raise RuntimeError("docformatter found issues. Run docformatter")
     subprocess.check_call(["flake8", "--select=D", docs_dir])
 
 


### PR DESCRIPTION
## Summary
- fail the docs build if `docformatter` detects problems

## Testing
- `bash scripts/setup_codex.sh` *(fails: build finished with problems)*
- `pytest scripts/tests/test_cli.py -q` *(fails: ModuleNotFoundError for ldclient.config)*

------
https://chatgpt.com/codex/tasks/task_b_687fe3a8a73c8331aa486388c9845887