### PR TITLE
Use hashed filenames for generated mockups

### DIFF
--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -355,6 +355,9 @@ def generate_single_mockup(
                 with open(output_path, "rb") as fh:
                     data = fh.read()
                 sha256 = hashlib.sha256(data).hexdigest()
+                hashed_path = Path(output_dir) / f"{sha256}.png"
+                Path(output_path).replace(hashed_path)
+                output_path = hashed_path
                 obj_name = f"generated-mockups/{sha256}.png"
                 bucket = settings.s3_bucket or ""
                 try:


### PR DESCRIPTION
## Summary
- ensure generated mockups get renamed to their content hash

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py`
- `black backend/mockup-generation/mockup_generation/tasks.py`
- `docformatter --check backend/mockup-generation/mockup_generation/tasks.py`
- `pydocstyle backend/mockup-generation/mockup_generation/tasks.py`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: missing stubs and other errors)*
- `pytest -n auto -W error -vv` *(fails: connection refused for postgres)*

------
https://chatgpt.com/codex/tasks/task_b_68800517ea548331bc403e5e5af8a39f