### PR TITLE
Improve scoring engine JSON performance

### DIFF
--- a/backend/scoring-engine/requirements.txt
+++ b/backend/scoring-engine/requirements.txt
@@ -4,6 +4,7 @@ psycopg2-binary
 redis
 fakeredis
 pydantic
+orjson
 uvloop
 pytest
 scikit-learn

--- a/backend/scoring-engine/scoring_engine/tasks.py
+++ b/backend/scoring-engine/scoring_engine/tasks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import orjson
 from typing import Mapping, cast
 
 from celery import Task
@@ -38,7 +38,11 @@ def batch_embed(self: Task, signals: list[Mapping[str, object]]) -> int:
             for msg in signals:
                 embedding = msg.get("embedding")
                 if embedding is None:
-                    payload = json.dumps(msg, default=str, sort_keys=True)
+                    payload = orjson.dumps(
+                        msg,
+                        option=orjson.OPT_SORT_KEYS,
+                        default=str,
+                    ).decode()
                     embedding_value = generate_embedding(payload)
                 else:
                     embedding_value = list(cast(list[float], embedding))

--- a/backend/scoring-engine/scoring_engine/weight_repository.py
+++ b/backend/scoring-engine/scoring_engine/weight_repository.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-import json
+import orjson
 from pathlib import Path
 from sqlalchemy import select
 
@@ -95,7 +95,9 @@ def update_weights(*, smoothing: float = 1.0, **kwargs: float) -> WeightParams:
 
     # Persist updated weights to a JSON file for durability
     try:
-        WEIGHTS_FILE.write_text(json.dumps(asdict(params)))
+        WEIGHTS_FILE.write_text(
+            orjson.dumps(asdict(params), option=orjson.OPT_SORT_KEYS).decode()
+        )
     except Exception:  # pragma: no cover - persistence failures should not crash
         pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn
 uvloop
 pydantic
+orjson
 pandas
 pytest
 pytest-cov


### PR DESCRIPTION
## Summary
- adopt `orjson` for critical JSON serialization in scoring engine
- persist weights with `orjson` for faster file writes
- add `orjson` dependency

## Testing
- `flake8 backend/scoring-engine/scoring_engine/tasks.py backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/scoring_engine/weight_repository.py`
- `pydocstyle backend/scoring-engine/scoring_engine/tasks.py backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/scoring_engine/weight_repository.py`
- `mypy backend/scoring-engine --config-file backend/mypy.ini` *(fails: Library stubs not installed for "requests" and other modules)*
- `pytest tests/test_search_api.py::test_trending_route -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `sphinx-build -b html docs docs/_build/html` *(fails: Could not import extension sphinxcontrib.openapi)*

------
https://chatgpt.com/codex/tasks/task_b_687ff7e20c9c8331be45a0509e72ef15