### PR TITLE
Fix eslint rules and update usages

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -61,9 +61,13 @@ sys.modules.setdefault(
     SimpleNamespace(set_tracer_provider=lambda *a, **k: None),
 )
 
-# Stub LaunchDarkly client to avoid heavy dependency.
+# Stub LaunchDarkly client to avoid heavy dependency when not installed.
 ld_mod = sys.modules.setdefault("ldclient", ModuleType("ldclient"))
 ld_mod.LDClient = object
+sys.modules.setdefault("ldclient.config", ModuleType("ldclient.config"))
+sys.modules["ldclient.config"].Config = object
+sys.modules.setdefault("ldclient.context", ModuleType("ldclient.context"))
+sys.modules["ldclient.context"].Context = object
 
 os.makedirs("/run/secrets", exist_ok=True)
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -9,5 +9,11 @@ const compat = new FlatCompat({
 
 module.exports = [
   ...compat.config(eslintrc),
+  {
+    rules: {
+      'no-console': 'error',
+      'no-var': 'error',
+    },
+  },
   { ignores: ['flow-typed/**', 'load_tests/**'] },
 ];

--- a/frontend/admin-dashboard/__tests__/layout.test.tsx
+++ b/frontend/admin-dashboard/__tests__/layout.test.tsx
@@ -3,6 +3,8 @@ import Router from 'next-router-mock';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import RootLayout from '../app/layout';
 
+/* eslint-disable no-console */
+
 test('renders children inside layout', () => {
   const originalError = console.error;
   console.error = jest.fn();

--- a/frontend/admin-dashboard/jest.setup.ts
+++ b/frontend/admin-dashboard/jest.setup.ts
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom';
 
+/* eslint-disable no-console */
+
 // Mock i18n translation hook used in dashboard pages
 jest.mock(
   'react-i18next',

--- a/frontend/admin-dashboard/scripts/monitorAndStart.js
+++ b/frontend/admin-dashboard/scripts/monitorAndStart.js
@@ -7,6 +7,8 @@
  */
 import { spawn } from 'child_process';
 
+/* eslint-disable no-console */
+
 const next = spawn(
   'node',
   ['--max-old-space-size=2048', './node_modules/.bin/next', 'start'],

--- a/frontend/admin-dashboard/src/trpc.ts
+++ b/frontend/admin-dashboard/src/trpc.ts
@@ -175,7 +175,6 @@ export const trpc = {
   },
 };
 
-export async function pingExample(): Promise<void> {
-  const result = await trpc.ping.mutate();
-  console.log(result.message, result.user);
+export async function pingExample(): Promise<{ message: string; user: string }> {
+  return trpc.ping.mutate();
 }

--- a/scripts/exit_on_warnings.js
+++ b/scripts/exit_on_warnings.js
@@ -1,4 +1,5 @@
 // Exit process with non-zero code if any warning is emitted
+/* eslint-disable no-console */
 process.on('warning', (warning) => {
   console.error(warning.stack || warning);
   if (process.exitCode === undefined) {

--- a/src/trpc.ts
+++ b/src/trpc.ts
@@ -124,7 +124,6 @@ export const trpc = {
   },
 };
 
-export async function pingExample(): Promise<void> {
-  const result = await trpc.ping.mutate();
-  console.log(result.message, result.user);
+export async function pingExample(): Promise<{ message: string; user: string }> {
+  return trpc.ping.mutate();
 }


### PR DESCRIPTION
## Summary
- enforce no-console and no-var via eslint flat config
- silence allowed console usage in tests and scripts
- adjust example ping functions to return result
- stub LaunchDarkly modules in tests

## Testing
- `npm run lint:eslint`
- `npm test --prefix frontend/admin-dashboard`
- `flake8 .`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails)*
- `pydocstyle .` *(fails)*
- `docformatter --check --recursive .` *(fails)*


------
https://chatgpt.com/codex/tasks/task_b_687fe39cc3908331a286dc630e62049d