### PR TITLE
Add bandit check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
     hooks:
       - id: interrogate
         args: ["--fail-under=100"]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: ["-ll"]
   - repo: local
     hooks:
       - id: eslint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ pydocstyle
 flake8-docstrings
 docformatter
 interrogate
+bandit
 uvloop
 watchdog
 vcrpy


### PR DESCRIPTION
## Summary
- add Bandit security scanner to the pre-commit config
- include Bandit in development requirements

## Testing
- `pre-commit run --all-files` *(fails: requires network access)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68801932ac6883318c20770bb629cb9b