### PR TITLE
Add uvloop integration for FastAPI services

### DIFF
--- a/backend/api-gateway/pyproject.toml
+++ b/backend/api-gateway/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Your Name <you@example.com>"]
 python = "^3.10"
 fastapi = "^0.110"
 uvicorn = {extras = ["standard"], version = "^0.29"}
+uvloop = "*"
 python-jose = {extras = ["cryptography"], version = "^3.3"}
 
 [tool.poetry.group.dev.dependencies]

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -178,7 +178,11 @@ async def get_stats(
 
 
 if __name__ == "__main__":  # pragma: no cover
+    import asyncio
+    import uvloop
     import uvicorn
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     uvicorn.run(
         "feedback_loop.main:app",

--- a/backend/marketplace-publisher/pyproject.toml
+++ b/backend/marketplace-publisher/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.10"
 fastapi = "*"
 uvicorn = {extras = ["standard"], version = "*"}
 pydantic = "*"
+uvloop = "*"
 requests = "*"
 sqlalchemy = "*"
 asyncpg = "*"

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -412,7 +412,10 @@ if __name__ == "__main__":  # pragma: no cover
     if args.no_selenium:
         os.environ["SELENIUM_SKIP"] = "1"
 
+    import uvloop
     import uvicorn
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     uvicorn.run(
         "main:app",

--- a/backend/mockup-generation/requirements.txt
+++ b/backend/mockup-generation/requirements.txt
@@ -4,6 +4,7 @@ requests
 Pillow
 opencv-python-headless
 numpy
+uvloop
 jinja2
 diffusers
 transformers

--- a/backend/monitoring/pyproject.toml
+++ b/backend/monitoring/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.10"
 fastapi = "^0.110"
 uvicorn = {extras = ["standard"], version = "^0.29"}
 psutil = "*"
+uvloop = "*"
 prometheus-client = "*"
 opentelemetry-sdk = "*"
 opentelemetry-instrumentation-fastapi = "*"

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -258,7 +258,11 @@ async def ready(request: Request) -> Response:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    import asyncio
+    import uvloop
     import uvicorn
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     uvicorn.run(
         "monitoring.main:app",

--- a/backend/scoring-engine/requirements.txt
+++ b/backend/scoring-engine/requirements.txt
@@ -4,6 +4,7 @@ psycopg2-binary
 redis
 fakeredis
 pydantic
+uvloop
 pytest
 scikit-learn
 numpy

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -285,7 +285,8 @@ async def update_weights_endpoint(
 
 @app.post("/weights/feedback")
 async def feedback_weights(request: Request, body: WeightsUpdate) -> JSONResponse:
-    """Update weights from feedback loop with smoothing.
+    """
+    Update weights from feedback loop with smoothing.
 
     Requires ``X-Weights-Token`` header matching ``settings.weights_token``.
     """
@@ -394,7 +395,10 @@ async def ready(request: Request) -> Response:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    import uvloop
     import uvicorn
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     uvicorn.run(
         "scoring_engine.app:app",

--- a/backend/service-template/pyproject.toml
+++ b/backend/service-template/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.10"
 fastapi = "*"
 uvicorn = {extras = ["standard"], version = "*"}
 pydantic = "*"
+uvloop = "*"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -97,7 +97,11 @@ async def ready(request: Request) -> Response:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    import asyncio
+    import uvloop
     import uvicorn
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     uvicorn.run(
         "main:app",

--- a/backend/signal-ingestion/pyproject.toml
+++ b/backend/signal-ingestion/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.10"
 fastapi = "*"
 uvicorn = {extras = ["standard"], version = "*"}
 pydantic = "*"
+uvloop = "*"
 httpx = "*"
 sqlalchemy = "*"
 asyncpg = "*"

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -128,7 +128,11 @@ async def trending(limit: int = 10) -> list[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    import asyncio
+    import uvloop
     import uvicorn
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     uvicorn.run(
         "signal_ingestion.main:app",

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -27,6 +27,11 @@ Cached:   0.25s for 100 runs
 
 Caching reduces request latency by roughly 3x in this small test.
 
+## Event Loop Optimization
+
+All FastAPI services install `uvloop` and configure it during startup for better
+I/O performance.
+
 ## Benchmark Automation
 
 The Dagster job `benchmark_score_job` executes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ mypy
 pydocstyle
 flake8-docstrings
 docformatter
+uvloop
 watchdog
 vcrpy
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn
+uvloop
 pydantic
 pandas
 pytest


### PR DESCRIPTION
## Summary
- install `uvloop` for faster event loops
- use `uvloop` in FastAPI service startup blocks
- mention the optimization in docs

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q` *(fails: OperationalError connection issues)*

------
https://chatgpt.com/codex/tasks/task_b_687fe9e65950833190c53bedadff878b