### PR TITLE
Cache settings database URL

### DIFF
--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import cached_property
+
 from pydantic import AnyUrl, Field, HttpUrl, RedisDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -63,9 +65,14 @@ class Settings(BaseSettings):
             raise ValueError("must be positive")
         return value
 
-    @property
+    @cached_property
     def effective_database_url(self) -> AnyUrl:
-        """Return ``pgbouncer_url`` if set, otherwise ``database_url``."""
+        """
+        Return ``pgbouncer_url`` if set, otherwise ``database_url``.
+
+        The value is cached so that it is computed only once per ``Settings``
+        instance.
+        """
         return self.pgbouncer_url or self.database_url
 
 


### PR DESCRIPTION
## Summary
- cache Settings.effective_database_url with functools.cached_property

## Testing
- `docformatter --check backend/shared/config.py`
- `pydocstyle backend/shared/config.py`
- `black backend/shared/config.py --check`
- `flake8 backend/shared/config.py`
- `mypy --explicit-package-bases backend/shared/config.py` *(fails: Library stubs not installed for "requests")*
- `python -m pytest -n auto -W error -vv tests` *(fails: connection refused)*
- `python scripts/setup_codex.py` *(fails: npm ci mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_6880193a3d448331a7b674e89afc59d6