### PR TITLE
Improve Docker build caching

### DIFF
--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --upgrade pip && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip && \
     pip install poetry && \
     poetry export -f requirements.txt --without-hashes --output requirements.txt && \
     pip install --prefix=/usr/local --no-cache-dir -r requirements.txt

--- a/backend/feedback-loop/Dockerfile
+++ b/backend/feedback-loop/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
 
 FROM python:3.11-slim
 WORKDIR /app

--- a/backend/marketplace-publisher/Dockerfile
+++ b/backend/marketplace-publisher/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --upgrade pip && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip && \
     pip install poetry && \
     poetry export -f requirements.txt --without-hashes --output requirements.txt && \
     pip install --prefix=/usr/local --no-cache-dir -r requirements.txt

--- a/backend/mockup-generation/Dockerfile
+++ b/backend/mockup-generation/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
 
 FROM nvidia/cuda:12.1.0-cudnn8-runtime-ubuntu20.04
 WORKDIR /app

--- a/backend/monitoring/Dockerfile
+++ b/backend/monitoring/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --upgrade pip && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip && \
     pip install poetry && \
     poetry export -f requirements.txt --without-hashes --output requirements.txt && \
     pip install --prefix=/usr/local --no-cache-dir -r requirements.txt

--- a/backend/orchestrator/Dockerfile
+++ b/backend/orchestrator/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11-slim AS builder
 WORKDIR /install
-RUN pip install --prefix=/usr/local dagster dagster-webserver
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefix=/usr/local dagster dagster-webserver
 
 FROM python:3.11-slim
 WORKDIR /app

--- a/backend/scoring-engine/Dockerfile
+++ b/backend/scoring-engine/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
 
 FROM python:3.11-slim
 WORKDIR /app

--- a/backend/signal-ingestion/Dockerfile
+++ b/backend/signal-ingestion/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
-RUN pip install --upgrade pip && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip && \
     pip install poetry && \
     poetry export -f requirements.txt --without-hashes --output requirements.txt && \
     pip install --prefix=/usr/local --no-cache-dir -r requirements.txt

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,6 +7,7 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
 - Docker Engine with the Buildx plugin installed
 - QEMU emulation binaries for cross-platform builds
 - `docker buildx` configured as the default builder
+- Docker BuildKit enabled to cache pip and npm packages using `--mount=type=cache`
 
 ## Docker Compose
 

--- a/frontend/admin-dashboard/Dockerfile
+++ b/frontend/admin-dashboard/Dockerfile
@@ -3,7 +3,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup -S app && adduser -S app -G app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev && npm cache clean --force
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev && npm cache clean --force
 COPY LICENSES /licenses/LICENSES
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- add BuildKit cache mounts for pip and npm installs
- mention BuildKit caching in the deployment docs

## Testing
- `./scripts/setup_codex.sh`
- `pytest -n auto -W error -vv` *(fails: Docker compose not found)*
- `npm test` *(fails: SyntaxError in exit_on_warnings.js)*
- `npm run test:e2e` *(fails: Playwright web server error)*

------
https://chatgpt.com/codex/tasks/task_b_687ff280034483318f8360ace9b70cc3