### PR TITLE
Replace timezone.now calls

### DIFF
--- a/backend/feedback-loop/feedback_loop/ab_testing.py
+++ b/backend/feedback-loop/feedback_loop/ab_testing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from contextlib import contextmanager
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from typing import Iterator, Mapping
 
 from sqlalchemy import (
@@ -34,7 +34,7 @@ class TestResult(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc)
+        DateTime, default=lambda: datetime.utcnow().replace(tzinfo=UTC)
     )
     variant: Mapped[str] = mapped_column(String(1))
     success: Mapped[bool] = mapped_column(Boolean)

--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Iterable, Mapping
 
 import requests
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def ingest_metrics(metrics: Iterable[Mapping[str, float]]) -> list[dict[str, float]]:
     """Persist incoming metrics and return them as a list of dictionaries."""
     metrics_list = [dict(m) for m in metrics]
-    now = datetime.now(timezone.utc)
+    now = datetime.utcnow().replace(tzinfo=UTC)
     for entry in metrics_list:
         entry.setdefault("timestamp", now)
     logger.info("ingested %s metrics", len(metrics_list))
@@ -64,7 +64,7 @@ def store_marketplace_metrics(metrics: Iterable[Mapping[str, float]]) -> None:
     rows = [
         models.MarketplacePerformanceMetric(
             listing_id=int(m["listing_id"]),
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.utcnow().replace(tzinfo=UTC),
             views=int(m["views"]),
             favorites=int(m["favorites"]),
             orders=int(m["orders"]),

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import asyncio
 import psutil
 import logging
@@ -89,7 +89,7 @@ scheduler = AsyncIOScheduler()
 def record_resource_usage(target_store: MetricsStore = store) -> None:
     """Capture current CPU, memory and disk usage and store the metric."""
     metric = ResourceMetric(
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow().replace(tzinfo=UTC),
         cpu_percent=psutil.cpu_percent(),
         memory_mb=psutil.virtual_memory().used / (1024 * 1024),
         disk_usage_mb=psutil.disk_usage("/").used / (1024 * 1024),

--- a/backend/optimization/tests/test_api_routes.py
+++ b/backend/optimization/tests/test_api_routes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
 
@@ -18,7 +18,7 @@ def test_recommendation_routes(tmp_path: Path) -> None:
     client = TestClient(opt_api.app)
 
     metric = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "cpu_percent": 85.0,
         "memory_mb": 2048.0,
         "disk_usage_mb": 4096.0,

--- a/backend/optimization/tests/test_metrics_analyzer.py
+++ b/backend/optimization/tests/test_metrics_analyzer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from backend.optimization.metrics import MetricsAnalyzer, ResourceMetric
 
@@ -11,7 +11,7 @@ def test_average_cpu_memory() -> None:
     """Validate average CPU and memory calculations."""
     metrics = [
         ResourceMetric(
-            timestamp=datetime.now(timezone.utc) - timedelta(minutes=i),
+            timestamp=datetime.utcnow().replace(tzinfo=UTC) - timedelta(minutes=i),
             cpu_percent=10 * i,
             memory_mb=256.0,
             disk_usage_mb=1024.0,
@@ -28,7 +28,7 @@ def test_top_recommendations() -> None:
     """Ensure prioritized recommendations are returned."""
     metrics = [
         ResourceMetric(
-            timestamp=datetime.now(timezone.utc) - timedelta(minutes=i),
+            timestamp=datetime.utcnow().replace(tzinfo=UTC) - timedelta(minutes=i),
             cpu_percent=90,
             memory_mb=2048,
             disk_usage_mb=12 * 1024.0,
@@ -45,7 +45,7 @@ def test_top_recommendations() -> None:
 
 def test_trend_calculation() -> None:
     """Verify trend slopes for CPU, memory and disk."""
-    now = datetime.now(timezone.utc)
+    now = datetime.utcnow().replace(tzinfo=UTC)
     metrics = [
         ResourceMetric(
             timestamp=now - timedelta(minutes=5 - i),
@@ -63,7 +63,7 @@ def test_trend_calculation() -> None:
 
 def test_recommendations_for_high_usage() -> None:
     """Recommendations should mention scaling when usage is high."""
-    now = datetime.now(timezone.utc)
+    now = datetime.utcnow().replace(tzinfo=UTC)
     metrics = [
         ResourceMetric(
             timestamp=now - timedelta(minutes=20 - i),

--- a/backend/optimization/tests/test_metrics_store.py
+++ b/backend/optimization/tests/test_metrics_store.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from backend.optimization.metrics import ResourceMetric
@@ -13,7 +13,7 @@ def test_sqlite_metrics_store(tmp_path: Path) -> None:
     """Verify metrics are persisted in a temporary SQLite database."""
     store = MetricsStore(f"sqlite:///{tmp_path/'metrics.db'}")
     metric = ResourceMetric(
-        datetime.now(timezone.utc), 50.0, 128.0, disk_usage_mb=256.0
+        datetime.utcnow().replace(tzinfo=UTC), 50.0, 128.0, disk_usage_mb=256.0
     )
     store.add_metric(metric)
     metrics = store.get_metrics()

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import asyncio
@@ -124,7 +124,7 @@ def score_signals(  # type: ignore[no-untyped-def]
 
     async def _score(client: httpx.AsyncClient) -> float:
         payload = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
             "engagement_rate": 0.0,
             "embedding": [0.0],
         }

--- a/backend/scoring-engine/scoring_engine/scoring.py
+++ b/backend/scoring-engine/scoring_engine/scoring.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Iterable
 
 from numpy.typing import NDArray
@@ -45,7 +45,7 @@ _SCALER_BUF: NDArray[np.floating] = np.empty((2, 1), dtype=float)
 
 def compute_freshness(timestamp: datetime, trending_factor: float = 1.0) -> float:
     """Return freshness score weighted by ``trending_factor``."""
-    hours = (datetime.now(timezone.utc) - timestamp).total_seconds() / 3600
+    hours = (datetime.utcnow().replace(tzinfo=UTC) - timestamp).total_seconds() / 3600
     base = 1 / (1 + math.exp(hours / 24))
     return base * trending_factor
 

--- a/backend/scoring-engine/tests/test_cache.py
+++ b/backend/scoring-engine/tests/test_cache.py
@@ -2,7 +2,7 @@
 
 # mypy: ignore-errors
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import importlib
 
 from fastapi.testclient import TestClient
@@ -30,7 +30,7 @@ def test_score_endpoint_caches() -> None:
         seasonality=1.0,
     )
     payload = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "engagement_rate": 1.0,
         "embedding": [1.0, 0.0],
         "metadata": {"a": 1.0},

--- a/backend/scoring-engine/tests/test_metrics.py
+++ b/backend/scoring-engine/tests/test_metrics.py
@@ -2,7 +2,7 @@
 
 # mypy: ignore-errors
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import importlib
 
 from fastapi.testclient import TestClient
@@ -39,7 +39,7 @@ def test_metrics_endpoint_counts_hits_and_misses() -> None:
         seasonality=1.0,
     )
     payload = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "engagement_rate": 1.0,
         "embedding": [1.0, 0.0],
     }

--- a/backend/scoring-engine/tests/test_score_metrics_store.py
+++ b/backend/scoring-engine/tests/test_score_metrics_store.py
@@ -2,7 +2,7 @@
 
 # mypy: ignore-errors
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 import importlib
 import sqlite3
@@ -43,7 +43,7 @@ def test_score_metrics_written_once(monkeypatch, tmp_path: Path) -> None:
         seasonality=1.0,
     )
     payload = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "engagement_rate": 1.0,
         "embedding": [1.0, 0.0],
     }

--- a/backend/scoring-engine/tests/test_scoring.py
+++ b/backend/scoring-engine/tests/test_scoring.py
@@ -2,7 +2,7 @@
 
 # mypy: ignore-errors
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import numpy as np
 
@@ -24,7 +24,7 @@ def test_calculate_score_simple(tmp_path, monkeypatch):
     )
     signal = Signal(
         source="src",
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow().replace(tzinfo=UTC),
         engagement_rate=1.0,
         embedding=[1.0, 0.0],
         metadata={"a": 1.0, "b": 0.0},
@@ -59,7 +59,7 @@ def test_scoring_uses_db_centroid(tmp_path) -> None:
     compute_and_store_centroids()
     signal = Signal(
         source="src",
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow().replace(tzinfo=UTC),
         engagement_rate=0.0,
         embedding=dim_vec1,
         metadata={},

--- a/backend/signal-ingestion/src/signal_ingestion/retention.py
+++ b/backend/signal-ingestion/src/signal_ingestion/retention.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +12,6 @@ from .models import Signal
 
 async def purge_old_signals(session: AsyncSession, days: int) -> None:
     """Delete ``Signal`` rows older than ``days`` days."""
-    threshold = datetime.now(timezone.utc) - timedelta(days=days)
+    threshold = datetime.utcnow().replace(tzinfo=UTC) - timedelta(days=days)
     await session.execute(delete(Signal).where(Signal.timestamp < threshold))
     await session.commit()

--- a/backend/signal-ingestion/tests/test_retention.py
+++ b/backend/signal-ingestion/tests/test_retention.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
@@ -22,8 +22,8 @@ async def test_purge_old_signals() -> None:
     await database.init_db()
 
     async with database.SessionLocal() as session:
-        old_ts = datetime.now(timezone.utc) - timedelta(days=100)
-        new_ts = datetime.now(timezone.utc)
+        old_ts = datetime.utcnow().replace(tzinfo=UTC) - timedelta(days=100)
+        new_ts = datetime.utcnow().replace(tzinfo=UTC)
         session.add_all(
             [
                 Signal(

--- a/scripts/benchmark_score.py
+++ b/scripts/benchmark_score.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import os
 from time import perf_counter
 
@@ -26,7 +26,7 @@ async def main() -> tuple[float, float, int]:
     url = os.environ.get("SCORING_URL", "http://localhost:5002/score")
     runs = int(os.environ.get("RUNS", "100"))
     payload = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "engagement_rate": 1.0,
         "embedding": [0.1, 0.2],
     }

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import List
 
@@ -36,7 +36,7 @@ def score(engagement_rate: float, embedding: List[float]) -> None:
 
     signal = Signal(
         source="cli",
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow().replace(tzinfo=UTC),
         engagement_rate=engagement_rate,
         embedding=embedding,
         metadata={},

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Iterable
 import logging
 import tracemalloc
@@ -27,7 +27,7 @@ def fetch_overview(url: str) -> dict[str, float]:
 def submit_metric(opt_url: str, metric: dict[str, float]) -> None:
     """Send a metric to the optimization service."""
     payload = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "cpu_percent": metric["cpu_percent"],
         "memory_mb": metric["memory_mb"],
     }

--- a/scripts/daily_summary.py
+++ b/scripts/daily_summary.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Callable, ContextManager, Mapping
 
 from sqlalchemy import func, select
@@ -87,7 +87,7 @@ async def generate_daily_summary(
     The summary is persisted as JSON to ``output_file`` or to the path
     specified by the ``DAILY_SUMMARY_FILE`` environment variable.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.utcnow().replace(tzinfo=UTC)
     since = now - timedelta(days=1)
 
     with session_provider() as session:

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -137,7 +137,7 @@ async def test_full_flow(
     monkeypatch.setattr(weight_repository, "update_weights", lambda **k: None)
     sig = scoring.Signal(
         source="global",
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow().replace(tzinfo=UTC),
         engagement_rate=1.0,
         embedding=[0.1, 0.2],
         metadata={},
@@ -159,7 +159,7 @@ async def test_full_flow(
     )
     client = TestClient(opt_api.app)
     metric = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "cpu_percent": 10,
         "memory_mb": 100,
     }

--- a/tests/integration/test_pipeline_metrics.py
+++ b/tests/integration/test_pipeline_metrics.py
@@ -33,7 +33,7 @@ kafka_schema.SchemaRegistryClient.fetch = MagicMock(return_value={})  # type: ig
 
 import psutil  # noqa: E402
 import time  # noqa: E402
-from datetime import datetime, timezone  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
 
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
@@ -90,7 +90,7 @@ async def test_pipeline_with_metrics(
                     source=adapter.__class__.__name__,
                     content=str(row),
                     content_hash=f"{adapter.__class__.__name__}:{row['id']}",
-                    timestamp=datetime.now(timezone.utc),
+                    timestamp=datetime.utcnow().replace(tzinfo=UTC),
                     embedding=[0.0, 0.0],
                 )
                 session.add(signal)
@@ -103,7 +103,7 @@ async def test_pipeline_with_metrics(
     monkeypatch.setattr(
         models,
         "datetime",
-        SimpleNamespace(utcnow=lambda: datetime.now(timezone.utc)),
+        SimpleNamespace(utcnow=lambda: datetime.utcnow().replace(tzinfo=UTC)),
     )
 
     sent: list[dict] = []
@@ -173,7 +173,7 @@ async def test_pipeline_with_metrics(
     monkeypatch.setattr(opt_api, "store", MetricsStore(str(tmp_path / "metrics.db")))
     client = TestClient(opt_api.app)
     metric = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "cpu_percent": 10,
         "memory_mb": 100,
     }

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -91,7 +91,7 @@ async def test_end_to_end(
     )
     sig = scoring.Signal(
         source="global",
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow().replace(tzinfo=UTC),
         engagement_rate=1.0,
         embedding=[0.1, 0.2],
         metadata={},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "optimization")
 )  # noqa: E402
 
-from datetime import datetime, timezone  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
 
 from fastapi.testclient import TestClient  # noqa: E402
 
@@ -20,7 +20,7 @@ client = TestClient(app)
 def test_add_metric_and_get_optimizations() -> None:
     """Ensure metrics endpoint stores data and returns suggestions."""
     metric = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "cpu_percent": 90,
         "memory_mb": 2048,
     }

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 import sys
 
@@ -60,7 +60,7 @@ def _fake_load(self: MockupGenerator) -> None:  # noqa: D401 - short helper
 
 def _worker(client, gen: MockupGenerator, tmp: Path, idx: int) -> None:
     payload = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.utcnow().replace(tzinfo=UTC).isoformat(),
         "engagement_rate": 1.0,
         "embedding": [1.0, 0.0],
         "metadata": {},

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,6 @@
 """Tests for metrics analysis utilities."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from backend.optimization.metrics import MetricsAnalyzer, ResourceMetric
 
@@ -9,7 +9,7 @@ def test_average_cpu_memory() -> None:
     """Validate average calculations for CPU and memory."""
     metrics = [
         ResourceMetric(
-            datetime.now(timezone.utc) - timedelta(minutes=i),
+            datetime.utcnow().replace(tzinfo=UTC) - timedelta(minutes=i),
             50 + i,
             512,
             disk_usage_mb=1024.0,
@@ -25,7 +25,7 @@ def test_top_recommendations() -> None:
     """Ensure top recommendations are returned in priority order."""
     metrics = [
         ResourceMetric(
-            datetime.now(timezone.utc) - timedelta(minutes=i),
+            datetime.utcnow().replace(tzinfo=UTC) - timedelta(minutes=i),
             90,
             2048,
             disk_usage_mb=11 * 1024.0,
@@ -41,7 +41,7 @@ def test_top_recommendations() -> None:
 
 def test_trend_methods() -> None:
     """Check that trend utilities return positive slopes."""
-    now = datetime.now(timezone.utc)
+    now = datetime.utcnow().replace(tzinfo=UTC)
     metrics = [
         ResourceMetric(
             now - timedelta(minutes=5 - i),

--- a/tests/test_resource_metrics_store.py
+++ b/tests/test_resource_metrics_store.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -24,7 +24,7 @@ def test_add_and_get_metrics(use_postgres: bool, tmp_path: Path, postgresql) -> 
         store = MetricsStore(postgresql.info.dsn)
 
     metric = ResourceMetric(
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow().replace(tzinfo=UTC),
         cpu_percent=1.0,
         memory_mb=2.0,
         disk_usage_mb=3.0,


### PR DESCRIPTION
## Summary
- use `datetime.utcnow().replace(tzinfo=UTC)` across the codebase instead of `datetime.now(timezone.utc)`
- update tests accordingly
- format with Black

## Testing
- `flake8`
- `mypy backend scripts --exclude tests` *(failed: missing stubs and other type errors)*
- `pytest -q -W error` *(failed: 103 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687ffffb8d508331b31e6fda149cc143