### PR TITLE
Implement shared async HTTP client

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/clients.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/clients.py
@@ -9,8 +9,7 @@ import gzip
 import os
 import requests
 import httpx
-import atexit
-from backend.shared.http import request_with_retry
+from backend.shared.http import request_with_retry, get_async_http_client
 from requests_oauthlib import OAuth2Session
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
@@ -29,23 +28,9 @@ from .db import (
 from . import rules
 
 
-_async_client: httpx.AsyncClient | None = None
-
-
 async def get_async_client() -> httpx.AsyncClient:
     """Return a shared ``AsyncClient`` for marketplace requests."""
-    global _async_client
-    if _async_client is None:
-        _async_client = httpx.AsyncClient(timeout=30)
-    return _async_client
-
-
-@atexit.register
-def _close_client() -> None:
-    if _async_client is not None:
-        import asyncio
-
-        asyncio.run(_async_client.aclose())
+    return await get_async_http_client(timeout=httpx.Timeout(30))
 
 
 class BaseClient:

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -51,6 +51,6 @@ HTTP Timeouts
 
 All services make outbound requests using ``httpx``. The recommended timeout
 for these calls is 10 seconds and is exposed as
-``backend.shared.http.DEFAULT_TIMEOUT``. Instantiate
-``httpx.AsyncClient`` with this timeout to ensure consistent behavior across
-services.
+``backend.shared.http.DEFAULT_TIMEOUT``. Use
+``backend.shared.http.get_async_http_client()`` to obtain a shared
+``httpx.AsyncClient`` instance configured with this timeout.

--- a/scripts/benchmark_score.py
+++ b/scripts/benchmark_score.py
@@ -9,23 +9,12 @@ import os
 from time import perf_counter
 
 import httpx
-import atexit
-
-_HTTP_CLIENT: httpx.AsyncClient | None = None
+from backend.shared.http import get_async_http_client
 
 
 async def get_http_client() -> httpx.AsyncClient:
     """Return a shared HTTP client."""
-    global _HTTP_CLIENT
-    if _HTTP_CLIENT is None:
-        _HTTP_CLIENT = httpx.AsyncClient()
-    return _HTTP_CLIENT
-
-
-@atexit.register
-def _close_http_client() -> None:
-    if _HTTP_CLIENT is not None:
-        asyncio.run(_HTTP_CLIENT.aclose())
+    return await get_async_http_client()
 
 
 async def _run(


### PR DESCRIPTION
## Summary
- centralize async client logic in backend.shared.http
- use shared async http client throughout services
- document new client helper

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*
- `pytest -n auto -W error -vv` *(fails: 84 failed, 96 passed, 1 skipped, 197 errors)*
- `flake8`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: Found 191 errors)*
- `pydocstyle`
- `docformatter --check --recursive .`
- `interrogate backend` *(fails: RESULT: FAILED (minimum: 100.0%, actual: 80.3%))*

------
https://chatgpt.com/codex/tasks/task_b_68800268c7c08331803ca804eee8e4b8