### PR TITLE
Add Next.js profiling build

### DIFF
--- a/frontend/admin-dashboard/README.md
+++ b/frontend/admin-dashboard/README.md
@@ -10,6 +10,14 @@ npm run dev
 npm run flow
 ```
 
+## Analyzing the Bundle Size
+
+Profile the production build and open the bundle analyzer report:
+
+```bash
+npm run analyze
+```
+
 ## Environment Variables
 
 The dashboard reads the following variables at build time:

--- a/frontend/admin-dashboard/__tests__/featureFlags.test.tsx
+++ b/frontend/admin-dashboard/__tests__/featureFlags.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { FeatureFlagsList } from '../src/components/FeatureFlags/FeatureFlagsList';
 
 beforeEach(() => {
-  // eslint-disable-next-line no-undef
   global.fetch = jest.fn((url: RequestInfo, init?: RequestInit) => {
     if (typeof url === 'string' && url.endsWith('/feature-flags')) {
       if (!init || !init.method || init.method === 'GET') {

--- a/frontend/admin-dashboard/__tests__/useLiveMetrics.test.tsx
+++ b/frontend/admin-dashboard/__tests__/useLiveMetrics.test.tsx
@@ -53,6 +53,7 @@ describe('useLiveMetrics', () => {
       return wsInstance as unknown as WebSocket;
     });
     process.env.NEXT_PUBLIC_WS_MAX_RETRIES = '2';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { useLiveMetrics } = require('../src/hooks/useLiveMetrics');
     TestComponent = function TestComponent() {
       const metrics = useLiveMetrics();

--- a/frontend/admin-dashboard/jest.setup.ts
+++ b/frontend/admin-dashboard/jest.setup.ts
@@ -65,10 +65,10 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  if (typeof (console.error as any).mockRestore === 'function') {
+  if (typeof (console.error as jest.Mock).mockRestore === 'function') {
     (console.error as jest.Mock).mockRestore();
   }
-  if (typeof (console.warn as any).mockRestore === 'function') {
+  if (typeof (console.warn as jest.Mock).mockRestore === 'function') {
     (console.warn as jest.Mock).mockRestore();
   }
 });

--- a/frontend/admin-dashboard/package.json
+++ b/frontend/admin-dashboard/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
-    "analyze": "cross-env ANALYZE=true next build",
+    "build": "next build --profile",
+    "analyze": "cross-env ANALYZE=true next build --profile",
     "start": "node scripts/monitorAndStart.js",
     "lint:eslint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "lint:css": "stylelint \"**/*.{css,scss}\" --max-warnings=0 --allow-empty-input",


### PR DESCRIPTION
## Summary
- profile Next.js builds with `--profile` flag
- document how to run the bundle analyzer
- fix ESLint warnings in dashboard tests
- tighten mocked console types

## Testing
- `npx prettier -w package.json README.md`
- `npm run lint:css`
- `npm run format:check`
- `npm run lint:eslint`
- `npm run flow`
- `npm test`
- `npm run test:e2e` *(fails: `/bin/sh: 1: docker: not found`)*
- `pytest tests/test_api.py::test_health_ready_endpoints -vv` *(fails: ModuleNotFoundError: No module named 'ldclient.config')*
- `make -C docs html` *(fails: command returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_b_687fe3a647ac8331847a84f14c447741