### PR TITLE
Use HTTP/2 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 ./scripts/setup_codex.sh
 ```
 
+## Environment requirements
+
+Make sure the following tools are available before setting up the project:
+
+- **Python 3.11**
+- **Node.js 20**
+- **Docker** and **Docker Compose** supporting schema version 3.8
+
+These versions match the containers used in `docker-compose.prod.yml` and the
+development tooling. Newer versions may also work but are not tested.
+
 ## Installing dependencies
 
 Install Python and Node requirements before running tests or building the

--- a/frontend/admin-dashboard/scripts/monitorAndStart.js
+++ b/frontend/admin-dashboard/scripts/monitorAndStart.js
@@ -2,7 +2,7 @@
 /**
  * Start the Next.js server with memory monitoring.
  *
- * This script runs "next start" with a maximum heap size and logs
+ * This script runs the custom HTTP/2 server with a maximum heap size and logs
  * memory usage every minute.
  */
 import { spawn } from 'child_process';
@@ -11,7 +11,7 @@ import { spawn } from 'child_process';
 /** @type {import('child_process').ChildProcess} */
 const next = spawn(
   'node',
-  ['--max-old-space-size=2048', './node_modules/.bin/next', 'start'],
+  ['--max-old-space-size=2048', './server.js'],
   { stdio: 'inherit' }
 );
 

--- a/frontend/admin-dashboard/server.js
+++ b/frontend/admin-dashboard/server.js
@@ -1,0 +1,18 @@
+import { createServer } from 'http2';
+import { parse } from 'url';
+import next from 'next';
+
+const port = parseInt(process.env.PORT || '3000', 10);
+const app = next({ dev: false });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+  const server = createServer({ allowHTTP1: true }, (req, res) => {
+    const parsedUrl = parse(req.url || '', true);
+    handle(req, res, parsedUrl);
+  });
+
+  server.listen(port, () => {
+    console.log(`> Ready on http://localhost:${port} (HTTP/2)`);
+  });
+});


### PR DESCRIPTION
## Summary
- launch a custom HTTP/2 server for Next.js
- monitor memory usage of the new server
- document required Python/Node/Docker versions

## Testing
- `python -m pip install -r requirements.txt -r requirements-dev.txt`
- `npm ci --legacy-peer-deps`
- `make lint` *(fails: mypy errors)*
- `make test` *(fails: docker not found)*
- `npm run lint` *(fails: missing eslint parser)*

------
https://chatgpt.com/codex/tasks/task_b_687fe6cf3054833182aca677175120f5