### PR TITLE
Add shellcheck to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
     hooks:
       - id: interrogate
         args: ["--fail-under=100"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        files: \.(sh)$
   - repo: local
     hooks:
       - id: eslint

--- a/scripts/check_k8s_health.sh
+++ b/scripts/check_k8s_health.sh
@@ -18,7 +18,8 @@ for svc in "${SERVICES[@]}"; do
   echo "Waiting for $svc in namespace $NAMESPACE"
   port="$(kubectl get service "$svc" -n "$NAMESPACE" -o jsonpath='{.spec.ports[0].port}')"
   local_port=$((RANDOM%30000 + 1025))
-  kubectl port-forward "service/$svc" "$local_port:$port" -n "$NAMESPACE" >/tmp/pf-$svc.log 2>&1 &
+  kubectl port-forward "service/$svc" "$local_port:$port" -n "$NAMESPACE" \
+    >"/tmp/pf-${svc}.log" 2>&1 &
   pf_pid=$!
   start=$(date +%s)
   until curl -fsS "http://localhost:$local_port/ready" >/dev/null 2>&1; do
@@ -31,7 +32,7 @@ for svc in "${SERVICES[@]}"; do
   done
   kill "$pf_pid"
   echo "$svc is healthy"
-  rm -f "/tmp/pf-$svc.log"
+  rm -f "/tmp/pf-${svc}.log"
 done
 
 echo "All services healthy"


### PR DESCRIPTION
## Summary
- add shellcheck hook to `.pre-commit-config.yaml`
- fix shellcheck warnings in scripts

## Testing
- `shellcheck $(find scripts -name '*.sh')`
- `flake8 scripts/smoke_compose.sh scripts/check_k8s_health.sh` *(fails: SyntaxError because not Python)*
- `pytest -k ""` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pre-commit run --files .pre-commit-config.yaml scripts/smoke_compose.sh scripts/check_k8s_health.sh` *(fails: prompt for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_b_68801935c2548331a43cfd26f2ec66bd