### PR TITLE
Add custom exceptions for signal ingestion tasks

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/errors.py
+++ b/backend/signal-ingestion/src/signal_ingestion/errors.py
@@ -1,0 +1,32 @@
+"""Custom exceptions for the signal ingestion service."""
+
+
+class SignalIngestionError(Exception):
+    """Base class for signal ingestion errors."""
+
+
+class UnknownAdapterError(SignalIngestionError):
+    """Raised when an adapter name is not registered."""
+
+    def __init__(self, adapter_name: str) -> None:
+        """Store ``adapter_name`` and initialize the message."""
+        super().__init__(f"Unknown adapter: {adapter_name}")
+        self.adapter_name = adapter_name
+
+
+class AdapterFetchError(SignalIngestionError):
+    """Raised when fetching data from an adapter fails."""
+
+    def __init__(self, adapter_name: str, message: str) -> None:
+        """Store context for the failed fetch."""
+        super().__init__(f"{adapter_name}: {message}")
+        self.adapter_name = adapter_name
+
+
+class EmbeddingGenerationError(SignalIngestionError):
+    """Raised when generating embeddings fails."""
+
+    def __init__(self, reason: str) -> None:
+        """Create error with ``reason`` message."""
+        super().__init__(reason)
+        self.reason = reason


### PR DESCRIPTION
## Summary
- add `errors.py` with custom exceptions for signal ingestion
- raise new exceptions in ingestion tasks when adapters fail or aren't found

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/errors.py backend/signal-ingestion/src/signal_ingestion/tasks.py`
- `pydocstyle backend/signal-ingestion/src/signal_ingestion/errors.py backend/signal-ingestion/src/signal_ingestion/tasks.py`
- `docformatter -i backend/signal-ingestion/src/signal_ingestion/errors.py backend/signal-ingestion/src/signal_ingestion/tasks.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_b_68800516c9f4833185a74e050ac8cbae