### PR TITLE
CI: run flow check

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,6 +33,8 @@ jobs:
         run: python scripts/generate_openapi.py
       - name: Run linting
         run: make lint
+      - name: Run Flow
+        run: npm run flow
       - name: Run tests
         run: make test
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -59,6 +59,8 @@ jobs:
           npm ci --prefix frontend/admin-dashboard
           npx playwright install --with-deps
           python -m pip install -e .
+      - name: Run Flow
+        run: npm run flow
       - name: Run tests
         env:
           PYTHONWARNINGS: error


### PR DESCRIPTION
## Summary
- ensure flow type checking runs in the `pipeline` and `ci-cd` workflows

## Testing
- `npx --yes flow-bin check --max-warnings=0` *(fails: Unclear type in admin-dashboard mocks)*
- `pip install -r requirements.txt -r requirements-dev.txt` *(truncated output)*
- `pytest -k "" -q` *(fails: ModuleNotFoundError: fastapi)

------
https://chatgpt.com/codex/tasks/task_b_687ff7de1e448331b59892bee9abe74a