### PR TITLE
Switch dedup to Redis set

### DIFF
--- a/backend/signal-ingestion/pyproject.toml
+++ b/backend/signal-ingestion/pyproject.toml
@@ -14,7 +14,7 @@ uvloop = "*"
 httpx = "*"
 sqlalchemy = "*"
 asyncpg = "*"
-redis = {extras = ["bloom"], version = "*"}
+redis = "*"
 kafka-python = "*"
 
 [tool.poetry.dev-dependencies]

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -58,9 +58,7 @@ async def startup() -> None:
     """Initialize resources."""
     await run_migrations_if_needed("backend/shared/db/alembic_signal_ingestion.ini")
     await init_db()
-    dedup.initialize(
-        settings.dedup_error_rate, settings.dedup_capacity, settings.dedup_ttl
-    )
+    dedup.initialize(settings.dedup_ttl)
     scheduler.start()
 
 

--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -14,8 +14,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     app_name: str = "signal-ingestion"
     log_level: str = "INFO"
     signal_retention_days: int = 90
-    dedup_error_rate: float = 0.01
-    dedup_capacity: int = 100_000
     dedup_ttl: int = 86_400
     ingest_interval_minutes: int = 60
     ingest_cron: str | None = None
@@ -58,8 +56,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
         return limits
 
     @field_validator(  # type: ignore[misc]
-        "dedup_error_rate",
-        "dedup_capacity",
         "dedup_ttl",
         "ingest_interval_minutes",
         "instagram_fetch_limit",
@@ -75,8 +71,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
         cls, value: float | int | list[str] | None
     ) -> float | int | list[str] | None:
         if isinstance(value, float):
-            if not 0 <= value <= 1:
-                raise ValueError("dedup_error_rate must be in [0,1]")
             return value
         if isinstance(value, list) or value is None:
             return value

--- a/docs/blueprints/DesignIdeaEngineCompleteBlueprint.md
+++ b/docs/blueprints/DesignIdeaEngineCompleteBlueprint.md
@@ -249,7 +249,7 @@ The Design Idea Engine follows a microservices architecture pattern with clear s
 
 - **Source Adapters**: Modular adapters for each signal source (TikTok, Instagram, Reddit, YouTube, etc.)
 - **Normalization Engine**: Converts diverse signal formats into a unified schema
-- **Deduplication Service**: Uses Redis Bloom filters to prevent duplicate signal processing
+- **Deduplication Service**: Uses a Redis set to prevent duplicate signal processing
 - **Rate Limiter**: Intelligent rate limiting based on source-specific quotas and policies
 
 **Data Flow**:
@@ -1221,7 +1221,7 @@ Event-driven microservices with a robust vector store provide scalability and fl
 | Event & Holiday Calendars            | Static CSV \+ lightweight scrape    | Event name, locale, date           | Cache with long TTL                         |
 | Nostalgia Archives (Wiki, TV Tropes) | Daily scrape                        | Topic, anniversary year            | Low-frequency job                           |
 
-**Normalization** into a common `Signal` schema; dedupe with a Redis Bloom filter.
+**Normalization** into a common `Signal` schema; dedupe with a Redis set.
 
 ### **3.2 Data Store**
 
@@ -1455,7 +1455,7 @@ npm run dev
 
 - **Multi-platform support**: TikTok, Instagram, Reddit, YouTube
 - **Real-time processing**: Webhook-based and scheduled ingestion
-- **Deduplication**: Redis Bloom filters prevent duplicate processing
+- **Deduplication**: A Redis set prevents duplicate processing
 - **Rate limiting**: Intelligent quota management
 
 ### AI-Powered Scoring

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,8 +38,6 @@ See the blueprint environment variables section in `blueprints/DesignIdeaEngineC
 | `PAGERDUTY_ROUTING_KEY`              | Integration key for sending PagerDuty incidents                                   |
 | `ENABLE_PAGERDUTY`                   | Set to `true` to enable PagerDuty notifications                                   |
 | `SLA_ALERT_COOLDOWN_MINUTES`         | Minimum minutes between SLA alerts                                                |
-| `DEDUP_ERROR_RATE`                   | Probability of false positives in the Bloom filter                                |
-| `DEDUP_CAPACITY`                     | Estimated maximum number of entries in the Bloom filter                           |
 | `DEDUP_TTL`                          | Time-to-live in seconds for deduplication keys                                    |
 | `PUBLISHER_METRICS_INTERVAL_MINUTES` | Interval for fetching publisher metrics                                           |
 | `WEIGHT_UPDATE_INTERVAL_MINUTES`     | Interval for updating scoring weights                                             |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -17,11 +17,9 @@ Signals older than the configured `signal_retention_days` setting (default: 90 d
 
 ## Deduplication
 
-`signal_ingestion.dedup` uses a Redis Bloom filter to avoid processing duplicates.
-The filter is created on startup with the error rate specified by the
-`dedup_error_rate` setting (default: `0.01`).
-Entries remain for the number of seconds configured by `dedup_ttl` (default:
-`86400` seconds).
+`signal_ingestion.dedup` uses a Redis set to avoid processing duplicates.
+The set expires after the number of seconds configured by `dedup_ttl`
+(default: `86400` seconds).
 
 ## Compliance Steps
 


### PR DESCRIPTION
## Summary
- use Redis SET for duplicate key tracking
- drop bloom filter settings
- update docs for new dedup method
- adjust tests for Redis set

## Testing
- `make lint` *(fails: mypy errors)*
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687ff7e4ba9c8331a39a38cb0d4d6685