### PR TITLE
Add caching headers and optional Redis cache

### DIFF
--- a/backend/api-gateway/src/api_gateway/settings.py
+++ b/backend/api-gateway/src/api_gateway/settings.py
@@ -19,8 +19,14 @@ class Settings(BaseSettings):
     rate_limit_per_user: int = 60
     rate_limit_window: int = 60
     ws_interval_ms: int = int(os.environ.get("API_GATEWAY_WS_INTERVAL_MS", "5000"))
+    request_cache_ttl: int = int(os.environ.get("API_GATEWAY_REQUEST_CACHE_TTL", "0"))
 
-    @field_validator("rate_limit_per_user", "rate_limit_window", "ws_interval_ms")
+    @field_validator(
+        "rate_limit_per_user",
+        "rate_limit_window",
+        "ws_interval_ms",
+        "request_cache_ttl",
+    )
     @classmethod
     def _positive(cls, value: int) -> int:
         if value <= 0:

--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -206,6 +206,7 @@ def test_optimization_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(httpx, "AsyncClient", MockClient)
     resp = client.get("/optimizations", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
+    assert resp.headers["Cache-Control"].startswith("public")
     assert resp.json() == ["a", "b"]
 
 
@@ -249,6 +250,7 @@ def test_monitoring_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(httpx, "AsyncClient", MockClient)
     resp = client.get("/monitoring/overview")
     assert resp.status_code == 200
+    assert resp.headers["Cache-Control"].startswith("public")
     assert resp.json() == {"cpu": 1}
 
 
@@ -292,4 +294,5 @@ def test_analytics_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(httpx, "AsyncClient", MockClient)
     resp = client.get("/analytics/low_performers?limit=5")
     assert resp.status_code == 200
+    assert resp.headers["Cache-Control"].startswith("public")
     assert resp.json() == [{"id": 1}]

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -63,6 +63,7 @@ def test_system_health(monkeypatch: Any) -> None:
     client = TestClient(main_module.app)
     resp = client.get("/api/health")
     assert resp.status_code == 200
+    assert resp.headers["Cache-Control"].startswith("public")
     body = resp.json()
     for service in routes.HEALTH_ENDPOINTS:
         assert body[service] == "ok"

--- a/tests/test_trending_route.py
+++ b/tests/test_trending_route.py
@@ -51,4 +51,5 @@ def test_trending_proxy(monkeypatch: Any) -> None:
 
     resp = client.get("/trending?limit=5")
     assert resp.status_code == 200
+    assert resp.headers["Cache-Control"].startswith("public")
     assert resp.json() == ["foo", "bar"]


### PR DESCRIPTION
## Summary
- add CacheControlRoute to attach Cache-Control headers
- allow optional request caching using Redis
- expose request cache TTL in settings
- verify caching headers in API gateway tests

## Testing
- `flake8 backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/src/api_gateway/settings.py tests/test_trending_route.py tests/test_system_health.py backend/api-gateway/tests/test_routes.py`
- `mypy --config-file pyproject.toml backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/src/api_gateway/settings.py` *(fails: Class cannot subclass "APIRoute" and several untyped decorator errors)*
- `pytest -k "trending_route or system_health or test_routes" -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687ff26e6a148331b88487da0abae196