### PR TITLE
Add docs for cached virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ python -m pip install -r requirements.txt -r requirements-dev.txt
 npm ci --legacy-peer-deps
 ```
 
+Using a dedicated virtual environment path outside the repository keeps
+dependencies cached between runs:
+
+```bash
+python -m venv ~/.cache/desainz_venv
+source ~/.cache/desainz_venv/bin/activate
+```
+
 Build the HTML documentation locally with:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,14 @@ python -m pip install -r requirements.txt -r requirements-dev.txt
 npm ci --legacy-peer-deps
 ```
 
+Using a dedicated virtual environment path outside the repository keeps
+dependencies cached between runs:
+
+```bash
+python -m venv ~/.cache/desainz_venv
+source ~/.cache/desainz_venv/bin/activate
+```
+
 Build the HTML documentation with:
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,6 +17,15 @@ Use the provided setup script to install Python and Node packages and build the 
 ./scripts/setup_codex.sh
 ```
 
+For faster repeated runs, activate a virtual environment stored outside the
+repository before executing the script:
+
+```bash
+python -m venv ~/.cache/desainz_venv
+source ~/.cache/desainz_venv/bin/activate
+./scripts/setup_codex.sh
+```
+
 ## 3. Launch the stack
 
 Start the application and its services with Docker Compose.


### PR DESCRIPTION
## Summary
- document using a reusable virtualenv in the README
- mention the same reusable virtualenv path inside docs

## Testing
- `python -m pip install -r requirements.txt -r requirements-dev.txt`
- `python -m pytest -n auto -W error -vv` *(fails: DockerException and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_b_6880194a692c833194f9fce1448800f5