### PR TITLE
Fix metrics_store logging session

### DIFF
--- a/backend/shared/tests/test_http.py
+++ b/backend/shared/tests/test_http.py
@@ -28,3 +28,24 @@ def test_request_with_retry_failure(requests_mock):
     requests_mock.get("http://example.com", exc=requests.ConnectionError)
     with pytest.raises(requests.ConnectionError):
         request_with_retry("GET", "http://example.com", retries=2)
+
+
+def test_request_with_retry_custom_session(requests_mock):
+    """Custom session is used for the request."""
+
+    session = requests.Session()
+    requests_mock.get(
+        "http://example.com",
+        [
+            {"status_code": 500},
+            {"text": "ok"},
+        ],
+    )
+    resp = request_with_retry(
+        "GET",
+        "http://example.com",
+        retries=2,
+        session=session,
+    )
+    assert resp.text == "ok"
+    assert requests_mock.call_count == 2


### PR DESCRIPTION
## Summary
- reuse `requests.Session` in metrics_store._send_loki_log
- allow passing a session to `request_with_retry`
- test custom session behaviour

## Testing
- `flake8 backend/shared/http.py backend/monitoring/src/monitoring/metrics_store.py backend/shared/tests/test_http.py`
- `mypy backend/shared/http.py backend/monitoring/src/monitoring/metrics_store.py backend/shared/tests/test_http.py` *(fails: untyped decorator errors in unrelated modules)*
- `pytest -n auto -W error -vv` *(fails: missing services like docker and Postgres)*

------
https://chatgpt.com/codex/tasks/task_b_687fe9f949288331a7c2ea7ab3590fd2