### PR TITLE
Enforce console and var rules

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -9,5 +9,11 @@ const compat = new FlatCompat({
 
 module.exports = [
   ...compat.config(eslintrc),
+  {
+    rules: {
+      'no-console': 'error',
+      'no-var': 'error',
+    },
+  },
   { ignores: ['flow-typed/**', 'load_tests/**'] },
 ];

--- a/frontend/admin-dashboard/__tests__/layout.test.tsx
+++ b/frontend/admin-dashboard/__tests__/layout.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { render, screen } from '@testing-library/react';
 import Router from 'next-router-mock';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';

--- a/frontend/admin-dashboard/jest.setup.ts
+++ b/frontend/admin-dashboard/jest.setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import '@testing-library/jest-dom';
 
 // Mock i18n translation hook used in dashboard pages

--- a/frontend/admin-dashboard/public/sw.js
+++ b/frontend/admin-dashboard/public/sw.js
@@ -1,5 +1,7 @@
 // @flow
 
+/* eslint-disable no-var */
+
 declare var self: mixed;
 
 self.addEventListener('message', (event: MessageEvent<mixed>): void => {

--- a/frontend/admin-dashboard/scripts/monitorAndStart.js
+++ b/frontend/admin-dashboard/scripts/monitorAndStart.js
@@ -18,7 +18,9 @@ const next = spawn(
 setInterval((): void => {
   /** @type {NodeJS.MemoryUsage} */
   const usage = process.memoryUsage();
-  console.log(`Memory Usage - RSS: ${usage.rss}, Heap Used: ${usage.heapUsed}`);
+  process.stdout.write(
+    `Memory Usage - RSS: ${usage.rss}, Heap Used: ${usage.heapUsed}\n`
+  );
 }, 60000);
 
 next.on('close', (code) => process.exit(code ?? 0));

--- a/frontend/admin-dashboard/src/trpc.ts
+++ b/frontend/admin-dashboard/src/trpc.ts
@@ -177,5 +177,5 @@ export const trpc = {
 
 export async function pingExample(): Promise<void> {
   const result = await trpc.ping.mutate();
-  console.log(result.message, result.user);
+  process.stdout.write(`${result.message} ${result.user}\n`);
 }

--- a/scripts/exit_on_warnings.js
+++ b/scripts/exit_on_warnings.js
@@ -6,8 +6,10 @@
  * @param {Error | string} warning - The warning object or message.
  */
 process.on('warning', (warning: Error | string): void => {
-  console.error(
-    typeof warning === 'string' ? warning : warning.stack || String(warning)
+  process.stderr.write(
+    `${
+      typeof warning === 'string' ? warning : warning.stack || String(warning)
+    }\n`
   );
   if (process.exitCode === undefined) {
     process.exitCode = 1;

--- a/src/trpc.ts
+++ b/src/trpc.ts
@@ -126,5 +126,5 @@ export const trpc = {
 
 export async function pingExample(): Promise<void> {
   const result = await trpc.ping.mutate();
-  console.log(result.message, result.user);
+  process.stdout.write(`${result.message} ${result.user}\n`);
 }


### PR DESCRIPTION
## Summary
- enable `no-console` and `no-var` rules
- suppress console use in tests
- log memory usage and ping output without `console`
- replace console.error in exit script
- silence `no-var` for service worker

## Testing
- `npx prettier "**/*.{js,jsx,ts,tsx}" -w`
- `npx stylelint "**/*.{css,scss}"`
- `npx flow check`
- `npm test` *(fails: SyntaxError in exit_on_warnings.js)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687fe78a3768833185ea76ed32d25bf9