### PR TITLE
Fix flow config and add JS annotations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,15 @@ module.exports = {
     'standard',
     'prettier',
   ],
+  plugins: ['flowtype'],
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
+    requireConfigFile: false,
+    babelOptions: {
+      plugins: ['@babel/plugin-syntax-flow'],
+    },
   },
   settings: {
     react: {

--- a/.flowconfig
+++ b/.flowconfig
@@ -6,6 +6,7 @@
 <PROJECT_ROOT>/scripts/.*
 <PROJECT_ROOT>/load_tests/.*
 frontend/admin-dashboard/scripts/.*
+<PROJECT_ROOT>/frontend/admin-dashboard/public/sw.js
 
 [libs]
 

--- a/frontend/admin-dashboard/__mocks__/@auth0/nextjs-auth0/client.js
+++ b/frontend/admin-dashboard/__mocks__/@auth0/nextjs-auth0/client.js
@@ -1,4 +1,13 @@
+// @flow
+import * as React from 'react';
+
+export type UserProviderProps = {|
+  children: React.Node,
+|};
+
 module.exports = {
-  withPageAuthRequired: (Component) => Component,
-  UserProvider: ({ children }) => children,
+  withPageAuthRequired: <P>(
+    Component: React.ComponentType<P>
+  ): React.ComponentType<P> => Component,
+  UserProvider: ({ children }: UserProviderProps): React.Node => children,
 };

--- a/frontend/admin-dashboard/public/sw.js
+++ b/frontend/admin-dashboard/public/sw.js
@@ -1,4 +1,8 @@
-self.addEventListener('message', (event) => {
+// @flow
+
+declare var self: mixed;
+
+self.addEventListener('message', (event: MessageEvent<mixed>): void => {
   if (event.data && event.data.type === 'SKIP_WAITING') {
     self.skipWaiting();
   }

--- a/frontend/admin-dashboard/scripts/monitorAndStart.js
+++ b/frontend/admin-dashboard/scripts/monitorAndStart.js
@@ -7,13 +7,16 @@
  */
 import { spawn } from 'child_process';
 
+// Type annotation for the spawned Next.js process
+/** @type {import('child_process').ChildProcess} */
 const next = spawn(
   'node',
   ['--max-old-space-size=2048', './node_modules/.bin/next', 'start'],
   { stdio: 'inherit' }
 );
 
-setInterval(() => {
+setInterval((): void => {
+  /** @type {NodeJS.MemoryUsage} */
   const usage = process.memoryUsage();
   console.log(`Memory Usage - RSS: ${usage.rss}, Heap Used: ${usage.heapUsed}`);
 }, 60000);

--- a/scripts/exit_on_warnings.js
+++ b/scripts/exit_on_warnings.js
@@ -1,6 +1,14 @@
-// Exit process with non-zero code if any warning is emitted
-process.on('warning', (warning) => {
-  console.error(warning.stack || warning);
+// @flow
+
+/**
+ * Exit the process with a non-zero code if any warning is emitted.
+ *
+ * @param {Error | string} warning - The warning object or message.
+ */
+process.on('warning', (warning: Error | string): void => {
+  console.error(
+    typeof warning === 'string' ? warning : warning.stack || String(warning)
+  );
   if (process.exitCode === undefined) {
     process.exitCode = 1;
   }


### PR DESCRIPTION
## Summary
- add `flowtype` linting support through `@babel/eslint-parser`
- ignore service worker for Flow
- annotate script and mocks with Flow types
- add type comments to monitor script and warning handler

## Testing
- `npx eslint scripts/exit_on_warnings.js frontend/admin-dashboard/scripts/monitorAndStart.js frontend/admin-dashboard/__mocks__/@auth0/nextjs-auth0/client.js frontend/admin-dashboard/public/sw.js .eslintrc.js --max-warnings=0`
- `npx --yes flow-bin@0.276.0 status`
- `pytest -k "nonexistent" -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687fe3a6cf6483318a06a4b8d051cda4