### PR TITLE
Switch Node base image to slim variant

### DIFF
--- a/frontend/admin-dashboard/Dockerfile
+++ b/frontend/admin-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-slim
 WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup -S app && adduser -S app -G app


### PR DESCRIPTION
## Summary
- use `node:20-slim` for admin dashboard Dockerfile

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -k "" -W error -vv` *(fails: connection refused)*
- `npm test` *(fails: MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_b_6880194648408331b7b061c667093a4b