### PR TITLE
Eager load ABTest in results export

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -16,6 +16,7 @@ from backend.shared.security import require_status_api_key
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
+from sqlalchemy.orm import joinedload
 
 from backend.shared.db import AsyncSessionLocal
 from backend.shared.db import models
@@ -152,6 +153,7 @@ async def export_ab_test_results(
         async with AsyncSessionLocal() as session:
             stmt = (
                 select(models.ABTestResult)
+                .options(joinedload(models.ABTestResult.ab_test))
                 .filter(models.ABTestResult.ab_test_id == ab_test_id)
                 .order_by(models.ABTestResult.timestamp)
                 .execution_options(yield_per=1000)

--- a/tests/test_gpu_temperature_metric.py
+++ b/tests/test_gpu_temperature_metric.py
@@ -1,3 +1,5 @@
+"""Tests for GPU temperature metric."""
+
 from typing import Any
 
 import subprocess


### PR DESCRIPTION
## Summary
- load related ABTest via `joinedload` when exporting results
- add missing module docstring for GPU metric test

## Testing
- `flake8`
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: Library stubs not installed for `requests`, unused ignore comments, etc.)*
- `pydocstyle .` *(fails: D202 No blank lines allowed after function docstring, etc.)*
- `docformatter --check --recursive backend/analytics/api.py tests/test_gpu_temperature_metric.py`
- `interrogate backend` *(fails: total coverage 80.7% < 100%)*
- `pip-audit -r requirements.txt -r requirements-dev.txt` *(fails: py 1.11.0 vulnerability)*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run lint:css` *(fails: stylelint not found)*
- `npm run flow` *(fails: flow not found)*
- `python -m pytest -n auto -W error -vv` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_6880192d11e08331b28bc3a642276b7a