### PR TITLE
Use executemany for latency metrics

### DIFF
--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -146,17 +146,19 @@ def _record_latencies() -> Iterable[float]:
     with session_scope() as session:
         rows = session.execute(stmt).all()
     latencies: list[float] = []
+    metrics: list[PublishLatencyMetric] = []
     for idea_id, signal_time, listing_time in rows:
         seconds = (listing_time - signal_time).total_seconds()
         latencies.append(seconds)
         SIGNAL_TO_PUBLISH_SECONDS.observe(seconds)
-        metrics_store.add_latency(
+        metrics.append(
             PublishLatencyMetric(
                 idea_id=idea_id,
                 timestamp=listing_time,
                 latency_seconds=seconds,
             )
         )
+    metrics_store.add_latencies(metrics)
     return latencies
 
 


### PR DESCRIPTION
## Summary
- batch insert latency metrics with `executemany`
- update `_record_latencies` to use new batch insert
- adjust SLA test for updated API

## Testing
- `flake8 backend/monitoring/src/monitoring/metrics_store.py backend/monitoring/src/monitoring/main.py tests/test_sla.py`
- `mypy --ignore-missing-imports backend/monitoring/src/monitoring/metrics_store.py backend/monitoring/src/monitoring/main.py tests/test_sla.py` *(fails: various errors)*
- `pytest -n auto -W error -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', Docker errors)*

------
https://chatgpt.com/codex/tasks/task_b_687fffdf94c483318aeed984b32103fa