### PR TITLE
Improve S3 upload handling

### DIFF
--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -107,7 +107,36 @@ class DummyClient:
             raise DummyError()
 
     async def put_object(self, Bucket: str, Key: str, Body: bytes | str) -> None:
-        self.calls.append((Bucket, Key, ""))
+        self.calls.append((Bucket, Key, "put"))
+
+    async def create_multipart_upload(self, Bucket: str, Key: str) -> dict[str, str]:
+        self.calls.append((Bucket, Key, "create"))
+        return {"UploadId": "1"}
+
+    async def upload_part(
+        self,
+        Bucket: str,
+        Key: str,
+        UploadId: str,
+        PartNumber: int,
+        Body: bytes,
+    ) -> dict[str, str]:
+        self.calls.append((Bucket, Key, f"part-{PartNumber}"))
+        return {"ETag": "tag"}
+
+    async def complete_multipart_upload(
+        self,
+        Bucket: str,
+        Key: str,
+        UploadId: str,
+        MultipartUpload: dict[str, list[dict[str, str]]],
+    ) -> None:
+        self.calls.append((Bucket, Key, "complete"))
+
+    async def abort_multipart_upload(
+        self, Bucket: str, Key: str, UploadId: str
+    ) -> None:
+        self.calls.append((Bucket, Key, "abort"))
 
 
 class DummyGenerator:


### PR DESCRIPTION
## Summary
- support multipart uploads for mockup generation
- extend task upload tests for new S3 API helpers

## Testing
- `black backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py`
- `docformatter --in-place --wrap-summaries 88 --wrap-descriptions 88 backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py`
- `flake8 backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py`
- `pydocstyle backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py`
- `mypy backend/mockup-generation/mockup_generation/tasks.py backend/mockup-generation/tests/test_tasks_upload.py --ignore-missing-imports --follow-imports=skip`
- `python -m pytest -W error -vv backend/mockup-generation/tests/test_tasks_upload.py`

------
https://chatgpt.com/codex/tasks/task_b_687ff270f998833190b60aa09cf5934f