### PR TITLE
Add __slots__ to metric dataclasses

### DIFF
--- a/backend/feedback-loop/feedback_loop/ab_testing.py
+++ b/backend/feedback-loop/feedback_loop/ab_testing.py
@@ -51,7 +51,7 @@ class DailySummary(Base):
     conversions_b: Mapped[int] = mapped_column(Integer, default=0)
 
 
-@dataclass
+@dataclass(slots=True)
 class BudgetAllocation:
     """Promotion budget allocation for variants."""
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/rules.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rules.py
@@ -34,7 +34,7 @@ def _load_yaml(path: Path) -> Mapping[str, Any]:
     return _raw_rules_cache
 
 
-@dataclass
+@dataclass(slots=True)
 class MarketplaceRules:
     """Validation rules for a single marketplace."""
 

--- a/backend/mockup-generation/mockup_generation/comfy_workflow.py
+++ b/backend/mockup-generation/mockup_generation/comfy_workflow.py
@@ -12,7 +12,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class ComfyResult:
     """Result information for a ComfyUI run."""
 

--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class GenerationResult:
     """Result from a generation request."""
 

--- a/backend/mockup-generation/mockup_generation/listing_generator.py
+++ b/backend/mockup-generation/mockup_generation/listing_generator.py
@@ -12,7 +12,7 @@ from .settings import settings
 import requests
 
 
-@dataclass
+@dataclass(slots=True)
 class ListingMetadata:
     """Metadata for a marketplace listing."""
 

--- a/backend/mockup-generation/mockup_generation/model_repository.py
+++ b/backend/mockup-generation/mockup_generation/model_repository.py
@@ -14,7 +14,7 @@ from backend.shared.db.models import AIModel, GeneratedMockup
 Base.metadata.create_all(bind=engine)
 
 
-@dataclass
+@dataclass(slots=True)
 class ModelInfo:
     """Dataclass representing an AI model entry."""
 
@@ -26,7 +26,7 @@ class ModelInfo:
     is_default: bool
 
 
-@dataclass
+@dataclass(slots=True)
 class GeneratedMockupInfo:
     """Dataclass representing a generated mockup entry."""
 

--- a/backend/mockup-generation/mockup_generation/prompt_builder.py
+++ b/backend/mockup-generation/mockup_generation/prompt_builder.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 from jinja2 import Template
 
 
-@dataclass
+@dataclass(slots=True)
 class PromptContext:
     """Context data for prompt generation."""
 
@@ -30,7 +30,6 @@ TEMPLATES: List[Template] = [
 
 def _mix_keywords(keywords: list[str], rng: Random) -> list[str]:
     """Return ``keywords`` shuffled and occasionally combined."""
-
     mixed = keywords.copy()
     rng.shuffle(mixed)
     if len(mixed) > 1 and rng.random() > 0.5:
@@ -42,7 +41,6 @@ def _mix_keywords(keywords: list[str], rng: Random) -> list[str]:
 
 def build_prompt(context: PromptContext, rng: Random | None = None) -> str:
     """Return a formatted prompt string using mixed keywords."""
-
     rng = rng or Random()
     keywords = _mix_keywords(context.keywords, rng)
     template = rng.choice(TEMPLATES)

--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -31,7 +31,7 @@ from .generator import MockupGenerator
 tracer = trace.get_tracer(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class MockupResult:
     """Result from successful mockup generation."""
 
@@ -42,7 +42,7 @@ class MockupResult:
     tags: list[str]
 
 
-@dataclass
+@dataclass(slots=True)
 class MockupError:
     """Error information for failed mockup generation."""
 
@@ -106,7 +106,7 @@ async def _multipart_upload(
     resp = await client.create_multipart_upload(Bucket=bucket, Key=key)
     upload_id = resp["UploadId"]
 
-    @dataclass
+    @dataclass(slots=True)
     class UploadedPart:
         """Information about a single uploaded part."""
 

--- a/backend/monitoring/src/monitoring/metrics_store.py
+++ b/backend/monitoring/src/monitoring/metrics_store.py
@@ -39,7 +39,7 @@ def invalidate_analytics_cache() -> None:
         pass
 
 
-@dataclass
+@dataclass(slots=True)
 class ScoreMetric:
     """Score metric for a design idea."""
 
@@ -48,7 +48,7 @@ class ScoreMetric:
     score: float
 
 
-@dataclass
+@dataclass(slots=True)
 class PublishLatencyMetric:
     """Publish latency metric for a design idea."""
 

--- a/backend/optimization/metrics.py
+++ b/backend/optimization/metrics.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type checking
     from .storage import MetricsStore
 
 
-@dataclass
+@dataclass(slots=True)
 class ResourceMetric:
     """Represents a single resource usage metric."""
 

--- a/backend/scoring-engine/scoring_engine/weight_repository.py
+++ b/backend/scoring-engine/scoring_engine/weight_repository.py
@@ -24,7 +24,7 @@ WEIGHTS_FILE = Path(__file__).with_name("weights.json")
 Base.metadata.create_all(bind=engine)
 
 
-@dataclass
+@dataclass(slots=True)
 class WeightParams:
     """Dataclass for weight values."""
 

--- a/backend/signal-ingestion/src/signal_ingestion/normalization.py
+++ b/backend/signal-ingestion/src/signal_ingestion/normalization.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, asdict
 from typing import Any, Callable, Dict
 
 
-@dataclass
+@dataclass(slots=True)
 class Signal:
     """Standard representation of an ingested signal."""
 


### PR DESCRIPTION
## Summary
- reduce memory usage in ResourceMetric and other dataclasses by enabling slots

## Testing
- `flake8 backend/optimization/metrics.py backend/monitoring/src/monitoring/metrics_store.py backend/marketplace-publisher/src/marketplace_publisher/rules.py backend/feedback-loop/feedback_loop/ab_testing.py backend/mockup-generation/mockup_generation/model_repository.py backend/mockup-generation/mockup_generation/listing_generator.py backend/mockup-generation/mockup_generation/prompt_builder.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/comfy_workflow.py backend/mockup-generation/mockup_generation/tasks.py backend/scoring-engine/scoring_engine/weight_repository.py backend/signal-ingestion/src/signal_ingestion/normalization.py`
- `pydocstyle backend/optimization/metrics.py backend/monitoring/src/monitoring/metrics_store.py backend/marketplace-publisher/src/marketplace_publisher/rules.py backend/feedback-loop/feedback_loop/ab_testing.py backend/mockup-generation/mockup_generation/model_repository.py backend/mockup-generation/mockup_generation/listing_generator.py backend/mockup-generation/mockup_generation/prompt_builder.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/comfy_workflow.py backend/mockup-generation/mockup_generation/tasks.py backend/scoring-engine/scoring_engine/weight_repository.py backend/signal-ingestion/src/signal_ingestion/normalization.py`
- `docformatter --check backend/optimization/metrics.py backend/monitoring/src/monitoring/metrics_store.py backend/marketplace-publisher/src/marketplace_publisher/rules.py backend/feedback-loop/feedback_loop/ab_testing.py backend/mockup-generation/mockup_generation/model_repository.py backend/mockup-generation/mockup_generation/listing_generator.py backend/mockup-generation/mockup_generation/prompt_builder.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/comfy_workflow.py backend/mockup-generation/mockup_generation/tasks.py backend/scoring-engine/scoring_engine/weight_repository.py backend/signal-ingestion/src/signal_ingestion/normalization.py`
- `pytest -vv` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6880050d03f8833181a60e6a5c79d05a