### PR TITLE
Refactor async loops with TaskGroup

### DIFF
--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -685,7 +685,11 @@ async def metrics_ws(websocket: WebSocket) -> None:
         while True:
             overview_req = client.get(f"{MONITORING_URL}/overview")
             analytics_req = client.get(f"{MONITORING_URL}/analytics")
-            overview, analytics = await asyncio.gather(overview_req, analytics_req)
+            async with asyncio.TaskGroup() as tg:
+                overview_task = tg.create_task(overview_req)
+                analytics_task = tg.create_task(analytics_req)
+            overview = overview_task.result()
+            analytics = analytics_task.result()
             data: Dict[str, Any] = {}
             if overview.status_code == 200:
                 data.update(cast(Dict[str, Any], overview.json()))
@@ -706,7 +710,11 @@ async def metrics_sse() -> EventSourceResponse:
         while True:
             overview_req = client.get(f"{MONITORING_URL}/overview")
             analytics_req = client.get(f"{MONITORING_URL}/analytics")
-            overview, analytics = await asyncio.gather(overview_req, analytics_req)
+            async with asyncio.TaskGroup() as tg:
+                overview_task = tg.create_task(overview_req)
+                analytics_task = tg.create_task(analytics_req)
+            overview = overview_task.result()
+            analytics = analytics_task.result()
             data: Dict[str, Any] = {}
             if overview.status_code == 200:
                 data.update(cast(Dict[str, Any], overview.json()))

--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -98,8 +98,9 @@ async def _fetch_metrics_async(
             "revenue": float(data.get("revenue", 0.0)),
         }
 
-    tasks = [_get(c, lid) for c in clients for lid in listing_ids]
-    results = await asyncio.gather(*tasks)
+    async with asyncio.TaskGroup() as tg:
+        tasks = [tg.create_task(_get(c, lid)) for c in clients for lid in listing_ids]
+    results = [t.result() for t in tasks]
     return [r for r in results if r]
 
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
@@ -46,7 +46,9 @@ async def _dispatch_notifications(task_id: int, marketplace: str) -> None:
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning("pagerduty notification failed: %s", exc)
 
-    await asyncio.gather(slack(), pagerduty())
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(slack())
+        tg.create_task(pagerduty())
 
 
 def notify_failure(task_id: int, marketplace: str) -> None:


### PR DESCRIPTION
## Summary
- use asyncio.TaskGroup for concurrent scoring and generation
- use TaskGroup when fetching metrics and trending scores
- update notifications dispatch to use TaskGroup
- refactor API gateway metric endpoints to TaskGroup

## Testing
- `flake8 backend/orchestrator/orchestrator/ops.py backend/feedback-loop/feedback_loop/ingestion.py backend/scoring-engine/scoring_engine/app.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/api-gateway/src/api_gateway/routes.py`
- `pydocstyle backend/orchestrator/orchestrator/ops.py backend/feedback-loop/feedback_loop/ingestion.py backend/scoring-engine/scoring_engine/app.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/api-gateway/src/api_gateway/routes.py`
- `docformatter -r -i backend/orchestrator/orchestrator/ops.py backend/feedback-loop/feedback_loop/ingestion.py backend/scoring-engine/scoring_engine/app.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/api-gateway/src/api_gateway/routes.py`
- `black backend/orchestrator/orchestrator/ops.py backend/feedback-loop/feedback_loop/ingestion.py backend/scoring-engine/scoring_engine/app.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/api-gateway/src/api_gateway/routes.py`
- `mypy backend/orchestrator/orchestrator/ops.py backend/feedback-loop/feedback_loop/ingestion.py backend/scoring-engine/scoring_engine/app.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/api-gateway/src/api_gateway/routes.py` *(fails: Library stubs not installed for "requests" ...)*
- `python -m pytest -n auto -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_687ff267582c8331a1d283d6badf0023