### PR TITLE
Add quickstart env templates

### DIFF
--- a/.env.quickstart.example
+++ b/.env.quickstart.example
@@ -1,0 +1,6 @@
+# Minimal environment variables for local development
+DATABASE_URL=sqlite:///desainz.db
+REDIS_URL=redis://localhost:6379/0
+SECRET_KEY=dev_secret_key
+LOG_LEVEL=INFO
+

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ Execute `scripts/analyze_query_plans.py` periodically to inspect query plans and
 identify missing indexes.
 
 ## Configuration and Secrets
-Local development uses dotenv files. Copy the root `.env.example` to `.env` and the `.env.example` in **every** `backend` service directory to their respective `.env` files. The services automatically load these variables using Pydantic `BaseSettings`.
+Local development uses dotenv files. For a quick start copy `.env.quickstart.example` to `.env`. This file contains only the variables required for running the stack with default local services. If you need the full configuration copy the root `.env.example` to `.env` and the `.env.example` in **every** `backend` service directory to their respective `.env` files. The services automatically load these variables using Pydantic `BaseSettings`.
 For convenience you can run:
 
 ```bash
-for f in backend/*/.env.example; do cp "$f" "$(dirname "$f")/.env"; done
+for f in backend/*/.env.quickstart.example; do cp "$f" "$(dirname "$f")/.env"; done
 ```
 
 In production, secrets are stored in HashiCorp Vault or AWS Secrets Manager and surfaced to the containers via Docker secrets or Kubernetes Secrets. The settings modules read from `/run/secrets` if present. Do not rely on `.env` files in production.

--- a/backend/analytics/.env.quickstart.example
+++ b/backend/analytics/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for analytics local run
+DATABASE_URL=sqlite:///analytics.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/api-gateway/.env.quickstart.example
+++ b/backend/api-gateway/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for api-gateway local run
+DATABASE_URL=sqlite:///api-gateway.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/feedback-loop/.env.quickstart.example
+++ b/backend/feedback-loop/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for feedback-loop local run
+DATABASE_URL=sqlite:///feedback-loop.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/marketplace-publisher/.env.quickstart.example
+++ b/backend/marketplace-publisher/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for marketplace-publisher local run
+DATABASE_URL=sqlite:///marketplace-publisher.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/mockup-generation/.env.quickstart.example
+++ b/backend/mockup-generation/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for mockup-generation local run
+DATABASE_URL=sqlite:///mockup-generation.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/monitoring/.env.quickstart.example
+++ b/backend/monitoring/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for monitoring local run
+DATABASE_URL=sqlite:///monitoring.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/optimization/.env.quickstart.example
+++ b/backend/optimization/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for optimization local run
+DATABASE_URL=sqlite:///optimization.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/orchestrator/.env.quickstart.example
+++ b/backend/orchestrator/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for orchestrator local run
+DATABASE_URL=sqlite:///orchestrator.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/scoring-engine/.env.quickstart.example
+++ b/backend/scoring-engine/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for scoring-engine local run
+DATABASE_URL=sqlite:///scoring-engine.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/service-template/.env.quickstart.example
+++ b/backend/service-template/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for service-template local run
+DATABASE_URL=sqlite:///service-template.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+

--- a/backend/signal-ingestion/.env.quickstart.example
+++ b/backend/signal-ingestion/.env.quickstart.example
@@ -1,0 +1,5 @@
+# Minimal variables for signal-ingestion local run
+DATABASE_URL=sqlite:///signal-ingestion.db
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+


### PR DESCRIPTION
## Summary
- document quickstart env setup
- provide `.env.quickstart.example` at repo root and for each backend service

## Testing
- `./scripts/setup_codex.sh` *(fails: `npm ci` lock file issues)*
- `pytest -k "" -q` *(fails: ModuleNotFoundError and other errors)*
- `make lint` *(fails: mypy type errors)*

------
https://chatgpt.com/codex/tasks/task_b_687fffef33bc833189bcb3ba486caf66