### PR TITLE
Use typed models in API endpoints

### DIFF
--- a/backend/api-gateway/src/api_gateway/models.py
+++ b/backend/api-gateway/src/api_gateway/models.py
@@ -29,3 +29,62 @@ class FlagState(BaseModel):
     """Desired state for a feature flag."""
 
     enabled: bool
+
+
+class StatusResponse(BaseModel):
+    """Simple status message."""
+
+    status: str
+
+
+class TokenResponse(BaseModel):
+    """JWT token pair returned on authentication."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class PendingRuns(BaseModel):
+    """IDs of runs waiting for approval."""
+
+    runs: list[str]
+
+
+class RoleItem(BaseModel):
+    """Role assignment for a single user."""
+
+    username: str
+    role: str
+
+
+class RolesResponse(BaseModel):
+    """Paginated list of role assignments."""
+
+    total: int
+    items: list[RoleItem]
+
+
+class RefreshRequest(BaseModel):
+    """Request body containing a refresh token."""
+
+    refresh_token: str
+
+
+class UserResponse(BaseModel):
+    """Authenticated username payload."""
+
+    user: str | None
+
+
+class PurgeResult(BaseModel):
+    """Result of a PII purge."""
+
+    status: str
+    purged: int
+
+
+class ApprovalStatus(BaseModel):
+    """Approval status for a run."""
+
+    approved: bool


### PR DESCRIPTION
## Summary
- add explicit response models for API gateway
- use the new models in routes

## Testing
- `flake8`
- `black --check backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/src/api_gateway/models.py`
- `mypy backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/src/api_gateway/models.py` *(fails: no output)*
- `pytest backend/api-gateway/tests/test_routes.py::test_status -q` *(fails: DeprecationWarning)*

------
https://chatgpt.com/codex/tasks/task_b_687fe9f8a4488331abccc57275569c0e