### PR TITLE
Compute SHA256 before upload

### DIFF
--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -30,6 +30,26 @@ def _task_decorator(*_d_args: object, **_d_kwargs: object) -> callable:
 mock_celery_app.app = types.SimpleNamespace(task=_task_decorator)
 mock_celery_app.queue_for_gpu = lambda *args, **kwargs: None
 sys.modules.setdefault("mockup_generation.celery_app", mock_celery_app)
+trace_mod = types.ModuleType("opentelemetry.trace")
+
+
+class _DummyTracer:
+    def start_as_current_span(self, *_a: object, **_kw: object) -> object:
+        class _Span:
+            def __enter__(self) -> None:  # noqa: D401 - simple pass-through
+                return None
+
+            def __exit__(self, *exc: object) -> bool:  # noqa: D401
+                return False
+
+        return _Span()
+
+
+trace_mod.get_tracer = lambda *_a, **_kw: _DummyTracer()
+sys.modules["opentelemetry.trace"] = trace_mod
+otel_root = types.ModuleType("opentelemetry")
+otel_root.trace = trace_mod
+sys.modules["opentelemetry"] = otel_root
 from mockup_generation import tasks  # noqa: E402
 
 _orig_generate_mockup = tasks.generate_mockup.run
@@ -68,11 +88,23 @@ sys.modules["pgvector.sqlalchemy"].Vector = object
 warnings.filterwarnings("ignore", category=UserWarning)
 
 
-class DummyClient:
-    """Collect upload calls."""
+class DummyError(Exception):
+    """Fake botocore.ClientError with a 404 status."""
 
     def __init__(self) -> None:
+        self.response = {"Error": {"Code": "404"}}
+
+
+class DummyClient:
+    """Collect upload calls and simulate object existence."""
+
+    def __init__(self, exists: bool = False) -> None:
         self.calls: list[tuple[str, str, str]] = []
+        self.exists = exists
+
+    async def head_object(self, Bucket: str, Key: str) -> None:
+        if not self.exists:
+            raise DummyError()
 
     async def put_object(self, Bucket: str, Key: str, Body: bytes | str) -> None:
         self.calls.append((Bucket, Key, ""))
@@ -171,3 +203,67 @@ def test_generate_mockup_upload(
 
     tasks.generate_mockup([["kw"]], str(tmp_path), model="m", gpu_index=0)
     assert gen.cleaned
+
+
+def test_generate_mockup_duplicate_not_uploaded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Skip upload when an object with the same hash exists."""
+    gen = DummyGenerator()
+    monkeypatch.setattr(tasks, "generator", gen)
+    monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
+
+    client = DummyClient(exists=True)
+
+    @asynccontextmanager
+    async def _client() -> AsyncIterator[DummyClient]:
+        yield client
+
+    monkeypatch.setattr(tasks, "_get_storage_client", _client)
+    monkeypatch.setattr(
+        tasks,
+        "redis_client",
+        types.SimpleNamespace(
+            lock=lambda *a, **k: types.SimpleNamespace(
+                acquire=lambda *a, **k: True,
+                locked=lambda: False,
+                release=lambda: None,
+            )
+        ),
+    )
+
+    class _Lock:
+        async def acquire(self, *args: object, **kwargs: object) -> bool:
+            return True
+
+        def locked(self) -> bool:
+            return False
+
+        async def release(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        tasks,
+        "async_redis_client",
+        types.SimpleNamespace(lock=lambda *a, **k: _Lock()),
+    )
+    monkeypatch.setattr(tasks, "remove_background", lambda img: img)
+    monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)
+    monkeypatch.setattr(tasks, "ensure_not_nsfw", lambda img: None)
+    monkeypatch.setattr(tasks, "validate_dpi_image", lambda img: True)
+    monkeypatch.setattr(tasks, "validate_color_space", lambda img: True)
+    monkeypatch.setattr(
+        tasks.model_repository, "save_generated_mockup", lambda *a, **k: 1
+    )
+    called: list[str] = []
+    monkeypatch.setattr(
+        tasks, "_invalidate_cdn_cache", lambda path: called.append(path)
+    )
+    tasks.settings.s3_bucket = "b"
+    tasks.settings.s3_endpoint = "http://test"  # type: ignore
+    tasks.settings.s3_base_url = "http://cdn.test"  # type: ignore
+
+    tasks.generate_mockup([["kw"]], str(tmp_path), model="m", gpu_index=0)
+    assert gen.cleaned
+    assert not client.calls
+    assert not called


### PR DESCRIPTION
## Summary
- compute SHA256 of generated mock-up image before S3 upload
- skip S3 upload if object with same SHA256 already exists
- add regression test for duplicate uploads

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py`
- `docformatter --check backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py`
- `mypy backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py --ignore-missing-imports --follow-imports=skip`
- `pydocstyle backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py`
- `pytest backend/mockup-generation/tests/test_tasks_upload.py -k "test_generate_mockup_upload or test_generate_mockup_duplicate_not_uploaded" -vv -W error`

------
https://chatgpt.com/codex/tasks/task_b_687fec4a77308331be0108e992f0f411