### PR TITLE
Reuse global httpx clients

### DIFF
--- a/scripts/benchmark_score.py
+++ b/scripts/benchmark_score.py
@@ -9,6 +9,24 @@ import os
 from time import perf_counter
 
 import httpx
+import atexit
+import asyncio
+
+_ASYNC_CLIENT: httpx.AsyncClient | None = None
+
+
+async def get_async_client() -> httpx.AsyncClient:
+    """Return a shared ``AsyncClient`` instance."""
+    global _ASYNC_CLIENT
+    if _ASYNC_CLIENT is None:
+        _ASYNC_CLIENT = httpx.AsyncClient()
+    return _ASYNC_CLIENT
+
+
+@atexit.register
+def _close_client() -> None:
+    if _ASYNC_CLIENT is not None:
+        asyncio.run(_ASYNC_CLIENT.aclose())
 
 
 async def _run(
@@ -30,11 +48,11 @@ async def main() -> tuple[float, float, int]:
         "engagement_rate": 1.0,
         "embedding": [0.1, 0.2],
     }
-    async with httpx.AsyncClient() as client:
-        # Warm up
-        await client.post(url, json=payload)
-        uncached = await _run(client, url, payload, runs)
-        cached = await _run(client, url, payload, runs)
+    client = await get_async_client()
+    # Warm up
+    await client.post(url, json=payload)
+    uncached = await _run(client, url, payload, runs)
+    cached = await _run(client, url, payload, runs)
     print(f"Uncached: {uncached:.2f}s for {runs} runs")
     print(f"Cached:   {cached:.2f}s for {runs} runs")
     return uncached, cached, runs


### PR DESCRIPTION
## Summary
- create module-level httpx.AsyncClient helpers
- reuse AsyncClient across orchestrator ops
- reuse AsyncClient in signal ingestion adapters
- reuse AsyncClient in monitoring service
- cache AsyncClient in benchmark script

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -n auto -W error -vv` *(fails: test_tracing_profiling.py::test_tracing_and_profiling[backend/monitoring/src-monitoring.main-fastapi] et al.)*
- `flake8 .` *(fails: numerous style violations)*
- `mypy backend --explicit-package-bases --exclude "tests"` *(errors: Awaitable object is not iterable, etc.)*
- `docformatter --check --recursive .`
- `pydocstyle .` *(fails: D202 No blank lines allowed after function docstring)*

------
https://chatgpt.com/codex/tasks/task_b_687ff7e43fd0833191f0904e2cff16e0