### PR TITLE
Avoid duplicate image uploads

### DIFF
--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -13,6 +13,7 @@ import warnings
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 import pytest
+from botocore.exceptions import ClientError
 
 root = Path(__file__).resolve().parents[1]
 sys.path.append(str(root))  # noqa: E402
@@ -73,9 +74,15 @@ class DummyClient:
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, str]] = []
+        self.head_calls: list[tuple[str, str]] = []
+        self.exceptions = types.SimpleNamespace(ClientError=ClientError)
 
     async def put_object(self, Bucket: str, Key: str, Body: bytes | str) -> None:
         self.calls.append((Bucket, Key, ""))
+
+    async def head_object(self, Bucket: str, Key: str) -> None:
+        self.head_calls.append((Bucket, Key))
+        raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
 
 
 class DummyGenerator:


### PR DESCRIPTION
## Summary
- hash generated mockups and skip upload when already present
- update upload tests for new head_object check

## Testing
- `pre-commit run --files backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py` *(fails: Repository access requiring authentication)*
- `pytest -q` *(fails: 70 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687fe9f7eb208331a3eeabfe60077d1f