### PR TITLE
Add tmpfs volumes

### DIFF
--- a/infrastructure/helm/README.md
+++ b/infrastructure/helm/README.md
@@ -56,3 +56,7 @@ resource requests and limits, horizontal pod autoscaling and secret mounting.
 Secrets referenced via `secretName` are mounted under `/run/secrets`.
 Adjust these settings in the values files or override them on the command line
 to tune deployments for your environment.
+
+Each service also mounts an ephemeral volume at `/tmpfs` for intermediate data.
+The volume is memory-backed using `emptyDir` with `medium: Memory`, providing
+low-latency storage at the cost of additional RAM usage.

--- a/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
+++ b/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
@@ -38,9 +38,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/backup-jobs/templates/cronjob.yaml
+++ b/infrastructure/helm/backup-jobs/templates/cronjob.yaml
@@ -27,6 +27,8 @@ spec:
                 - name: secret-volume
                   mountPath: /run/secrets
                   readOnly: true
+                - name: tmpfs-volume
+                  mountPath: /tmpfs
               resources:
 {{ toYaml .Values.resources | nindent 14 }}
               command: ["python", "/app/backup.py"]
@@ -34,3 +36,6 @@ spec:
             - name: secret-volume
               secret:
                 secretName: {{ .Values.secretName }}
+            - name: tmpfs-volume
+              emptyDir:
+                medium: Memory

--- a/infrastructure/helm/data-storage/templates/deployment.yaml
+++ b/infrastructure/helm/data-storage/templates/deployment.yaml
@@ -34,9 +34,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/feedback-loop/templates/deployment.yaml
+++ b/infrastructure/helm/feedback-loop/templates/deployment.yaml
@@ -34,9 +34,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/logrotate-jobs/templates/cronjob.yaml
+++ b/infrastructure/helm/logrotate-jobs/templates/cronjob.yaml
@@ -25,6 +25,8 @@ spec:
                 - name: secret-volume
                   mountPath: /run/secrets
                   readOnly: true
+                - name: tmpfs-volume
+                  mountPath: /tmpfs
               resources:
 {{ toYaml .Values.resources | nindent 14 }}
               command: ["python", "/app/rotate_logs.py"]
@@ -32,3 +34,6 @@ spec:
             - name: secret-volume
               secret:
                 secretName: {{ .Values.secretName }}
+            - name: tmpfs-volume
+              emptyDir:
+                medium: Memory

--- a/infrastructure/helm/marketplace-publisher/templates/deployment.yaml
+++ b/infrastructure/helm/marketplace-publisher/templates/deployment.yaml
@@ -34,9 +34,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/monitoring/templates/deployment.yaml
+++ b/infrastructure/helm/monitoring/templates/deployment.yaml
@@ -36,9 +36,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/orchestrator/templates/deployment.yaml
+++ b/infrastructure/helm/orchestrator/templates/deployment.yaml
@@ -34,9 +34,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/scoring-engine/templates/deployment.yaml
+++ b/infrastructure/helm/scoring-engine/templates/deployment.yaml
@@ -34,9 +34,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/signal-ingestion/templates/deployment.yaml
+++ b/infrastructure/helm/signal-ingestion/templates/deployment.yaml
@@ -34,9 +34,14 @@ spec:
             - name: secret-volume
               mountPath: /run/secrets
               readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
           resources:
 {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:
             secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory


### PR DESCRIPTION
## Summary
- mount ephemeral tmpfs volumes for intermediate data in every chart
- note new tmpfs mount in Helm README

## Testing
- `flake8 .`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: Library stubs not installed)*
- `pydocstyle .` *(fails: D202 violation)*
- `docformatter --check --recursive .` *(fails: several files not formatted)*
- `interrogate backend` *(fails: 80.2% < 100% required)*
- `pip-audit -r requirements.txt -r requirements-dev.txt`
- `npm run lint:eslint` *(fails: Cannot find module '@eslint/eslintrc')*
- `pytest -n auto -W error -vv` *(fails: multiple tests fail)*

------
https://chatgpt.com/codex/tasks/task_b_6880051570688331b185e7b62fbcfd48