### PR TITLE
Update pre-commit Black settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
+        files: "\\.(py|pyi)$"
+        args: ["--line-length=88"]
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:


### PR DESCRIPTION
## Summary
- run Black on any Python and stub files
- enforce an 88 char line length in pre-commit

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pre-commit run --files .pre-commit-config.yaml` *(fails: repository access requires credentials)*
- `pytest -k "" -vv` *(fails: connection to PostgreSQL at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_b_687ff26acc0c8331a03096e94a45af49