### PR TITLE
Add docstrings to frontend components

### DIFF
--- a/frontend/admin-dashboard/src/components/AbTestSummary.tsx
+++ b/frontend/admin-dashboard/src/components/AbTestSummary.tsx
@@ -2,6 +2,13 @@
 import React from 'react';
 import { useAbTestSummary } from '../lib/trpc/hooks';
 
+/**
+ * Display conversion statistics for the given A/B test.
+ *
+ * Fetches data using ``useAbTestSummary`` and shows loading state while
+ * waiting for the results.
+ */
+
 export function AbTestSummary({ abTestId }: { abTestId: number }) {
   const { data, isLoading } = useAbTestSummary(abTestId);
 

--- a/frontend/admin-dashboard/src/components/AlertStatusIndicator.tsx
+++ b/frontend/admin-dashboard/src/components/AlertStatusIndicator.tsx
@@ -2,6 +2,10 @@
 import React from 'react';
 import { useAlertStatus } from '../hooks/useMonitoringData';
 
+/**
+ * Show whether the monitoring system is currently alerting.
+ */
+
 export function AlertStatusIndicator() {
   const alert = useAlertStatus(2);
   return (

--- a/frontend/admin-dashboard/src/components/Button.tsx
+++ b/frontend/admin-dashboard/src/components/Button.tsx
@@ -1,6 +1,10 @@
 // @flow
 import React from 'react';
 
+/**
+ * Reusable button styled for the admin dashboard.
+ */
+
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**

--- a/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagToggle.tsx
+++ b/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagToggle.tsx
@@ -1,6 +1,10 @@
 // @flow
 import React from 'react';
 
+/**
+ * Checkbox for toggling a single feature flag.
+ */
+
 interface Props {
   name: string;
   enabled: boolean;

--- a/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagsList.tsx
+++ b/frontend/admin-dashboard/src/components/FeatureFlags/FeatureFlagsList.tsx
@@ -2,6 +2,10 @@
 import React, { useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../hooks/useAuthFetch';
 
+/**
+ * Manage and toggle all available feature flags.
+ */
+
 export function FeatureFlagsList() {
   const [flags, setFlags] = useState<Record<string, boolean>>({});
   useEffect(() => {

--- a/frontend/admin-dashboard/src/components/RolesList.tsx
+++ b/frontend/admin-dashboard/src/components/RolesList.tsx
@@ -3,6 +3,10 @@ import React, { useEffect, useState } from 'react';
 import { fetchWithAuth } from '../hooks/useAuthFetch';
 import PaginationControls from './PaginationControls';
 
+/**
+ * Paginated list of user role assignments.
+ */
+
 interface Assignment {
   username: string;
   role: string;

--- a/frontend/admin-dashboard/src/components/TrendingKeywords.tsx
+++ b/frontend/admin-dashboard/src/components/TrendingKeywords.tsx
@@ -2,6 +2,10 @@
 import React from 'react';
 import { useTrendingKeywords } from '../lib/trpc/hooks';
 
+/**
+ * List keywords with the highest recent search volume.
+ */
+
 export function TrendingKeywords({ limit }: { limit?: number }) {
   const { data, isLoading } = useTrendingKeywords(limit);
 


### PR DESCRIPTION
## Summary
- document various exported React components in admin dashboard

## Testing
- `flake8 backend`
- `black --check backend frontend`
- `pydocstyle frontend/admin-dashboard/src/components`
- `docformatter --check --recursive frontend/admin-dashboard/src/components`
- `npx prettier --check frontend/admin-dashboard/src/components/*.tsx frontend/admin-dashboard/src/components/FeatureFlags/*.tsx`
- `npx eslint frontend/admin-dashboard/src/components/*.tsx frontend/admin-dashboard/src/components/FeatureFlags/*.tsx` *(fails: Cannot find module '@babel/plugin-syntax-flow')*
- `pytest -n auto -W error -vv` *(failed: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687fe6f585148331aecda198da9fdaed