### PR TITLE
Enable HTTP2 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 ./scripts/setup_codex.sh
 ```
 
+## Environment
+
+The project targets **Python 3.11** and **Node.js 20**. Ensure these versions
+are available before installing dependencies or running any commands.
+
 ## Installing dependencies
 
 Install Python and Node requirements before running tests or building the

--- a/frontend/admin-dashboard/package.json
+++ b/frontend/admin-dashboard/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "analyze": "cross-env ANALYZE=true next build",
-    "start": "node scripts/monitorAndStart.js",
+    "start": "node server.js",
     "lint:eslint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "lint:css": "stylelint \"**/*.{css,scss}\" --max-warnings=0 --allow-empty-input",
     "format": "prettier \"**/*.{js,jsx,ts,tsx,css,scss,md}\" --write",

--- a/frontend/admin-dashboard/server.js
+++ b/frontend/admin-dashboard/server.js
@@ -1,0 +1,58 @@
+// @flow
+/**
+ * Custom production server using Node's HTTP/2 module.
+ *
+ * This server starts Next.js with HTTP/2 support and logs memory usage
+ * every minute.
+ */
+
+import { createServer, createSecureServer, type Http2Server } from 'http2';
+import fs from 'fs';
+import { parse } from 'url';
+import next from 'next';
+
+const port: number = parseInt(process.env.PORT ?? '3000', 10);
+const dev: boolean = process.env.NODE_ENV !== 'production';
+
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+type Options = {
+  allowHTTP1: boolean,
+  key?: Buffer,
+  cert?: Buffer,
+};
+
+function buildOptions(): Options {
+  const options: Options = { allowHTTP1: true };
+  if (process.env.HTTPS_KEY_PATH && process.env.HTTPS_CERT_PATH) {
+    options.key = fs.readFileSync(process.env.HTTPS_KEY_PATH);
+    options.cert = fs.readFileSync(process.env.HTTPS_CERT_PATH);
+  }
+  return options;
+}
+
+app.prepare().then(() => {
+  const options = buildOptions();
+  const server: Http2Server =
+    options.key && options.cert
+      ? createSecureServer(options, (req, res) => {
+          const parsedUrl = parse(req.url ?? '', true);
+          handle(req, res, parsedUrl);
+        })
+      : createServer(options, (req, res) => {
+          const parsedUrl = parse(req.url ?? '', true);
+          handle(req, res, parsedUrl);
+        });
+
+  setInterval(() => {
+    const usage = process.memoryUsage();
+    // eslint-disable-next-line no-console
+    console.log(`Memory Usage - RSS: ${usage.rss}, Heap Used: ${usage.heapUsed}`);
+  }, 60000);
+
+  server.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`> Ready on ${options.key ? 'https' : 'http'}://localhost:${port}`);
+  });
+});


### PR DESCRIPTION
## Summary
- switch dashboard start script to custom HTTP/2 server
- document Python and Node requirements

## Testing
- `pytest -k ""` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pre-commit run --files README.md frontend/admin-dashboard/package.json frontend/admin-dashboard/server.js` *(fails: prompts for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_b_687fe39f8f008331b6c632ca21af0fab