### PR TITLE
Add cron job for S3 lifecycle enforcement

### DIFF
--- a/docker/s3-lifecycle/Dockerfile
+++ b/docker/s3-lifecycle/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+RUN apt-get update \
+    && apt-get install -y awscli cron \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY scripts/apply_s3_lifecycle.py /app/apply_s3_lifecycle.py
+COPY LICENSES /licenses/LICENSES
+COPY docker/s3-lifecycle/s3lifecycle-crontab /etc/cron.d/s3lifecycle
+RUN chmod 0644 /etc/cron.d/s3lifecycle && crontab /etc/cron.d/s3lifecycle
+CMD ["cron", "-f"]

--- a/docker/s3-lifecycle/s3lifecycle-crontab
+++ b/docker/s3-lifecycle/s3lifecycle-crontab
@@ -1,0 +1,2 @@
+0 2 * * * BUCKET=$BUCKET STORAGE_CLASS=$STORAGE_CLASS python /app/apply_s3_lifecycle.py >> /var/log/s3lifecycle.log 2>&1
+

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -79,6 +79,13 @@ In production Docker Compose deployments a `backup` service runs `scripts/backup
 using cron. The container uploads a PostgreSQL dump to the bucket defined by
 `BACKUP_BUCKET` every night at midnight UTC.
 
+## Bucket Lifecycle Enforcement
+
+To ensure objects transition to cheaper storage tiers, the `s3-lifecycle` job
+invokes `scripts/apply_s3_lifecycle.py` daily. The job passes the target bucket
+and optional storage class through environment variables. It runs as a
+Kubernetes CronJob created by the `s3-lifecycle-jobs` Helm chart.
+
 ## Monthly Secret Rotation
 
 Secrets used by internal services are rotated automatically. The

--- a/infrastructure/helm/all-services/Chart.yaml
+++ b/infrastructure/helm/all-services/Chart.yaml
@@ -32,6 +32,9 @@ dependencies:
   - name: logrotate-jobs
     version: 0.1.0
     repository: "file://../logrotate-jobs"
+  - name: s3-lifecycle-jobs
+    version: 0.1.0
+    repository: "file://../s3-lifecycle-jobs"
   - name: monitoring
     version: 0.1.0
     repository: "file://../monitoring"

--- a/infrastructure/helm/s3-lifecycle-jobs/Chart.yaml
+++ b/infrastructure/helm/s3-lifecycle-jobs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: s3-lifecycle-jobs
+version: 0.1.0
+description: Helm chart for applying S3 lifecycle policies
+type: application
+appVersion: "1.0"

--- a/infrastructure/helm/s3-lifecycle-jobs/templates/cronjob.yaml
+++ b/infrastructure/helm/s3-lifecycle-jobs/templates/cronjob.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "s3-lifecycle-jobs.fullname" . }}
+  labels: {{- include "s3-lifecycle-jobs.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: s3-lifecycle
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: BUCKET
+                  value: {{ .Values.bucket | quote }}
+                - name: STORAGE_CLASS
+                  value: {{ .Values.storageClass | quote }}
+{{- range $key, $value := .Values.extraEnv }}
+                - name: {{ $key }}
+                  value: {{ $value | quote }}
+{{- end }}
+              volumeMounts:
+                - name: secret-volume
+                  mountPath: /run/secrets
+                  readOnly: true
+                - name: tmpfs-volume
+                  mountPath: /tmpfs
+              resources:
+{{ toYaml .Values.resources | nindent 14 }}
+              command: ["python", "/app/apply_s3_lifecycle.py"]
+          volumes:
+            - name: secret-volume
+              secret:
+                secretName: {{ .Values.secretName }}
+            - name: tmpfs-volume
+              emptyDir:
+                medium: Memory

--- a/infrastructure/helm/s3-lifecycle-jobs/values-dev.yaml
+++ b/infrastructure/helm/s3-lifecycle-jobs/values-dev.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: example/s3-lifecycle
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-bucket
+storageClass: GLACIER
+# Additional environment variables
+extraEnv: {}
+# Name of the Kubernetes secret mounted at /run/secrets
+secretName: shared-secret

--- a/infrastructure/helm/s3-lifecycle-jobs/values-prod.yaml
+++ b/infrastructure/helm/s3-lifecycle-jobs/values-prod.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: example/s3-lifecycle
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-bucket
+storageClass: GLACIER
+# Additional environment variables
+extraEnv: {}
+# Name of the Kubernetes secret mounted at /run/secrets
+secretName: shared-secret

--- a/infrastructure/helm/s3-lifecycle-jobs/values-production.yaml
+++ b/infrastructure/helm/s3-lifecycle-jobs/values-production.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: example/s3-lifecycle
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-bucket
+storageClass: GLACIER
+# Additional environment variables
+extraEnv: {}
+# Name of the Kubernetes secret mounted at /run/secrets
+secretName: shared-secret

--- a/infrastructure/helm/s3-lifecycle-jobs/values-staging.yaml
+++ b/infrastructure/helm/s3-lifecycle-jobs/values-staging.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: example/s3-lifecycle
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-bucket
+storageClass: GLACIER
+# Additional environment variables
+extraEnv: {}
+# Name of the Kubernetes secret mounted at /run/secrets
+secretName: shared-secret

--- a/infrastructure/helm/s3-lifecycle-jobs/values.yaml
+++ b/infrastructure/helm/s3-lifecycle-jobs/values.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: example/s3-lifecycle
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-bucket
+storageClass: GLACIER
+# Additional environment variables
+extraEnv: {}
+# Name of the Kubernetes secret mounted at /run/secrets
+secretName: shared-secret

--- a/scripts/apply_s3_lifecycle.py
+++ b/scripts/apply_s3_lifecycle.py
@@ -6,6 +6,7 @@ import json
 import logging
 import subprocess
 import sys
+import os
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
@@ -53,12 +54,27 @@ def apply_policy(bucket: str, storage_class: str = "GLACIER") -> None:
 
 
 def main(argv: list[str]) -> int:
-    """CLI entrypoint."""
-    if not argv or len(argv) > 2:
+    """
+    Run the lifecycle configuration utility.
+
+    The bucket name can be supplied as the first CLI argument or via the
+    ``BUCKET`` environment variable. The storage class defaults to
+    ``GLACIER`` and can be overridden by a second CLI argument or the
+    ``STORAGE_CLASS`` environment variable.
+    """
+
+    bucket = argv[0] if argv else os.environ.get("BUCKET")
+    if not bucket:
         logger.error("Usage: apply_s3_lifecycle.py <bucket> [storage-class]")
         return 1
-    storage_class = argv[1] if len(argv) == 2 else "GLACIER"
-    apply_policy(argv[0], storage_class)
+    if len(argv) > 2:
+        logger.error("Usage: apply_s3_lifecycle.py <bucket> [storage-class]")
+        return 1
+
+    storage_class = (
+        argv[1] if len(argv) == 2 else os.environ.get("STORAGE_CLASS", "GLACIER")
+    )
+    apply_policy(bucket, storage_class)
     return 0
 
 

--- a/tests/test_s3_lifecycle.py
+++ b/tests/test_s3_lifecycle.py
@@ -6,6 +6,7 @@ import json
 from unittest import mock
 
 from scripts.apply_s3_lifecycle import apply_policy
+from scripts.apply_s3_lifecycle import main
 
 
 def test_apply_policy_invokes_cli() -> None:
@@ -22,3 +23,12 @@ def test_apply_policy_invokes_cli() -> None:
         data = json.loads(cmd[-1])
         transition = data["Rules"][0]["Transitions"][0]
         assert transition["StorageClass"] == "GLACIER"
+
+
+def test_main_env_vars(monkeypatch: mock.MagicMock) -> None:
+    """``main`` falls back to environment variables."""
+    monkeypatch.setenv("BUCKET", "envbucket")
+    monkeypatch.setenv("STORAGE_CLASS", "DEEP_ARCHIVE")
+    with mock.patch("scripts.apply_s3_lifecycle.apply_policy") as apply:
+        assert main([]) == 0
+        apply.assert_called_once_with("envbucket", "DEEP_ARCHIVE")


### PR DESCRIPTION
## Summary
- allow `apply_s3_lifecycle.py` to read BUCKET and STORAGE_CLASS env vars
- run it daily via new `s3-lifecycle` Docker image
- provide Helm chart `s3-lifecycle-jobs` to schedule the cron job
- document lifecycle enforcement in maintenance docs
- test env var fallback logic

## Testing
- `mypy --config-file /tmp/mypy.ini --ignore-missing-imports tests/test_s3_lifecycle.py`
- `pytest tests/test_s3_lifecycle.py tests/test_maintenance_s3.py tests/test_rotate_s3_keys.py -W error -vv`

------
https://chatgpt.com/codex/tasks/task_b_688019456b748331b274ee6658c3fa9d