### PR TITLE
Run vulture and remove dead code

### DIFF
--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -109,7 +109,7 @@ def schedule_marketplace_ingestion(
     listing_ids: Iterable[int],
     scoring_api: str,
     interval_minutes: int = 60,
-) -> "Job":
+) -> Job:
     """Register a job fetching metrics and update scoring weights."""
 
     async def _job() -> None:

--- a/backend/mockup-generation/mockup_generation/celery_app.py
+++ b/backend/mockup-generation/mockup_generation/celery_app.py
@@ -83,7 +83,6 @@ def _route_gpu_tasks(
     args: tuple[object, ...],
     kwargs: dict[str, object],
     options: dict[str, object],
-    **kws: object,
 ) -> dict[str, object]:
     """Route tasks with a ``gpu_index`` kwarg to the corresponding queue."""
     gpu = kwargs.get("gpu_index")

--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -17,7 +17,6 @@ import os
 import time
 from botocore.exceptions import ClientError
 
-from redis.lock import Lock as RedisLock
 from redis.asyncio.lock import Lock as AsyncRedisLock
 from celery import Task, chord
 from prometheus_client import Counter, Gauge, Histogram

--- a/load_tests/test_gpu_concurrency.py
+++ b/load_tests/test_gpu_concurrency.py
@@ -162,9 +162,7 @@ def patched_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
     tasks.settings.s3_endpoint = "http://test"
 
 
-def test_slot_contention(
-    celery_app: Celery, patched_tasks: None, tmp_path: Path
-) -> None:
+def test_slot_contention(celery_app: Celery, tmp_path: Path) -> None:
     """Run two tasks concurrently and observe lock metrics."""
 
     queues = ["q1", "q2"]

--- a/tests/stubs/celery.py
+++ b/tests/stubs/celery.py
@@ -7,9 +7,10 @@ class Celery:
     """Simplified Celery class used in tests."""
 
     def __init__(self, *args: object, **_kwargs: object) -> None:
+        """Initialize the stub with minimal configuration."""
         self.conf = SimpleNamespace(result_backend=None)
 
-    def task(self, *d_args: object, **d_kwargs: object):  # pragma: no cover
+    def task(self, *_: object, **__: object):  # pragma: no cover
         """Return a decorator that leaves the function unmodified."""
 
         def decorator(func):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -19,7 +19,7 @@ def test_dump_postgres_creates_and_uploads(
     """Database dump should be uploaded and local file removed."""
     commands: list[list[str]] = []
 
-    def fake_run(cmd: list[str], check: bool = True) -> None:
+    def fake_run(cmd: list[str], _check: bool = True) -> None:
         commands.append(cmd)
         if cmd[0] == "pg_dump":
             # create dump file to mimic pg_dump output

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -46,7 +46,7 @@ def test_pool_used_for_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     created: dict[str, str] = {}
 
     class DummyPool:
-        def __init__(self, minconn: int, maxconn: int, dsn: str) -> None:
+        def __init__(self, _minconn: int, maxconn: int, dsn: str) -> None:
             created["dsn"] = dsn
 
         def getconn(self) -> object:  # pragma: no cover - dummy

--- a/tests/test_rotate_s3_keys.py
+++ b/tests/test_rotate_s3_keys.py
@@ -24,7 +24,7 @@ def test_rotate_s3_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     iam.create_access_key(UserName="test")
     called: list[list[str]] = []
 
-    def fake_run(cmd: list[str], check: bool = True) -> None:
+    def fake_run(cmd: list[str], _check: bool = True) -> None:
         called.append(cmd)
 
     monkeypatch.setattr(subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary
- prune unused Job import in ingestion
- tidy GPU routing util
- drop unused RedisLock import
- clean up tests

## Testing
- `flake8 backend/feedback-loop/feedback_loop/ingestion.py backend/mockup-generation/mockup_generation/celery_app.py backend/mockup-generation/mockup_generation/tasks.py load_tests/test_gpu_concurrency.py tests/stubs/celery.py tests/test_backup.py tests/test_metrics_store.py tests/test_rotate_s3_keys.py`
- `pydocstyle backend/feedback-loop/feedback_loop/ingestion.py backend/mockup-generation/mockup_generation/celery_app.py backend/mockup-generation/mockup_generation/tasks.py load_tests/test_gpu_concurrency.py tests/stubs/celery.py tests/test_backup.py tests/test_metrics_store.py tests/test_rotate_s3_keys.py`
- `pytest tests/test_backup.py -q` *(fails: ModuleNotFoundError: No module named 'pgvector')*

------
https://chatgpt.com/codex/tasks/task_b_6880193b3da48331b673da3ac1fc5e8a