### PR TITLE
Batch signal ingestion tasks

### DIFF
--- a/backend/signal-ingestion/tests/test_parallel_ingestion.py
+++ b/backend/signal-ingestion/tests/test_parallel_ingestion.py
@@ -26,17 +26,12 @@ class DummyApp:
 
 
 def test_schedule_ingestion(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ensure each adapter is dispatched to its own queue."""
+    """Ensure adapters are dispatched in a single batch."""
     dummy = DummyApp()
     monkeypatch.setattr(tasks, "app", dummy)
     tasks.schedule_ingestion(["tiktok", "instagram"])
     assert dummy.sent == [
-        ("signal_ingestion.ingest_adapter", ["tiktok"], tasks.queue_for("tiktok")),
-        (
-            "signal_ingestion.ingest_adapter",
-            ["instagram"],
-            tasks.queue_for("instagram"),
-        ),
+        ("signal_ingestion.ingest_batch", ["tiktok", "instagram"], None)
     ]
 
 


### PR DESCRIPTION
## Summary
- process ingestion jobs in a single Celery batch
- update ingestion scheduler test for batched dispatch

## Testing
- `pytest -n auto -W error -vv` *(fails: FileNotFoundError: No such file or directory, docker.errors.DockerException)*
- `pytest backend/signal-ingestion/tests/test_parallel_ingestion.py -k test_schedule_ingestion -vv` *(fails: ModuleNotFoundError: No module named 'signal_ingestion')*

------
https://chatgpt.com/codex/tasks/task_b_6880193fd4e48331a5a64b13450dfd46