### PR TITLE
Add tracing spans to heavy tasks

### DIFF
--- a/backend/scoring-engine/scoring_engine/tasks.py
+++ b/backend/scoring-engine/scoring_engine/tasks.py
@@ -7,12 +7,15 @@ from typing import Mapping, cast
 
 from celery import Task
 from prometheus_client import Counter, Histogram
+from opentelemetry import trace
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding
 from signal_ingestion.embedding import generate_embedding
 
 from .celery_app import app
+
+tracer = trace.get_tracer(__name__)
 
 BATCH_COUNTER = Counter("embed_batches_total", "Number of processed embedding batches")
 SIGNAL_COUNTER = Counter(
@@ -30,15 +33,16 @@ def batch_embed(self: Task, signals: list[Mapping[str, object]]) -> int:
     BATCH_SIZE_HISTOGRAM.observe(len(signals))
     SIGNAL_COUNTER.inc(len(signals))
 
-    with session_scope() as session:
-        for msg in signals:
-            embedding = msg.get("embedding")
-            if embedding is None:
-                payload = json.dumps(msg, default=str, sort_keys=True)
-                embedding_value = generate_embedding(payload)
-            else:
-                embedding_value = list(cast(list[float], embedding))
-            source = str(msg.get("source", "global"))
-            session.add(Embedding(source=source, embedding=embedding_value))
-        session.flush()
-    return len(signals)
+    with tracer.start_as_current_span("batch_embed"):
+        with session_scope() as session:
+            for msg in signals:
+                embedding = msg.get("embedding")
+                if embedding is None:
+                    payload = json.dumps(msg, default=str, sort_keys=True)
+                    embedding_value = generate_embedding(payload)
+                else:
+                    embedding_value = list(cast(list[float], embedding))
+                source = str(msg.get("source", "global"))
+                session.add(Embedding(source=source, embedding=embedding_value))
+            session.flush()
+        return len(signals)


### PR DESCRIPTION
## Summary
- wrap `generate_mockup` task in tracing span
- wrap `batch_embed` task in tracing span

## Testing
- `black backend/mockup-generation/mockup_generation/tasks.py backend/scoring-engine/scoring_engine/tasks.py`
- `docformatter -i backend/mockup-generation/mockup_generation/tasks.py backend/scoring-engine/scoring_engine/tasks.py`
- `pydocstyle backend/mockup-generation/mockup_generation/tasks.py backend/scoring-engine/scoring_engine/tasks.py`
- `flake8 backend/mockup-generation/mockup_generation/tasks.py backend/scoring-engine/scoring_engine/tasks.py`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: Library stubs not installed)*
- `pytest backend/mockup-generation/tests/test_tasks_upload.py -W error -vv` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_b_687fe9ea78988331aae4da1e1a738ec6