### PR TITLE
Implement batched Prometheus metrics

### DIFF
--- a/backend/shared/metrics.py
+++ b/backend/shared/metrics.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from time import perf_counter
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, DefaultDict
+from collections import defaultdict
+import re
 
 from fastapi import FastAPI, Request, Response
 
@@ -28,24 +30,57 @@ REQUEST_LATENCY = Histogram(
 )
 
 
+_BUFFER: DefaultDict[tuple[str, str], list[float]] = defaultdict(list)
+_BATCH_SIZE = 100
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _normalize_path(path: str) -> str:
+    """Return ``path`` with dynamic segments replaced by ``:id``."""
+    segments = []
+    for part in path.strip("/").split("/"):
+        if part.isdigit() or _UUID_RE.match(part):
+            segments.append(":id")
+        else:
+            segments.append(part)
+    return "/" + "/".join(segments)
+
+
+def _flush_metrics() -> None:
+    """Update Prometheus metrics and clear in-memory buffers."""
+    for (method, endpoint), durations in list(_BUFFER.items()):
+        REQUEST_COUNTER.labels(method, endpoint).inc(len(durations))
+        for dur in durations:
+            REQUEST_LATENCY.labels(method, endpoint).observe(dur)
+    _BUFFER.clear()
+
+
 def register_metrics(app: FastAPI) -> None:
     """Attach metrics middleware and /metrics endpoint to ``app``."""
 
-    @app.middleware("http")
+    @app.middleware("http")  # type: ignore[misc]
     async def _record_metrics(
         request: Request,
         call_next: Callable[[Request], Coroutine[None, None, Response]],
     ) -> Response:
+        """Store request duration in the in-memory buffer."""
         start = perf_counter()
         response = await call_next(request)
         duration = perf_counter() - start
-        REQUEST_COUNTER.labels(request.method, request.url.path).inc()
-        REQUEST_LATENCY.labels(request.method, request.url.path).observe(duration)
+        key = (request.method, _normalize_path(request.url.path))
+        _BUFFER[key].append(duration)
+        if len(_BUFFER) >= _BATCH_SIZE:
+            _flush_metrics()
         return response
 
-    @app.get("/metrics")
+    @app.get("/metrics")  # type: ignore[misc]
     async def metrics() -> Response:
         """Return Prometheus metrics with aggressive caching."""
+        _flush_metrics()
         data = generate_latest()
         headers = cache_header(ttl=METRICS_CACHE_TTL)
         return Response(content=data, media_type=CONTENT_TYPE_LATEST, headers=headers)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -82,6 +82,10 @@ scrape_configs:
       - targets: ['orchestrator:3000']
 ```
 
+Prometheus metrics are aggregated in memory. Path segments matching numeric or
+UUID-like patterns are replaced with `:id` before counters are updated. This
+keeps label cardinality low even for dynamic endpoints.
+
 ## PagerDuty Alerts
 
 Set `PAGERDUTY_ROUTING_KEY` and `ENABLE_PAGERDUTY=true` in the environment to enable alerting. The monitoring service triggers alerts when the average publish latency breaches the configured SLA and when listing synchronization detects issues.


### PR DESCRIPTION
## Summary
- batch request metrics before flushing to Prometheus
- replace dynamic path segments so metrics have lower label cardinality
- document metrics aggregation approach

## Testing
- `flake8 backend/shared/metrics.py`
- `mypy backend/shared/metrics.py --follow-imports=skip`
- `pydocstyle backend/shared/metrics.py`
- `interrogate backend/shared/metrics.py`
- `docformatter --check backend/shared/metrics.py`
- `pytest tests/test_metrics_endpoints.py::test_metrics_endpoint -W error -vv` *(fails: ImportError: attempted relative import with no known parent package)*
- `npm test` *(fails: Cannot find module '@testing-library/dom')*
- `npm run test:e2e` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_687ffff5b5d88331b840964af8e48ea2