### PR TITLE
Fix infinite loops in tests

### DIFF
--- a/scripts/wait_for_services.py
+++ b/scripts/wait_for_services.py
@@ -14,13 +14,19 @@ SERVICES = [
 ]
 
 
-def _wait(host: str, port: int) -> None:
-    while True:
+DEFAULT_TIMEOUT = int(os.getenv("WAIT_TIMEOUT", "30"))
+
+
+def _wait(host: str, port: int, timeout: int = DEFAULT_TIMEOUT) -> None:
+    """Wait for ``host``:``port`` to accept connections or raise ``TimeoutError``."""
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
         try:
             with socket.create_connection((host, port), timeout=1):
                 return
         except OSError:
             time.sleep(1)
+    raise TimeoutError(f"Service {host}:{port} did not respond in {timeout} seconds")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add timeout handling when waiting for services
- limit duration of GPU lock test helper

## Testing
- `flake8 scripts/wait_for_services.py backend/mockup-generation/tests/test_signal_handlers.py`
- `black scripts/wait_for_services.py backend/mockup-generation/tests/test_signal_handlers.py`
- `mypy scripts/wait_for_services.py backend/mockup-generation/tests/test_signal_handlers.py` *(fails: Class cannot subclass "DeclarativeBase" etc.)*
- `pytest backend/mockup-generation/tests/test_signal_handlers.py::test_gpu_lock_released_on_sigterm -q` *(fails: ModuleNotFoundError: No module named 'aiobotocore')*

------
https://chatgpt.com/codex/tasks/task_b_687ff268bb448331bb3c0add810e3646