### PR TITLE
Maintain global httpx clients

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import itertools
 import os
 import asyncio
+import atexit
 from typing import Any, Iterable, Optional, cast
 
 from ..rate_limit import AdapterRateLimiter
@@ -12,6 +13,27 @@ from backend.shared.cache import async_get, async_set
 
 import httpx
 from backend.shared.http import DEFAULT_TIMEOUT
+
+_HTTP_CLIENTS: dict[str | None, httpx.AsyncClient] = {}
+
+
+async def get_http_client(proxy: str | None) -> httpx.AsyncClient:
+    """Return a cached HTTP client for ``proxy``."""
+    client = _HTTP_CLIENTS.get(proxy)
+    if client is None:
+        client = httpx.AsyncClient(proxy=cast(Any, proxy), timeout=DEFAULT_TIMEOUT)
+        _HTTP_CLIENTS[proxy] = client
+    return client
+
+
+@atexit.register
+def _close_clients() -> None:
+    async def _close_all() -> None:
+        for cli in _HTTP_CLIENTS.values():
+            await cli.aclose()
+        _HTTP_CLIENTS.clear()
+
+    asyncio.run(_close_all())
 
 
 class BaseAdapter:
@@ -77,21 +99,19 @@ class BaseAdapter:
 
         for attempt in range(self.retries):
             proxy = next(self._proxies_cycle)
-            async with httpx.AsyncClient(
-                proxy=cast(Any, proxy), timeout=DEFAULT_TIMEOUT
-            ) as client:
-                try:
-                    resp = await client.get(url, headers=req_headers or None)
-                    if resp.status_code == 304:
-                        return None
-                    if etag := resp.headers.get("ETag"):
-                        await async_set(etag_key, etag)
-                    resp.raise_for_status()
-                    return resp
-                except httpx.HTTPError:
-                    if attempt >= self.retries - 1:
-                        raise
-                    await asyncio.sleep(2**attempt)
+            client = await get_http_client(proxy)
+            try:
+                resp = await client.get(url, headers=req_headers or None)
+                if resp.status_code == 304:
+                    return None
+                if etag := resp.headers.get("ETag"):
+                    await async_set(etag_key, etag)
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPError:
+                if attempt >= self.retries - 1:
+                    raise
+                await asyncio.sleep(2**attempt)
 
         raise RuntimeError("Unreachable")
 

--- a/scripts/benchmark_score.py
+++ b/scripts/benchmark_score.py
@@ -9,6 +9,23 @@ import os
 from time import perf_counter
 
 import httpx
+import atexit
+
+_HTTP_CLIENT: httpx.AsyncClient | None = None
+
+
+async def get_http_client() -> httpx.AsyncClient:
+    """Return a shared HTTP client."""
+    global _HTTP_CLIENT
+    if _HTTP_CLIENT is None:
+        _HTTP_CLIENT = httpx.AsyncClient()
+    return _HTTP_CLIENT
+
+
+@atexit.register
+def _close_http_client() -> None:
+    if _HTTP_CLIENT is not None:
+        asyncio.run(_HTTP_CLIENT.aclose())
 
 
 async def _run(
@@ -30,11 +47,11 @@ async def main() -> tuple[float, float, int]:
         "engagement_rate": 1.0,
         "embedding": [0.1, 0.2],
     }
-    async with httpx.AsyncClient() as client:
-        # Warm up
-        await client.post(url, json=payload)
-        uncached = await _run(client, url, payload, runs)
-        cached = await _run(client, url, payload, runs)
+    client = await get_http_client()
+    # Warm up
+    await client.post(url, json=payload)
+    uncached = await _run(client, url, payload, runs)
+    cached = await _run(client, url, payload, runs)
     print(f"Uncached: {uncached:.2f}s for {runs} runs")
     print(f"Cached:   {cached:.2f}s for {runs} runs")
     return uncached, cached, runs


### PR DESCRIPTION
## Summary
- use shared AsyncClient in monitoring service
- manage http client pool per proxy in signal ingestion
- reuse orchestrator client for scoring and approval
- share AsyncClient in benchmarking script

## Testing
- `flake8 backend scripts/benchmark_score.py`
- `black backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/ops.py backend/signal-ingestion/src/signal_ingestion/adapters/base.py scripts/benchmark_score.py`
- `mypy backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/ops.py backend/signal-ingestion/src/signal_ingestion/adapters/base.py scripts/benchmark_score.py --ignore-missing-imports --follow-imports=skip` *(fails: Found 14 errors in 1 file)*

------
https://chatgpt.com/codex/tasks/task_b_687ffceeef708331ac17a98e2f88de3b