### PR TITLE
Refactor config

### DIFF
--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 from typing import Callable, Coroutine
 
@@ -17,6 +16,7 @@ from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
+from .settings import settings as service_settings
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
@@ -32,7 +32,7 @@ from .celery_app import app as celery_app
 configure_logging()
 logger = logging.getLogger(__name__)
 
-SERVICE_NAME = os.getenv("SERVICE_NAME", "mockup-generation")
+SERVICE_NAME = service_settings.service_name
 app = FastAPI(title="Mockup Generation Service")
 app.add_middleware(
     CORSMiddleware,

--- a/backend/mockup-generation/mockup_generation/listing_generator.py
+++ b/backend/mockup-generation/mockup_generation/listing_generator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass
 from typing import List
 
@@ -26,9 +25,9 @@ class ListingGenerator:
 
     def __init__(self) -> None:
         """Initialize with API credentials from the environment."""
-        self._openai_key = settings.openai_api_key or os.getenv("OPENAI_API_KEY")
+        self._openai_key = settings.openai_api_key
         self._openai_model = settings.openai_model
-        self._claude_key = os.getenv("CLAUDE_API_KEY")
+        self._claude_key = settings.claude_api_key
         self._session = requests.Session()
 
     def generate(self, keywords: List[str]) -> ListingMetadata:

--- a/backend/mockup-generation/mockup_generation/settings.py
+++ b/backend/mockup-generation/mockup_generation/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import field_validator
+from pydantic import RedisDsn, field_validator
 
 
 class Settings(BaseSettings):  # type: ignore[misc]
@@ -18,9 +18,30 @@ class Settings(BaseSettings):  # type: ignore[misc]
     stability_ai_api_key: str | None = None
     openai_api_key: str | None = None
     openai_model: str = "gpt-4"
+    claude_api_key: str | None = None
+    service_name: str = "mockup-generation"
     fallback_provider: Literal["stability", "openai"] = "stability"
     use_comfyui: bool = False
     comfyui_url: str = "http://localhost:8188"
+
+    # Runtime and Celery configuration
+    redis_url: RedisDsn = RedisDsn("redis://localhost:6379/0")
+    gpu_slots: int = 1
+    gpu_lock_timeout: int = 600
+    gpu_queue_prefix: str = "gpu"
+    gpu_worker_index: int = -1
+    gpu_autoscale_factor: int = 2
+    celery_broker: Literal["redis", "rabbitmq", "kafka"] = "redis"
+    celery_broker_url: str | None = None
+    celery_result_backend: str | None = None
+    redis_host: str = "localhost"
+    redis_port: str = "6379"
+    redis_db: str = "0"
+    rabbitmq_host: str = "localhost"
+    rabbitmq_port: str = "5672"
+    rabbitmq_user: str = "guest"
+    rabbitmq_password: str = "guest"
+    kafka_bootstrap_servers: str = "localhost:9092"
 
     @field_validator("fallback_provider")  # type: ignore[misc]
     @classmethod

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import os
 import uuid
 import asyncio
 import logging
@@ -34,6 +33,7 @@ from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 
 from backend.shared.config import settings
+from .settings import settings as service_settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.logging import configure_logging
@@ -100,7 +100,7 @@ class SearchRequest(BaseModel):
 configure_logging()
 logger = logging.getLogger(__name__)
 
-SERVICE_NAME = os.getenv("SERVICE_NAME", "scoring-engine")
+SERVICE_NAME = service_settings.service_name
 app = FastAPI(title="Scoring Engine")
 app.add_middleware(
     CORSMiddleware,
@@ -119,7 +119,7 @@ REDIS_URL = settings.redis_url
 CACHE_TTL_SECONDS = settings.score_cache_ttl
 redis_client: AsyncRedis = get_async_client()
 metrics_store = TimescaleMetricsStore()
-EMBED_BATCH_SIZE = int(os.getenv("EMBED_BATCH_SIZE", "50"))
+EMBED_BATCH_SIZE = service_settings.embed_batch_size
 
 
 # Background Kafka consumer setup
@@ -174,7 +174,7 @@ async def apply_migrations() -> None:
 async def start_consumer() -> None:
     """Launch background Kafka consumer."""
     global _consumer_thread, _consumer
-    if os.getenv("KAFKA_SKIP") == "1":
+    if service_settings.kafka_skip:
         return
     _consumer = _create_consumer()
     _stop_event.clear()

--- a/backend/scoring-engine/scoring_engine/celery_app.py
+++ b/backend/scoring-engine/scoring_engine/celery_app.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import os
-
 from celery import Celery
 
 from backend.shared.queue_metrics import register_redis_queue_collector
+from .settings import settings
 
-CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_BROKER_URL = settings.celery_broker_url
 app = Celery("scoring_engine", broker=CELERY_BROKER_URL)
 app.conf.result_backend = CELERY_BROKER_URL
 

--- a/backend/scoring-engine/scoring_engine/settings.py
+++ b/backend/scoring-engine/scoring_engine/settings.py
@@ -1,0 +1,30 @@
+"""Configuration for the scoring engine service."""
+
+from __future__ import annotations
+
+from pydantic import RedisDsn, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Expose configuration derived from environment variables."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env", env_prefix="", secrets_dir="/run/secrets"
+    )
+
+    service_name: str = "scoring-engine"
+    embed_batch_size: int = 50
+    kafka_skip: bool = False
+    celery_broker_url: RedisDsn = RedisDsn("redis://localhost:6379/0")
+
+    @field_validator("embed_batch_size")  # type: ignore[misc]
+    @classmethod
+    def _positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("embed_batch_size must be positive")
+        return value
+
+
+Settings.model_rebuild()
+settings: Settings = Settings()


### PR DESCRIPTION
## Summary
- centralize env config for scoring engine
- expand typed settings for mockup generation
- use typed settings across services

## Testing
- `make lint` *(fails: mypy errors)*
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687ff7dc9dac8331bc7c0b4a9f6fe10c