### PR TITLE
Add doc note on pushing publish task status

### DIFF
--- a/docs/publish_tasks.md
+++ b/docs/publish_tasks.md
@@ -11,3 +11,13 @@ All edits and retries are recorded in the audit log.
 If `SLACK_WEBHOOK_URL` is configured, failed publish attempts send a Discord notification.
 When `PAGERDUTY_ROUTING_KEY` is set and `ENABLE_PAGERDUTY` is `true`, the failure also triggers a PagerDuty alert.
 Both notifications run as background tasks with a short timeout so publishing is never blocked.
+
+## Push Updates Instead of Polling
+
+The Admin Dashboard currently polls `/tasks/{task_id}` to check publishing
+progress. When many tasks run concurrently this approach generates extra HTTP
+traffic and may delay user feedback. Consider exposing a callback URL or using a
+message queue (for example Redis Pub/Sub or Kafka) so the marketplace publisher
+can push status changes as soon as they occur. Clients subscribed to these
+events would no longer need to repeatedly request the task status, improving
+performance and reducing load on the API Gateway.


### PR DESCRIPTION
## Summary
- recommend using webhooks or a message queue to push publish task status

## Testing
- `pytest -n auto -W error -vv` *(fails: FileNotFoundError docker-compose)*
- `npm test` *(fails: Cannot find module jest.js)*
- `npm run test:e2e` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_687ff7ee06b883319fc0d7a52b50c07b