### PR TITLE
Add GPU temperature Prometheus gauge

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -79,6 +79,11 @@ The context manager `tasks.gpu_slot` updates two metrics:
 
 These metrics appear alongside existing ones on the `/metrics` endpoint.
 
+In addition, GPU usage statistics are reported:
+
+- `gpu_utilization_percent` – a gauge with the current utilization rate.
+- `gpu_temperature_celsius` – a gauge with the GPU temperature in Celsius.
+
 ## Database Connection Metrics
 
 Each service now reports connection pool usage via two gauges:

--- a/tests/test_gpu_temperature_metric.py
+++ b/tests/test_gpu_temperature_metric.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+import subprocess
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "backend/mockup-generation")
+)
+client_mod = ModuleType("aiobotocore.client")
+setattr(client_mod, "AioBaseClient", object)
+sys.modules.setdefault("aiobotocore.client", client_mod)
+session_mod = ModuleType("aiobotocore.session")
+setattr(session_mod, "get_session", lambda: None)
+sys.modules.setdefault("aiobotocore.session", session_mod)
+botocore_exceptions = ModuleType("botocore.exceptions")
+setattr(botocore_exceptions, "ClientError", Exception)
+sys.modules.setdefault("botocore.exceptions", botocore_exceptions)
+celery_mod = ModuleType("celery")
+setattr(celery_mod, "Celery", object)
+setattr(celery_mod, "Task", object)
+setattr(celery_mod, "chord", lambda *args, **kwargs: None)
+sys.modules["celery"] = celery_mod
+signals_mod = ModuleType("celery.signals")
+setattr(signals_mod, "worker_ready", object)
+sys.modules["celery.signals"] = signals_mod
+
+
+def test_gpu_temperature_metric(monkeypatch: Any) -> None:
+    """GPU temperature gauge should use output from ``nvidia-smi``."""
+
+    from mockup_generation.tasks import _update_gpu_temperature, GPU_TEMPERATURE
+
+    class Result:
+        stdout = "55\n"
+
+    def fake_run(*args: Any, **kwargs: Any) -> Result:
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    _update_gpu_temperature()
+    assert GPU_TEMPERATURE._value.get() == 55.0


### PR DESCRIPTION
## Summary
- instrument GPU temperature using Prometheus gauge
- update performance docs to document new metric
- add unit test for GPU temperature metric

## Testing
- `flake8 backend/mockup-generation/mockup_generation/tasks.py tests/test_gpu_temperature_metric.py`
- `mypy --config-file pyproject.toml --follow-imports=skip backend/mockup-generation/mockup_generation/tasks.py tests/test_gpu_temperature_metric.py`
- `docformatter --check docs/performance.md`
- `pydocstyle docs/performance.md`
- `SKIP_HEAVY_DEPS=1 pytest tests/test_gpu_temperature_metric.py -q` *(fails: ModuleNotFoundError: No module named 'kafka')*

------
https://chatgpt.com/codex/tasks/task_b_68800521fc04833197513728ba35cf78