### PR TITLE
Add Redis caching for feature flags

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -7,7 +7,7 @@ Experimental features are toggled using [LaunchDarkly](https://launchdarkly.com/
 1. Provide a `LAUNCHDARKLY_SDK_KEY` to fetch flags from LaunchDarkly.
 2. Set `FEATURE_FLAGS` to a JSON mapping of flag names to booleans for simple environment-based toggles.
 3. Set `FEATURE_FLAGS_REDIS_URL` to read and write overrides from Redis, ensuring values persist across restarts.
-4. Results are cached for `FEATURE_FLAGS_CACHE_TTL` seconds (default `30`).
+4. Results are cached in Redis (and memory) for `FEATURE_FLAGS_CACHE_TTL` seconds (default `30`).
 
 ## Disabling a flag
 


### PR DESCRIPTION
## Summary
- cache feature flag lookups in Redis with a TTL
- document new behaviour in feature flag docs
- test Redis caching across reloads

## Testing
- `black backend/shared/feature_flags.py backend/shared/tests/test_feature_flags.py`
- `flake8 backend/shared/feature_flags.py backend/shared/tests/test_feature_flags.py`
- `docformatter --check backend/shared/feature_flags.py backend/shared/tests/test_feature_flags.py docs/feature-flags.md`
- `mypy --config-file pyproject.toml --ignore-missing-imports backend/shared/feature_flags.py backend/shared/tests/test_feature_flags.py` *(fails: Library stubs not installed for "requests")*
- `pytest backend/shared/tests/test_feature_flags.py::test_redis_result_cache -vv` *(fails: Required test coverage of 15% not reached)*

------
https://chatgpt.com/codex/tasks/task_b_6880051f35d48331bef4563708dc995e