### PR TITLE
Add Nginx cache sidecar

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -252,6 +252,14 @@ services:
     - openai_api_key
     - stability_ai_api_key
     - huggingface_token
+  api-gateway-cache:
+    image: nginx:1.25-alpine
+    ports:
+    - 8000:80
+    depends_on:
+    - api-gateway
+    volumes:
+    - ./docker/api_gateway_sidecar/nginx.conf:/etc/nginx/nginx.conf:ro
   scoring-engine:
     build: ./backend/scoring-engine
     command: python -m scoring_engine.app

--- a/docker/api_gateway_sidecar/nginx.conf
+++ b/docker/api_gateway_sidecar/nginx.conf
@@ -1,0 +1,27 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=api_cache:10m max_size=100m inactive=60m use_temp_path=off;
+
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://api-gateway:8000;
+            proxy_cache api_cache;
+            proxy_cache_methods GET;
+            proxy_cache_valid 200 10m;
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+    }
+}

--- a/docs/api_gateway_sidecar.rst
+++ b/docs/api_gateway_sidecar.rst
@@ -1,0 +1,10 @@
+API Gateway Nginx Sidecar
+=========================
+
+To minimize load on the API Gateway, an Nginx sidecar container is configured to cache
+successful GET responses. The sidecar listens on port ``8000`` and proxies requests to
+the ``api-gateway`` service. Cached responses are served directly by Nginx and include
+the ``X-Cache-Status`` header.
+
+The configuration is defined in ``docker/api_gateway_sidecar/nginx.conf`` and mounted via
+``docker-compose.dev.yml``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Welcome to desAInz's documentation!
    quickstart
    recommendations
    optimization
+   api_gateway_sidecar
    deployment
    cloud_deployment
    troubleshooting


### PR DESCRIPTION
## Summary
- add Nginx config for GET caching next to api-gateway
- wire up cache container in docker-compose
- document the sidecar in Sphinx docs

## Testing
- `flake8`
- `black --check .`
- `mypy backend`
- `pytest -k caching --maxfail=1 -q`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_b_6880194e38448331b922a713d205e692