### PR TITLE
Refactor HTTP usage

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
@@ -9,9 +9,9 @@ from typing import Any, Iterable, Optional, cast
 from ..rate_limit import AdapterRateLimiter
 from ..settings import settings
 from backend.shared.cache import async_get, async_set
+from backend.shared.http import get_async_client
 
 import httpx
-from backend.shared.http import DEFAULT_TIMEOUT
 
 
 class BaseAdapter:
@@ -75,23 +75,25 @@ class BaseAdapter:
         if cached_etag:
             req_headers["If-None-Match"] = cached_etag
 
+        client = await get_async_client()
         for attempt in range(self.retries):
             proxy = next(self._proxies_cycle)
-            async with httpx.AsyncClient(
-                proxy=cast(Any, proxy), timeout=DEFAULT_TIMEOUT
-            ) as client:
-                try:
-                    resp = await client.get(url, headers=req_headers or None)
-                    if resp.status_code == 304:
-                        return None
-                    if etag := resp.headers.get("ETag"):
-                        await async_set(etag_key, etag)
-                    resp.raise_for_status()
-                    return resp
-                except httpx.HTTPError:
-                    if attempt >= self.retries - 1:
-                        raise
-                    await asyncio.sleep(2**attempt)
+            try:
+                resp = await client.get(
+                    url,
+                    headers=req_headers or None,
+                    proxies=cast(Any, proxy),
+                )
+                if resp.status_code == 304:
+                    return None
+                if etag := resp.headers.get("ETag"):
+                    await async_set(etag_key, etag)
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPError:
+                if attempt >= self.retries - 1:
+                    raise
+                await asyncio.sleep(2**attempt)
 
         raise RuntimeError("Unreachable")
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -51,6 +51,7 @@ HTTP Timeouts
 
 All services make outbound requests using ``httpx``. The recommended timeout
 for these calls is 10 seconds and is exposed as
-``backend.shared.http.DEFAULT_TIMEOUT``. Instantiate
-``httpx.AsyncClient`` with this timeout to ensure consistent behavior across
-services.
+``backend.shared.http.DEFAULT_TIMEOUT``. Use
+``backend.shared.http.get_async_client`` to obtain a shared client configured
+with this timeout and reused across tasks. This avoids per-request client
+creation and ensures consistent behavior.

--- a/scripts/benchmark_score.py
+++ b/scripts/benchmark_score.py
@@ -9,6 +9,7 @@ import os
 from time import perf_counter
 
 import httpx
+from backend.shared.http import get_async_client
 
 
 async def _run(
@@ -30,11 +31,11 @@ async def main() -> tuple[float, float, int]:
         "engagement_rate": 1.0,
         "embedding": [0.1, 0.2],
     }
-    async with httpx.AsyncClient() as client:
-        # Warm up
-        await client.post(url, json=payload)
-        uncached = await _run(client, url, payload, runs)
-        cached = await _run(client, url, payload, runs)
+    client = await get_async_client()
+    # Warm up
+    await client.post(url, json=payload)
+    uncached = await _run(client, url, payload, runs)
+    cached = await _run(client, url, payload, runs)
     print(f"Uncached: {uncached:.2f}s for {runs} runs")
     print(f"Cached:   {cached:.2f}s for {runs} runs")
     return uncached, cached, runs


### PR DESCRIPTION
## Summary
- share async client in `backend.shared.http`
- use shared async HTTP client in adapters, monitoring, orchestrator and benchmark script
- document reuse in architecture docs

## Testing
- `flake8 backend/shared/http.py backend/signal-ingestion/src/signal_ingestion/adapters/base.py backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/ops.py scripts/benchmark_score.py`
- `mypy backend/shared/http.py --config-file backend/mypy.ini` *(fails: Class cannot subclass "BaseSettings")*
- `pytest -k '' -q` *(fails: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_b_687fffe576548331a30944fd39d5a45b