### PR TITLE
Add caching to user id helper

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator
 
 from datetime import datetime
 
+from functools import lru_cache
 from fastapi import Depends, FastAPI, Request, Response
 from backend.shared.security import require_status_api_key
 from fastapi.responses import StreamingResponse
@@ -50,10 +51,16 @@ register_metrics(app)
 add_security_headers(app)
 
 
+@lru_cache(maxsize=256)
+def _cached_user(x_user: str | None, client_host: str) -> str:
+    """Return user identifier from ``x_user`` or ``client_host``."""
+    return x_user or client_host
+
+
 def _identify_user(request: Request) -> str:
     """Return identifier for logging, header ``X-User`` or client IP."""
     client_host = request.client.host if request.client else "unknown"
-    return cast(str, request.headers.get("X-User", client_host))
+    return _cached_user(request.headers.get("X-User"), cast(str, client_host))
 
 
 @app.middleware("http")  # type: ignore[misc]
@@ -271,7 +278,9 @@ async def export_performance_metrics(
                 .execution_options(yield_per=1000)
             )
             if start is not None:
-                stmt = stmt.filter(models.MarketplacePerformanceMetric.timestamp >= start)
+                stmt = stmt.filter(
+                    models.MarketplacePerformanceMetric.timestamp >= start
+                )
             if end is not None:
                 stmt = stmt.filter(models.MarketplacePerformanceMetric.timestamp <= end)
             result = await session.stream_scalars(stmt)

--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, AsyncGenerator, cast
 from hashlib import md5
+from functools import lru_cache
 
 import httpx
 from backend.shared.http import DEFAULT_TIMEOUT
@@ -189,9 +190,9 @@ analytics_limiter = UserRateLimiter(
 )
 
 
-def _identify_user(request: Request) -> str:
-    """Return identifier for rate limiting."""
-    auth_header = request.headers.get("Authorization")
+@lru_cache(maxsize=256)
+def _cached_user(auth_header: str | None, client_host: str) -> str:
+    """Return user identifier from ``auth_header`` or ``client_host``."""
     if auth_header and auth_header.startswith("Bearer "):
         token = auth_header.split(" ", 1)[1]
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
@@ -201,8 +202,15 @@ def _identify_user(request: Request) -> str:
             if sub is not None:
                 return sub
         except Exception:  # pragma: no cover - invalid token
-            pass
-    return cast(str, request.client.host)
+            return client_host
+    return client_host
+
+
+def _identify_user(request: Request) -> str:
+    """Return identifier for rate limiting."""
+    return _cached_user(
+        request.headers.get("Authorization"), cast(str, request.client.host)
+    )
 
 
 async def _enforce_rate_limit(request: Request, limiter: UserRateLimiter) -> None:

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from functools import lru_cache
 from typing import Callable, Coroutine, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -45,12 +46,21 @@ add_profiling(app)
 add_error_handlers(app)
 register_metrics(app)
 add_security_headers(app)
+
+
+@lru_cache(maxsize=256)
+def _cached_user(x_user: str | None, client_host: str) -> str:
+    """Return user identifier from ``x_user`` or ``client_host``."""
+    return x_user or client_host
+
+
 scheduler = create_scheduler()
 
 
 def _identify_user(request: Request) -> str:
     """Return identifier for logging, header ``X-User`` or client IP."""
-    return cast(str, request.headers.get("X-User", request.client.host))
+    client_host = cast(str, request.client.host)
+    return _cached_user(request.headers.get("X-User"), client_host)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- add an LRU cache helper to all `_identify_user` functions

## Testing
- `flake8 backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/optimization/api.py backend/service-template/src/main.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `docformatter --check backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/optimization/api.py backend/service-template/src/main.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `pydocstyle backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/optimization/api.py backend/service-template/src/main.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `mypy backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/api-gateway/src/api_gateway/routes.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/mockup-generation/mockup_generation/api.py backend/optimization/api.py backend/service-template/src/main.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py --ignore-missing-imports` *(fails: many errors across repo)*
- `pytest -W error -vv` *(fails: tests require services like Postgres)*

------
https://chatgpt.com/codex/tasks/task_b_6880050c4ed88331845cc1c3a8f7cf6e