### PR TITLE
Introduce ServiceName enum

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -25,7 +25,7 @@ from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.responses import gzip_iter
 from backend.shared.logging import configure_logging
-from backend.shared import add_error_handlers, configure_sentry
+from backend.shared import ServiceName, add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -33,7 +33,7 @@ from fastapi.middleware.cors import CORSMiddleware
 configure_logging()
 logger = logging.getLogger(__name__)
 
-SERVICE_NAME = os.getenv("SERVICE_NAME", "analytics")
+SERVICE_NAME = os.getenv("SERVICE_NAME", ServiceName.ANALYTICS.value)
 app = FastAPI(title="Analytics Service")
 app.add_middleware(
     CORSMiddleware,

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -21,7 +21,7 @@ from backend.shared.security import add_security_headers, require_status_api_key
 from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared.db import run_migrations_if_needed
-from backend.shared import add_error_handlers, configure_sentry
+from backend.shared import ServiceName, add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from .rate_limiter import UserRateLimiter
 from .settings import settings
@@ -57,7 +57,7 @@ tags_metadata = [
     {"name": "Privacy", "description": "Handle deletion requests and PII purging."},
 ]
 
-SERVICE_NAME = os.getenv("SERVICE_NAME", "api-gateway")
+SERVICE_NAME = os.getenv("SERVICE_NAME", ServiceName.API_GATEWAY.value)
 app = FastAPI(title="API Gateway", openapi_tags=tags_metadata)
 app.add_middleware(
     CORSMiddleware,

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from backend.shared.logging import configure_logging
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
-from backend.shared import add_error_handlers, configure_sentry
+from backend.shared import ServiceName, add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
@@ -32,7 +32,7 @@ from .celery_app import app as celery_app
 configure_logging()
 logger = logging.getLogger(__name__)
 
-SERVICE_NAME = os.getenv("SERVICE_NAME", "mockup-generation")
+SERVICE_NAME = os.getenv("SERVICE_NAME", ServiceName.MOCKUP_GENERATION.value)
 app = FastAPI(title="Mockup Generation Service")
 app.add_middleware(
     CORSMiddleware,

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -22,7 +22,7 @@ from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
-from backend.shared import add_error_handlers, configure_sentry
+from backend.shared import ServiceName, add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
 from .metrics import MetricsAnalyzer, ResourceMetric
 from .storage import MetricsStore
@@ -31,7 +31,7 @@ from .storage import MetricsStore
 configure_logging()
 logger = logging.getLogger(__name__)
 
-SERVICE_NAME = os.getenv("SERVICE_NAME", "optimization")
+SERVICE_NAME = os.getenv("SERVICE_NAME", ServiceName.OPTIMIZATION.value)
 app = FastAPI(title="Optimization Service")
 app.add_middleware(
     CORSMiddleware,

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -11,6 +11,7 @@ from .currency import convert_price, start_rate_updater
 from .metrics import register_metrics
 from .responses import cache_header, json_cached, gzip_iter
 from .config import settings
+from .service_names import ServiceName
 from .security import add_security_headers
 from .clip import load_clip, open_clip, torch
 
@@ -34,4 +35,5 @@ __all__ = [
     "load_clip",
     "open_clip",
     "torch",
+    "ServiceName",
 ]

--- a/backend/shared/service_names.py
+++ b/backend/shared/service_names.py
@@ -1,0 +1,20 @@
+"""Enumerate backend service names."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ServiceName(str, Enum):
+    """Names of backend services."""
+
+    API_GATEWAY = "api-gateway"
+    ANALYTICS = "analytics"
+    FEEDBACK_LOOP = "feedback-loop"
+    MARKETPLACE_PUBLISHER = "marketplace-publisher"
+    MOCKUP_GENERATION = "mockup-generation"
+    MONITORING = "monitoring"
+    OPTIMIZATION = "optimization"
+    ORCHESTRATOR = "orchestrator"
+    SCORING_ENGINE = "scoring-engine"
+    SIGNAL_INGESTION = "signal-ingestion"


### PR DESCRIPTION
## Summary
- avoid typos in service names by adding a `ServiceName` enum
- use `ServiceName` when reading `SERVICE_NAME` environment variable

## Testing
- `make lint` *(fails: mypy reported 254 errors)*
- `python -m pytest -n auto -W error -vv` *(fails: 85 failed, 69 passed, 1 skipped, 204 errors)*

------
https://chatgpt.com/codex/tasks/task_b_687fffe6e8888331a3d67931ade8817d