### PR TITLE
Migrate analytics service to AsyncSession

### DIFF
--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -9,7 +9,7 @@ from .feature_flags import initialize as init_feature_flags, is_enabled
 from .errors import add_error_handlers, add_flask_error_handlers
 from .currency import convert_price, start_rate_updater
 from .metrics import register_metrics
-from .responses import cache_header, json_cached, gzip_iter
+from .responses import cache_header, json_cached, gzip_iter, gzip_aiter
 from .config import settings
 from .security import add_security_headers
 from .clip import load_clip, open_clip, torch
@@ -29,6 +29,7 @@ __all__ = [
     "cache_header",
     "json_cached",
     "gzip_iter",
+    "gzip_aiter",
     "settings",
     "add_security_headers",
     "load_clip",

--- a/backend/shared/responses.py
+++ b/backend/shared/responses.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastapi.responses import JSONResponse, Response
 import zlib
-from typing import Iterable
+from typing import Iterable, AsyncIterator
 
 CACHE_TTL_SECONDS = 60
 
@@ -25,6 +25,18 @@ def gzip_iter(text_iter: Iterable[str]) -> Iterable[bytes]:
     """Yield gzip-compressed bytes from an iterable of strings."""
     compressor = zlib.compressobj(wbits=31)
     for chunk in text_iter:
+        data = compressor.compress(chunk.encode())
+        if data:
+            yield data
+    data = compressor.flush()
+    if data:
+        yield data
+
+
+async def gzip_aiter(text_iter: AsyncIterator[str]) -> AsyncIterator[bytes]:
+    """Yield gzip-compressed bytes from an async iterator of strings."""
+    compressor = zlib.compressobj(wbits=31)
+    async for chunk in text_iter:
         data = compressor.compress(chunk.encode())
         if data:
             yield data

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from flask import Flask
 from typing import Any, cast
+import os
 from opentelemetry import trace
 from pydantic import HttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -18,7 +19,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 
-class TraceSettings(BaseSettings):
+class TraceSettings(BaseSettings):  # type: ignore[misc]
     """Environment settings controlling tracing behaviour."""
 
     model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
@@ -33,7 +34,7 @@ trace_settings = TraceSettings()
 
 def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     """Configure basic tracing for ``app``."""
-    if trace_settings.sdk_disabled:
+    if trace_settings.sdk_disabled or os.getenv("OTEL_SDK_DISABLED") in {"1", "true", "True"}:
         return
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
         OTLPSpanExporter as OTLPGrpcSpanExporter,


### PR DESCRIPTION
## Summary
- switch analytics service to AsyncSession using asyncpg
- stream results via new `gzip_aiter` helper
- expose async gzip helper in shared utilities
- allow tracing to be disabled via `OTEL_SDK_DISABLED`

## Testing
- `python -m mypy --follow-imports=skip backend/analytics/api.py backend/shared/tracing.py`
- `python -m pydocstyle backend/shared/tracing.py backend/analytics/api.py`
- `python -m docformatter --check backend/shared/tracing.py backend/analytics/api.py`
- `python -m flake8 backend/shared/tracing.py backend/analytics/api.py`
- `python -m pytest tests/test_analytics.py -W error`

------
https://chatgpt.com/codex/tasks/task_b_687fffdf0968833199f8d8c624385f7c