### PR TITLE
Refactor: reuse helper functions in tests

### DIFF
--- a/backend/marketplace-publisher/tests/test_policy_failures.py
+++ b/backend/marketplace-publisher/tests/test_policy_failures.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from fastapi.testclient import TestClient
 import fakeredis.aioredis
 from marketplace_publisher import publisher, db
+from tests.utils import return_none, return_true, return_false
 
 
 @pytest.mark.asyncio()
@@ -29,8 +30,8 @@ async def test_publish_trademark_failure(
             return "ok"
 
     publisher.CLIENTS[db.Marketplace.redbubble] = DummyClient()
-    monkeypatch.setattr(publisher, "is_trademarked", lambda term: True)
-    monkeypatch.setattr(publisher, "ensure_not_nsfw", lambda img: None)
+    monkeypatch.setattr(publisher, "is_trademarked", return_true)
+    monkeypatch.setattr(publisher, "ensure_not_nsfw", return_none)
 
     async with session_factory() as session:
         task = await db.create_task(
@@ -66,7 +67,7 @@ async def test_publish_nsfw_failure(
             return "ok"
 
     publisher.CLIENTS[db.Marketplace.redbubble] = DummyClient()
-    monkeypatch.setattr(publisher, "is_trademarked", lambda term: False)
+    monkeypatch.setattr(publisher, "is_trademarked", return_false)
 
     def raise_nsfw(img: Any) -> None:  # noqa: ANN001
         raise ValueError("NSFW")
@@ -110,8 +111,8 @@ def test_api_trademark_failure(monkeypatch: Any, tmp_path: Path) -> None:
         return None
 
     publisher._fallback.publish = _noop
-    monkeypatch.setattr(publisher, "is_trademarked", lambda term: True)
-    monkeypatch.setattr(publisher, "ensure_not_nsfw", lambda img: None)
+    monkeypatch.setattr(publisher, "is_trademarked", return_true)
+    monkeypatch.setattr(publisher, "ensure_not_nsfw", return_none)
 
     with TestClient(app) as client:
         design = tmp_path / "img.png"
@@ -147,7 +148,7 @@ def test_api_nsfw_failure(monkeypatch: Any, tmp_path: Path) -> None:
         return None
 
     publisher._fallback.publish = _noop2
-    monkeypatch.setattr(publisher, "is_trademarked", lambda term: False)
+    monkeypatch.setattr(publisher, "is_trademarked", return_false)
 
     def raise_nsfw(img: Any) -> None:  # noqa: ANN001
         raise ValueError("NSFW")

--- a/backend/mockup-generation/tests/test_api_mockups.py
+++ b/backend/mockup-generation/tests/test_api_mockups.py
@@ -10,9 +10,11 @@ from pathlib import Path
 import asyncio
 from typing import Any, AsyncIterator
 from contextlib import asynccontextmanager
+from functools import partial
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.utils import identity, return_true, return_none
 
 root = Path(__file__).resolve().parents[3]
 sys.path.append(str(root))
@@ -199,7 +201,7 @@ def test_metadata_recorded_and_listed(
     tasks = importlib.import_module("mockup_generation.tasks")
     api = importlib.import_module("mockup_generation.api")
     monkeypatch.setattr(tasks, "generator", DummyGenerator())
-    monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
+    monkeypatch.setattr(tasks, "ListingGenerator", partial(DummyListingGen))
 
     @asynccontextmanager
     async def _client() -> AsyncIterator[DummyClient]:
@@ -233,13 +235,13 @@ def test_metadata_recorded_and_listed(
         "async_redis_client",
         types.SimpleNamespace(lock=lambda *a, **k: _Lock()),
     )
-    monkeypatch.setattr(tasks, "remove_background", lambda img: img)
-    monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)
-    monkeypatch.setattr(tasks, "ensure_not_nsfw", lambda img: None)
-    monkeypatch.setattr(tasks, "validate_dpi_image", lambda img: True)
-    monkeypatch.setattr(tasks, "validate_color_space", lambda img: True)
-    monkeypatch.setattr(tasks, "validate_dimensions", lambda img: True)
-    monkeypatch.setattr(tasks, "validate_file_size", lambda p: True)
+    monkeypatch.setattr(tasks, "remove_background", identity)
+    monkeypatch.setattr(tasks, "convert_to_cmyk", identity)
+    monkeypatch.setattr(tasks, "ensure_not_nsfw", return_none)
+    monkeypatch.setattr(tasks, "validate_dpi_image", return_true)
+    monkeypatch.setattr(tasks, "validate_color_space", return_true)
+    monkeypatch.setattr(tasks, "validate_dimensions", return_true)
+    monkeypatch.setattr(tasks, "validate_file_size", return_true)
     tasks.settings.s3_bucket = "b"
     tasks.settings.s3_endpoint = "http://test"
     tasks.settings.s3_base_url = "http://cdn.test"

--- a/backend/mockup-generation/tests/test_gpu_lock.py
+++ b/backend/mockup-generation/tests/test_gpu_lock.py
@@ -122,6 +122,7 @@ import threading  # noqa: E402
 import asyncio
 import fakeredis.aioredis  # noqa: E402
 import pytest  # noqa: E402
+from tests.utils import return_one
 
 from mockup_generation import tasks  # noqa: E402
 
@@ -130,7 +131,7 @@ def test_gpu_slot(monkeypatch: pytest.MonkeyPatch) -> None:
     """Lock is acquired and released using the context manager."""
     fake = fakeredis.aioredis.FakeRedis()
     monkeypatch.setattr(tasks, "async_redis_client", fake)
-    monkeypatch.setattr(tasks, "get_gpu_slots", lambda: 1)
+    monkeypatch.setattr(tasks, "get_gpu_slots", return_one)
 
     async def run() -> None:
         async with tasks.gpu_slot():
@@ -144,7 +145,7 @@ def test_gpu_slot_contention(monkeypatch: pytest.MonkeyPatch) -> None:
     """Multiple workers should acquire the lock sequentially."""
     fake = fakeredis.aioredis.FakeRedis()
     monkeypatch.setattr(tasks, "async_redis_client", fake)
-    monkeypatch.setattr(tasks, "get_gpu_slots", lambda: 1)
+    monkeypatch.setattr(tasks, "get_gpu_slots", return_one)
 
     order: list[str] = []
 

--- a/backend/mockup-generation/tests/test_gpu_metrics.py
+++ b/backend/mockup-generation/tests/test_gpu_metrics.py
@@ -9,6 +9,7 @@ import types
 
 import fakeredis
 import pytest
+from tests.utils import return_one
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))  # noqa: E402
@@ -29,7 +30,7 @@ def test_gpu_queue_metric(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(redis.Redis, "from_url", lambda *a, **k: fake)
 
     stub_tasks = types.ModuleType("mockup_generation.tasks")
-    stub_tasks.get_gpu_slots = lambda: 1  # type: ignore[attr-defined]
+    stub_tasks.get_gpu_slots = return_one  # type: ignore[attr-defined]
     stub_tasks.queue_for_gpu = lambda idx: f"gpu-{idx}"  # type: ignore[attr-defined]
     sys.modules["mockup_generation.tasks"] = stub_tasks
 

--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -11,6 +11,7 @@ import sys
 import asyncio
 import warnings
 from contextlib import asynccontextmanager
+from functools import partial
 from typing import AsyncIterator
 import pytest
 
@@ -51,6 +52,7 @@ otel_root = types.ModuleType("opentelemetry")
 otel_root.trace = trace_mod
 sys.modules["opentelemetry"] = otel_root
 from mockup_generation import tasks  # noqa: E402
+from tests.utils import identity, return_true, return_none
 
 _orig_generate_mockup = tasks.generate_mockup.run
 
@@ -151,7 +153,7 @@ def test_generate_mockup_upload(
     """Image is uploaded using the storage client."""
     gen = DummyGenerator()
     monkeypatch.setattr(tasks, "generator", gen)
-    monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
+    monkeypatch.setattr(tasks, "ListingGenerator", partial(DummyListingGen))
 
     @asynccontextmanager
     async def _client() -> AsyncIterator[DummyClient]:
@@ -185,11 +187,11 @@ def test_generate_mockup_upload(
         "async_redis_client",
         types.SimpleNamespace(lock=lambda *a, **k: _Lock()),
     )
-    monkeypatch.setattr(tasks, "remove_background", lambda img: img)
-    monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)
-    monkeypatch.setattr(tasks, "ensure_not_nsfw", lambda img: None)
-    monkeypatch.setattr(tasks, "validate_dpi_image", lambda img: True)
-    monkeypatch.setattr(tasks, "validate_color_space", lambda img: True)
+    monkeypatch.setattr(tasks, "remove_background", identity)
+    monkeypatch.setattr(tasks, "convert_to_cmyk", identity)
+    monkeypatch.setattr(tasks, "ensure_not_nsfw", return_none)
+    monkeypatch.setattr(tasks, "validate_dpi_image", return_true)
+    monkeypatch.setattr(tasks, "validate_color_space", return_true)
     monkeypatch.setattr(
         tasks.model_repository, "save_generated_mockup", lambda *a, **k: 1
     )
@@ -211,7 +213,7 @@ def test_generate_mockup_duplicate_not_uploaded(
     """Skip upload when an object with the same hash exists."""
     gen = DummyGenerator()
     monkeypatch.setattr(tasks, "generator", gen)
-    monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
+    monkeypatch.setattr(tasks, "ListingGenerator", partial(DummyListingGen))
 
     client = DummyClient(exists=True)
 
@@ -247,11 +249,11 @@ def test_generate_mockup_duplicate_not_uploaded(
         "async_redis_client",
         types.SimpleNamespace(lock=lambda *a, **k: _Lock()),
     )
-    monkeypatch.setattr(tasks, "remove_background", lambda img: img)
-    monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)
-    monkeypatch.setattr(tasks, "ensure_not_nsfw", lambda img: None)
-    monkeypatch.setattr(tasks, "validate_dpi_image", lambda img: True)
-    monkeypatch.setattr(tasks, "validate_color_space", lambda img: True)
+    monkeypatch.setattr(tasks, "remove_background", identity)
+    monkeypatch.setattr(tasks, "convert_to_cmyk", identity)
+    monkeypatch.setattr(tasks, "ensure_not_nsfw", return_none)
+    monkeypatch.setattr(tasks, "validate_dpi_image", return_true)
+    monkeypatch.setattr(tasks, "validate_color_space", return_true)
     monkeypatch.setattr(
         tasks.model_repository, "save_generated_mockup", lambda *a, **k: 1
     )
@@ -275,7 +277,7 @@ def test_generate_mockup_uses_multipart(
     """Multipart upload is triggered for large files."""
     gen = DummyGenerator()
     monkeypatch.setattr(tasks, "generator", gen)
-    monkeypatch.setattr(tasks, "ListingGenerator", lambda: DummyListingGen())
+    monkeypatch.setattr(tasks, "ListingGenerator", partial(DummyListingGen))
 
     @asynccontextmanager
     async def _client() -> AsyncIterator[DummyClient]:
@@ -309,11 +311,11 @@ def test_generate_mockup_uses_multipart(
         "async_redis_client",
         types.SimpleNamespace(lock=lambda *a, **k: _Lock()),
     )
-    monkeypatch.setattr(tasks, "remove_background", lambda img: img)
-    monkeypatch.setattr(tasks, "convert_to_cmyk", lambda img: img)
-    monkeypatch.setattr(tasks, "ensure_not_nsfw", lambda img: None)
-    monkeypatch.setattr(tasks, "validate_dpi_image", lambda img: True)
-    monkeypatch.setattr(tasks, "validate_color_space", lambda img: True)
+    monkeypatch.setattr(tasks, "remove_background", identity)
+    monkeypatch.setattr(tasks, "convert_to_cmyk", identity)
+    monkeypatch.setattr(tasks, "ensure_not_nsfw", return_none)
+    monkeypatch.setattr(tasks, "validate_dpi_image", return_true)
+    monkeypatch.setattr(tasks, "validate_color_space", return_true)
     monkeypatch.setattr(
         tasks.model_repository, "save_generated_mockup", lambda *a, **k: 1
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,3 +12,33 @@ def assert_single_head(config_path: str) -> None:
     script = ScriptDirectory.from_config(cfg)
     heads = script.get_heads()
     assert len(heads) == 1, f"{config_path} has multiple heads: {heads}"
+
+
+def identity(value: object) -> object:
+    """Return ``value`` unchanged."""
+
+    return value
+
+
+def return_true(*_args: object, **_kwargs: object) -> bool:
+    """Return ``True`` regardless of arguments."""
+
+    return True
+
+
+def return_none(*_args: object, **_kwargs: object) -> None:
+    """Return ``None`` regardless of arguments."""
+
+    return None
+
+
+def return_one(*_args: object, **_kwargs: object) -> int:
+    """Return ``1`` regardless of arguments."""
+
+    return 1
+
+
+def return_false(*_args: object, **_kwargs: object) -> bool:
+    """Return ``False`` regardless of arguments."""
+
+    return False


### PR DESCRIPTION
## Summary
- add generic helper functions for tests
- replace repeated lambdas in tests with helper functions

## Testing
- `black tests/utils.py load_tests/test_gpu_concurrency.py backend/mockup-generation/tests/test_tasks_upload.py backend/mockup-generation/tests/test_api_mockups.py backend/marketplace-publisher/tests/test_policy_failures.py backend/mockup-generation/tests/test_gpu_lock.py backend/mockup-generation/tests/test_gpu_metrics.py`
- `flake8 tests/utils.py load_tests/test_gpu_concurrency.py backend/mockup-generation/tests/test_tasks_upload.py backend/mockup-generation/tests/test_api_mockups.py backend/marketplace-publisher/tests/test_policy_failures.py backend/mockup-generation/tests/test_gpu_lock.py backend/mockup-generation/tests/test_gpu_metrics.py`
- `mypy tests/utils.py load_tests/test_gpu_concurrency.py backend/mockup-generation/tests/test_tasks_upload.py backend/mockup-generation/tests/test_api_mockups.py backend/marketplace-publisher/tests/test_policy_failures.py backend/mockup-generation/tests/test_gpu_lock.py backend/mockup-generation/tests/test_gpu_metrics.py` *(failed: Module has no attribute errors)*
- `pytest -W error tests/utils.py load_tests/test_gpu_concurrency.py backend/mockup-generation/tests/test_tasks_upload.py backend/mockup-generation/tests/test_api_mockups.py backend/marketplace-publisher/tests/test_policy_failures.py backend/mockup-generation/tests/test_gpu_lock.py backend/mockup-generation/tests/test_gpu_metrics.py` *(failed: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_6880193ef0108331aefe1a7b3d35178d