### PR TITLE
Implement Pydantic settings

### DIFF
--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -5,6 +5,22 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration for backup destinations and database."""
+
+    model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
+
+    pgdatabase: str = Field(default="app", alias="PGDATABASE")
+    backup_bucket: str = Field(default="", alias="BACKUP_BUCKET")
+    backup_dir: Path = Field(default=Path("/tmp"), alias="BACKUP_DIR")
+
+
+settings = Settings()
+
 
 def run(command: list[str]) -> None:
     """Run a command and raise an error if it fails."""
@@ -12,7 +28,8 @@ def run(command: list[str]) -> None:
 
 
 def dump_postgres(backup_dir: Path, bucket: str) -> None:
-    """Dump the Postgres database and upload it to S3.
+    """
+    Dump the Postgres database and upload it to S3.
 
     Parameters
     ----------
@@ -23,24 +40,16 @@ def dump_postgres(backup_dir: Path, bucket: str) -> None:
     """
     timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     dump_file = backup_dir / f"postgres_{timestamp}.sql"
-    run(
-        [
-            "pg_dump",
-            os.getenv("PGDATABASE", "app"),
-            "-f",
-            str(dump_file),
-        ]
-    )
+    run(["pg_dump", settings.pgdatabase, "-f", str(dump_file)])
     run(["aws", "s3", "cp", str(dump_file), f"s3://{bucket}/postgres/{dump_file.name}"])
     dump_file.unlink()
 
 
 def main() -> None:
     """Run database backups."""
-    bucket = os.environ["BACKUP_BUCKET"]
-    backup_dir = Path(os.getenv("BACKUP_DIR", "/tmp"))
+    backup_dir = settings.backup_dir
     backup_dir.mkdir(parents=True, exist_ok=True)
-    dump_postgres(backup_dir, bucket)
+    dump_postgres(backup_dir, settings.backup_bucket)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- centralize tracing configuration via BaseSettings
- refactor backup configuration using Pydantic
- load query plan analyzer config from environment once
- register schemas with validated settings
- configure daily summary output via BaseSettings

## Testing
- `flake8 backend/shared/tracing.py scripts/backup.py scripts/analyze_query_plans.py scripts/register_schemas.py scripts/daily_summary.py`
- `mypy backend/shared/tracing.py scripts/backup.py scripts/analyze_query_plans.py scripts/register_schemas.py scripts/daily_summary.py --ignore-missing-imports --follow-imports skip`
- `pytest -k '' -q`

------
https://chatgpt.com/codex/tasks/task_b_687fe9e6bc748331a517a7f80cb417af