### PR TITLE
Remove global flake8 ignores

### DIFF
--- a/backend/api-gateway/tests/test_auth.py
+++ b/backend/api-gateway/tests/test_auth.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 """Tests for JWT auth middleware."""
 
 import sys

--- a/tests/test_daily_summary.py
+++ b/tests/test_daily_summary.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 """Tests for daily summary script."""
 
 from __future__ import annotations

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 """Tests for webhook handling in marketplace publisher."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- drop file-level flake8 suppressions for cleaner linting

## Testing
- `flake8 backend/api-gateway/tests/test_auth.py tests/test_daily_summary.py tests/test_webhooks.py`
- `black backend/api-gateway/tests/test_auth.py tests/test_daily_summary.py tests/test_webhooks.py --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_b_687ff28119f48331b956bd6ca05dee06