### PR TITLE
Add isort hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
       - id: black
         files: "\\.(py|pyi)$"
         args: ["--line-length=88"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile=black"]
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ To get started:
 Black and Prettier run in formatting mode, so staged files will be automatically
 updated.
 
-The hooks enforce Black, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Docstrings should follow the Numpy style and are checked with flake8-docstrings. Warnings are treated as errors, so commits will fail until issues are fixed.
+The hooks enforce Black, isort, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Docstrings should follow the Numpy style and are checked with flake8-docstrings. Warnings are treated as errors, so commits will fail until issues are fixed.
 
 ## CI Lint Commands
 

--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -5,31 +5,28 @@ from __future__ import annotations
 import logging
 import os
 import uuid
-from typing import Any, Callable, Coroutine, Dict, Iterable, cast
 from collections.abc import AsyncIterator
-
 from datetime import datetime
-
 from functools import lru_cache
+from typing import Any, Callable, Coroutine, Dict, Iterable, cast
+
 from fastapi import Depends, FastAPI, Request, Response
-from backend.shared.security import require_status_api_key
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
 
-from backend.shared.db import AsyncSessionLocal
-from backend.shared.db import models
-from .auth import require_role
-from backend.shared.tracing import configure_tracing
-from backend.shared.profiling import add_profiling
-from backend.shared.metrics import register_metrics
-from backend.shared.security import add_security_headers
-from backend.shared.responses import json_cached, gzip_aiter
-from backend.shared.logging import configure_logging
 from backend.shared import ServiceName, add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
-from fastapi.middleware.cors import CORSMiddleware
+from backend.shared.db import AsyncSessionLocal, models
+from backend.shared.logging import configure_logging
+from backend.shared.metrics import register_metrics
+from backend.shared.profiling import add_profiling
+from backend.shared.responses import gzip_aiter, json_cached
+from backend.shared.security import add_security_headers, require_status_api_key
+from backend.shared.tracing import configure_tracing
 
+from .auth import require_role
 
 configure_logging()
 logger = logging.getLogger(__name__)

--- a/backend/analytics/auth.py
+++ b/backend/analytics/auth.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Callable, cast, Iterable
+from typing import Any, Callable, Dict, Iterable, cast
 
 from fastapi import Depends, HTTPException, status
 

--- a/backend/api-gateway/src/api_gateway/auth.py
+++ b/backend/api-gateway/src/api_gateway/auth.py
@@ -1,6 +1,6 @@
 """JWT authentication utilities for the API gateway."""
 
-from typing import Any, Dict, Callable, cast, Iterable
+from typing import Any, Callable, Dict, Iterable, cast
 
 from fastapi import Depends, HTTPException, status
 

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -7,27 +7,27 @@ from functools import lru_cache
 from time import perf_counter
 from typing import Callable, Coroutine, cast
 
+from brotli_asgi import BrotliMiddleware
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
-from brotli_asgi import BrotliMiddleware
-from backend.shared.cache import get_async_client
 from fastapi.security import HTTPAuthorizationCredentials
 from prometheus_client import Counter, Histogram
 
-from .routes import router, close_http_clients
-from backend.shared.tracing import configure_tracing
-from backend.shared.profiling import add_profiling
-from backend.shared.metrics import register_metrics
-from backend.shared.security import add_security_headers, require_status_api_key
-from backend.shared.responses import json_cached
-from backend.shared.logging import configure_logging
-from backend.shared.db import run_migrations_if_needed
 from backend.shared import ServiceName, add_error_handlers, configure_sentry
+from backend.shared.cache import get_async_client
 from backend.shared.config import settings as shared_settings
-from .rate_limiter import UserRateLimiter
-from .settings import settings
-from .auth import verify_token
+from backend.shared.db import run_migrations_if_needed
+from backend.shared.logging import configure_logging
+from backend.shared.metrics import register_metrics
+from backend.shared.profiling import add_profiling
+from backend.shared.responses import json_cached
+from backend.shared.security import add_security_headers, require_status_api_key
+from backend.shared.tracing import configure_tracing
 
+from .auth import verify_token
+from .rate_limiter import UserRateLimiter
+from .routes import close_http_clients, router
+from .settings import settings
 
 configure_logging()
 logger = logging.getLogger(__name__)

--- a/backend/api-gateway/src/api_gateway/rate_limiter.py
+++ b/backend/api-gateway/src/api_gateway/rate_limiter.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+
 from redis.asyncio import WatchError
+
 from backend.shared.cache import AsyncRedis, get_async_client
 
 
 class UserRateLimiter:
     """Manage request quotas for individual users."""
 
-    def __init__(self, limit: int, window: int, redis: AsyncRedis | None = None) -> None:
+    def __init__(
+        self, limit: int, window: int, redis: AsyncRedis | None = None
+    ) -> None:
         """Instantiate the limiter with ``limit`` tokens per ``window`` seconds."""
         self._redis = redis or get_async_client()
         self._limit = limit

--- a/backend/api-gateway/tests/test_approvals.py
+++ b/backend/api-gateway/tests/test_approvals.py
@@ -5,8 +5,8 @@ import sys
 from pathlib import Path
 
 import fakeredis.aioredis
-from fastapi.testclient import TestClient
 from api_gateway.auth import create_access_token
+from fastapi.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 

--- a/backend/api-gateway/tests/test_audit_logs.py
+++ b/backend/api-gateway/tests/test_audit_logs.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+from api_gateway.auth import create_access_token  # noqa: E402
+from api_gateway.main import app  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app  # noqa: E402
-from api_gateway.auth import create_access_token  # noqa: E402
 from backend.shared.db import Base, engine, session_scope  # noqa: E402
 from backend.shared.db.models import UserRole  # noqa: E402
 

--- a/backend/api-gateway/tests/test_auth.py
+++ b/backend/api-gateway/tests/test_auth.py
@@ -7,10 +7,11 @@ root_path = Path(__file__).resolve().parents[3]
 sys.path.append(str(root_path))  # noqa: E402
 sys.path.append(str(root_path / "backend" / "api-gateway" / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient  # noqa: E402
 from typing import cast
 
 from api_gateway.main import app  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
 from backend.shared.db import Base, engine, session_scope  # noqa: E402
 from backend.shared.db.models import UserRole  # noqa: E402
 

--- a/backend/api-gateway/tests/test_feature_flags.py
+++ b/backend/api-gateway/tests/test_feature_flags.py
@@ -1,16 +1,17 @@
 """Tests for feature flag routes."""
 
-import sys
 import os
+import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient  # noqa: E402
 import importlib  # noqa: E402
-import fakeredis.aioredis  # noqa: E402
 
+import fakeredis.aioredis  # noqa: E402
 from api_gateway.auth import create_access_token  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
 from backend.shared import feature_flags  # noqa: E402
 
 

--- a/backend/api-gateway/tests/test_gateway_timeout.py
+++ b/backend/api-gateway/tests/test_gateway_timeout.py
@@ -3,14 +3,14 @@
 import importlib
 from typing import Any
 
+import api_gateway.main as main_module
+import api_gateway.routes as routes
 import httpx
 import pytest
 import respx
 from fastapi.testclient import TestClient
 
 from backend.shared.http import DEFAULT_TIMEOUT
-import api_gateway.main as main_module
-import api_gateway.routes as routes
 
 
 class AssertTimeoutClient(httpx.AsyncClient):

--- a/backend/api-gateway/tests/test_health.py
+++ b/backend/api-gateway/tests/test_health.py
@@ -5,9 +5,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient  # noqa: E402
-
 from api_gateway.main import app  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/api-gateway/tests/test_maintenance.py
+++ b/backend/api-gateway/tests/test_maintenance.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+from api_gateway.auth import create_access_token  # noqa: E402
+from api_gateway.main import app  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app  # noqa: E402
-from api_gateway.auth import create_access_token  # noqa: E402
 from backend.shared.db import Base, engine, session_scope  # noqa: E402
 from backend.shared.db.models import UserRole  # noqa: E402
 from scripts import maintenance  # noqa: E402

--- a/backend/api-gateway/tests/test_metrics_ws.py
+++ b/backend/api-gateway/tests/test_metrics_ws.py
@@ -10,6 +10,7 @@ import socket
 import sys
 import threading
 import time
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -18,7 +19,6 @@ import pytest
 import uvicorn
 import websockets
 from fastapi import FastAPI
-import warnings
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 sys.path.append(

--- a/backend/api-gateway/tests/test_privacy_endpoint.py
+++ b/backend/api-gateway/tests/test_privacy_endpoint.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
+from api_gateway.auth import create_access_token  # noqa: E402
+from api_gateway.main import app  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app  # noqa: E402
-from api_gateway.auth import create_access_token  # noqa: E402
 from backend.shared.db import Base, engine, session_scope  # noqa: E402
 from backend.shared.db.models import UserRole  # noqa: E402
 

--- a/backend/api-gateway/tests/test_roles.py
+++ b/backend/api-gateway/tests/test_roles.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+from api_gateway.auth import create_access_token  # noqa: E402
+from api_gateway.main import app  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app  # noqa: E402
-from api_gateway.auth import create_access_token  # noqa: E402
 from backend.shared.db import Base, engine, session_scope  # noqa: E402
 from backend.shared.db.models import UserRole  # noqa: E402
 

--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -8,17 +8,18 @@ sys.path.append(
     str(Path(__file__).resolve().parents[2] / "signal-ingestion" / "src")
 )  # noqa: E402
 
-from fastapi.testclient import TestClient  # noqa: E402
-import httpx  # noqa: E402
-import pytest  # noqa: E402
-
 from types import TracebackType  # noqa: E402
 from typing import Any, Optional, Type  # noqa: E402
+
+import httpx  # noqa: E402
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 
 def test_status(monkeypatch: pytest.MonkeyPatch) -> None:
     """Status endpoint should return OK."""
     import importlib
+
     import fakeredis.aioredis
 
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
@@ -26,7 +27,6 @@ def test_status(monkeypatch: pytest.MonkeyPatch) -> None:
 
     shared_config.settings.redis_url = "redis://localhost:6379/0"
     import api_gateway.main as main_module
-
     import api_gateway.routes as routes
 
     main_module.rate_limiter._redis = fakeredis.aioredis.FakeRedis()
@@ -47,6 +47,7 @@ import pytest  # noqa: E402
 def test_trpc_ping(monkeypatch: pytest.MonkeyPatch) -> None:
     """Proxy tRPC ping to backend service."""
     import importlib
+
     import fakeredis.aioredis
 
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
@@ -107,6 +108,7 @@ def test_trpc_etag(monkeypatch: pytest.MonkeyPatch) -> None:
     """TRPC endpoint should respond with 304 when ETag matches."""
     import importlib
     import warnings
+
     import fakeredis.aioredis
     import prometheus_client
 
@@ -172,6 +174,7 @@ def test_trpc_etag(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_optimization_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     """Proxy optimization endpoint to optimization service."""
     import importlib
+
     import fakeredis.aioredis
 
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
@@ -213,6 +216,7 @@ def test_optimization_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_monitoring_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     """Proxy monitoring endpoint."""
     import importlib
+
     import fakeredis.aioredis
 
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
@@ -257,6 +261,7 @@ def test_monitoring_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_analytics_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     """Proxy analytics endpoint."""
     import importlib
+
     import fakeredis.aioredis
 
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/api-gateway/tests/test_security_headers.py
+++ b/backend/api-gateway/tests/test_security_headers.py
@@ -2,12 +2,12 @@
 
 import importlib
 import sys
+import warnings
 from pathlib import Path
 from typing import Any
 
-from fastapi.testclient import TestClient
 import fakeredis.aioredis
-import warnings
+from fastapi.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 

--- a/backend/api-gateway/tests/test_trending.py
+++ b/backend/api-gateway/tests/test_trending.py
@@ -8,11 +8,10 @@ sys.path.append(
     str(Path(__file__).resolve().parents[2] / "signal-ingestion" / "src")
 )  # noqa: E402
 
-from fastapi.testclient import TestClient  # noqa: E402
-import pytest  # noqa: E402
-
 import api_gateway.main as main_module  # noqa: E402
 import api_gateway.routes as routes  # noqa: E402
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 client = TestClient(main_module.app)
 

--- a/backend/api-gateway/tests/test_ws_metrics.py
+++ b/backend/api-gateway/tests/test_ws_metrics.py
@@ -3,9 +3,9 @@
 import asyncio
 import importlib
 import sys
+import warnings
 from pathlib import Path
 from typing import Any, Optional, Type
-import warnings
 
 import fakeredis.aioredis
 import httpx

--- a/backend/feedback-loop/feedback_loop/ab_testing.py
+++ b/backend/feedback-loop/feedback_loop/ab_testing.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from typing import Iterator, Mapping
 
+import numpy as np
 from sqlalchemy import (
     Boolean,
     Date,
@@ -17,10 +18,10 @@ from sqlalchemy import (
     func,
     select,
 )
-from sqlalchemy.pool import StaticPool
-from backend.shared.db import register_pool_metrics
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
-import numpy as np
+from sqlalchemy.pool import StaticPool
+
+from backend.shared.db import register_pool_metrics
 
 
 class Base(DeclarativeBase):  # type: ignore[misc]

--- a/backend/feedback-loop/feedback_loop/auth.py
+++ b/backend/feedback-loop/feedback_loop/auth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, cast, Iterable
+from typing import Any, Callable, Dict, Iterable, cast
 
 from fastapi import Depends, HTTPException, status
 

--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -2,23 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from typing import Iterable, Mapping
 
 import requests
-from backend.shared.http import request_with_retry
-import asyncio
 from apscheduler.job import Job
-from apscheduler.schedulers.base import BaseScheduler
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from marketplace_publisher.publisher import CLIENTS
+from apscheduler.schedulers.base import BaseScheduler
 from marketplace_publisher.clients import BaseClient
+from marketplace_publisher.publisher import CLIENTS
+from scoring_engine import weight_repository
 from sqlalchemy import func
 
-from backend.shared.db import session_scope
-from backend.shared.db import models
-from scoring_engine import weight_repository
+from backend.shared.db import models, session_scope
+from backend.shared.http import request_with_retry
+
 from .weight_updater import update_weights
 
 logger = logging.getLogger(__name__)

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -8,19 +8,19 @@ import sys
 import uuid
 from typing import Any, Callable, Coroutine, Optional
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Response
-from backend.shared.security import require_status_api_key
-from fastapi.middleware.cors import CORSMiddleware
 from apscheduler.schedulers.background import BackgroundScheduler
-from backend.shared.metrics import register_metrics
-from backend.shared.security import add_security_headers
-from backend.shared.responses import json_cached
-from backend.shared.tracing import configure_tracing
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+
+from backend.shared.config import settings as shared_settings
+from backend.shared.metrics import register_metrics
+from backend.shared.responses import json_cached
+from backend.shared.security import add_security_headers, require_status_api_key
+from backend.shared.tracing import configure_tracing
 
 from .ab_testing import ABTestManager
 from .auth import require_role
-from backend.shared.config import settings as shared_settings
 from .settings import settings
 
 app = FastAPI(title="Feedback Loop")
@@ -63,8 +63,8 @@ async def startup() -> None:
     """Start background scheduler and setup exception logging."""
     global scheduler
     # Import here to avoid heavy dependencies at module import time
-    from .scheduler import setup_scheduler
     from .ingestion import schedule_marketplace_ingestion
+    from .scheduler import setup_scheduler
 
     listing_env = os.environ.get("MARKETPLACE_LISTING_IDS", "")
     listing_ids = [int(i) for i in listing_env.split(",") if i.strip()]
@@ -179,8 +179,9 @@ async def get_stats(
 
 if __name__ == "__main__":  # pragma: no cover
     import asyncio
-    import uvloop
+
     import uvicorn
+    import uvloop
 
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 

--- a/backend/feedback-loop/feedback_loop/scheduler.py
+++ b/backend/feedback-loop/feedback_loop/scheduler.py
@@ -10,8 +10,8 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from .ab_testing import ABTestManager
 from .ingestion import ingest_metrics, schedule_marketplace_ingestion
-from .weight_updater import update_weights
 from .settings import settings
+from .weight_updater import update_weights
 
 logger = logging.getLogger(__name__)
 

--- a/backend/feedback-loop/feedback_loop/weight_updater.py
+++ b/backend/feedback-loop/feedback_loop/weight_updater.py
@@ -6,8 +6,8 @@ import logging
 from typing import Iterable, Mapping
 
 import numpy as np
-
 import requests
+
 from backend.shared.http import request_with_retry
 
 logger = logging.getLogger(__name__)

--- a/backend/feedback-loop/tests/test_ab_testing.py
+++ b/backend/feedback-loop/tests/test_ab_testing.py
@@ -1,7 +1,7 @@
 """Tests for A/B test budget allocation."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 

--- a/backend/feedback-loop/tests/test_health.py
+++ b/backend/feedback-loop/tests/test_health.py
@@ -1,7 +1,7 @@
 """Tests for feedback loop health endpoints."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 

--- a/backend/feedback-loop/tests/test_ingestion.py
+++ b/backend/feedback-loop/tests/test_ingestion.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import os
 import importlib
-from pathlib import Path
+import os
 import sys
+import types
+from pathlib import Path
 
 import pytest
 from apscheduler.schedulers.background import BackgroundScheduler
-import types
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
@@ -37,7 +37,8 @@ def _db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     import backend.shared.db as db
 
     importlib.reload(db)
-    from backend.shared.db import Base, models as db_models  # noqa: F401
+    from backend.shared.db import Base
+    from backend.shared.db import models as db_models  # noqa: F401
 
     Base.metadata.create_all(db.engine)
     try:

--- a/backend/feedback-loop/tests/test_lifecycle.py
+++ b/backend/feedback-loop/tests/test_lifecycle.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from fastapi.testclient import TestClient  # noqa: E402
 import feedback_loop.main as main  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 
 class DummyScheduler:
@@ -58,8 +58,8 @@ def test_startup_schedules_ingestion(monkeypatch) -> None:
         called["ids"] = ids
         called["url"] = url
 
-    import feedback_loop.scheduler as scheduler_mod
     import feedback_loop.ingestion as ingestion_mod
+    import feedback_loop.scheduler as scheduler_mod
 
     monkeypatch.setattr(scheduler_mod, "setup_scheduler", fake_setup_scheduler)
     monkeypatch.setattr(ingestion_mod, "schedule_marketplace_ingestion", fake_schedule)

--- a/backend/feedback-loop/tests/test_main.py
+++ b/backend/feedback-loop/tests/test_main.py
@@ -1,21 +1,23 @@
 """Tests for feedback loop main endpoints."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import feedback_loop.main as main  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from feedback_loop import ABTestManager  # noqa: E402
-import feedback_loop.main as main  # noqa: E402
 from feedback_loop.auth import create_access_token  # noqa: E402
+
 from backend.shared.db import Base, SessionLocal, engine, models  # noqa: E402
 
 
 def test_impression_conversion_allocation(tmp_path, monkeypatch) -> None:
     """Recorded events should influence allocation."""
-    import backend.shared.db as shared_db
     import feedback_loop.ab_testing as abt
+
+    import backend.shared.db as shared_db
 
     monkeypatch.setattr(shared_db, "register_pool_metrics", lambda *_: None)
     monkeypatch.setattr(abt, "register_pool_metrics", lambda *_: None)
@@ -57,8 +59,9 @@ def test_impression_conversion_allocation(tmp_path, monkeypatch) -> None:
 
 def test_stats_endpoint(tmp_path, monkeypatch) -> None:
     """/stats should return conversion totals."""
-    import backend.shared.db as shared_db
     import feedback_loop.ab_testing as abt
+
+    import backend.shared.db as shared_db
 
     monkeypatch.setattr(shared_db, "register_pool_metrics", lambda *_: None)
     monkeypatch.setattr(abt, "register_pool_metrics", lambda *_: None)

--- a/backend/feedback-loop/tests/test_scheduler.py
+++ b/backend/feedback-loop/tests/test_scheduler.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import importlib.util
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Callable, Dict, cast
 

--- a/backend/feedback-loop/tests/test_weight_updater.py
+++ b/backend/feedback-loop/tests/test_weight_updater.py
@@ -1,9 +1,10 @@
 """Tests for weight updater."""
 
+import importlib.util
+import sys
 from pathlib import Path
 from typing import Any
-import sys
-import importlib.util
+
 import pytest
 from requests import RequestException
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/clients.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/clients.py
@@ -2,30 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
+import gzip
+import os
+import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
-import gzip
 
-import os
-import requests
 import httpx
-from backend.shared.http import request_with_retry, get_async_http_client
+import requests
 from requests_oauthlib import OAuth2Session
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
-import time
-import asyncio
 
-from datetime import datetime
+from backend.shared.http import get_async_http_client, request_with_retry
 
-from .settings import settings
-
-from .db import (
-    Marketplace,
-    get_oauth_token_sync,
-    upsert_oauth_token_sync,
-)
 from . import rules
+from .db import Marketplace, get_oauth_token_sync, upsert_oauth_token_sync
+from .settings import settings
 
 
 async def get_async_client() -> httpx.AsyncClient:

--- a/backend/marketplace-publisher/src/marketplace_publisher/db.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/db.py
@@ -7,15 +7,16 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from backend.shared.db import models as shared_models
-
 from sqlalchemy import DateTime
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy import ForeignKey, Integer, String, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from backend.shared.db import async_engine, AsyncSessionLocal, session_scope
+from backend.shared.db import AsyncSessionLocal, async_engine
+from backend.shared.db import models as shared_models
+from backend.shared.db import session_scope
+
 from .settings import settings
 
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -14,6 +14,11 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Coroutine, cast
 
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, ConfigDict  # noqa: I201
+from sqlalchemy import func, update
+
 from backend.shared import (
     add_error_handlers,
     configure_sentry,
@@ -27,15 +32,8 @@ from backend.shared.db import run_migrations_if_needed, session_scope
 from backend.shared.metrics import register_metrics
 from backend.shared.profiling import add_profiling
 from backend.shared.responses import json_cached
-from backend.shared.security import add_security_headers
+from backend.shared.security import add_security_headers, require_status_api_key
 from backend.shared.tracing import configure_tracing
-
-from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Response
-from backend.shared.security import require_status_api_key
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, ConfigDict  # noqa: I201
-
-from sqlalchemy import func, update
 
 from . import notifications, publisher
 from .db import (
@@ -420,8 +418,8 @@ if __name__ == "__main__":  # pragma: no cover
     if args.no_selenium:
         os.environ["SELENIUM_SKIP"] = "1"
 
-    import uvloop
     import uvicorn
+    import uvloop
 
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
@@ -3,19 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import os
 from typing import Any
 
-import atexit
-
+import requests
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .db import create_webhook_event
-
-import requests
 from backend.shared.http import request_with_retry
 
+from .db import create_webhook_event
 
 logger = logging.getLogger(__name__)
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/pricing.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/pricing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Any
+from typing import Any, Mapping
 
 from .db import Marketplace
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
@@ -2,29 +2,26 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Literal, Mapping
-import logging
 
+from mockup_generation.post_processor import ensure_not_nsfw
+from PIL import Image
 from requests import RequestException
-from sqlalchemy.exc import SQLAlchemyError
-
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from . import rules
 from .clients import (
     AmazonMerchClient,
     EtsyClient,
     RedbubbleClient,
+    SeleniumFallback,
     Society6Client,
     ZazzleClient,
-    SeleniumFallback,
 )
-from .trademark import is_trademarked
-from .notifications import notify_failure
-from mockup_generation.post_processor import ensure_not_nsfw
-from PIL import Image
-from . import rules
 from .db import (
     Marketplace,
     PublishStatus,
@@ -32,7 +29,8 @@ from .db import (
     increment_attempts,
     update_task_status,
 )
-
+from .notifications import notify_failure
+from .trademark import is_trademarked
 
 CLIENTS = {
     Marketplace.redbubble: RedbubbleClient(),

--- a/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from redis.asyncio import WatchError
+
 from backend.shared.cache import AsyncRedis, get_async_client
 
 from .db import Marketplace

--- a/backend/marketplace-publisher/src/marketplace_publisher/rules.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rules.py
@@ -6,10 +6,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, cast
 
+import yaml
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
-
-import yaml
 
 from .db import Marketplace
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from backend.shared.config import settings as shared_settings
-
 from pydantic import AnyUrl, HttpUrl, RedisDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict  # noqa: I201
+
+from backend.shared.config import settings as shared_settings
 
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from .db import Marketplace

--- a/backend/marketplace-publisher/src/marketplace_publisher/trademark.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/trademark.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, cast
 
 import requests
+
 from backend.shared.http import request_with_retry
 
 logger = logging.getLogger(__name__)

--- a/backend/marketplace-publisher/tests/test_api.py
+++ b/backend/marketplace-publisher/tests/test_api.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from fastapi.testclient import TestClient
-import fakeredis.aioredis
-from typing import Any
-from pathlib import Path
 import warnings
+from pathlib import Path
+from typing import Any
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
 
 
 def test_publish_and_progress(monkeypatch: Any, tmp_path: Path) -> None:
@@ -15,9 +16,9 @@ def test_publish_and_progress(monkeypatch: Any, tmp_path: Path) -> None:
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
     monkeypatch.setenv("SELENIUM_SKIP", "1")
     warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from marketplace_publisher import publisher
     from marketplace_publisher.db import Marketplace
     from marketplace_publisher.main import app, rate_limiter
-    from marketplace_publisher import publisher
 
     rate_limiter._redis = fakeredis.aioredis.FakeRedis()
 

--- a/backend/marketplace-publisher/tests/test_clients.py
+++ b/backend/marketplace-publisher/tests/test_clients.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Callable
 import os
 from datetime import datetime
+from pathlib import Path
+from typing import Callable
 
 import pytest
 import responses
@@ -189,8 +189,8 @@ async def test_tokens_persisted_and_reused(
 ) -> None:
     """Load tokens from database and refresh when expired."""
 
-    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from marketplace_publisher import db
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
@@ -237,8 +237,8 @@ async def test_oauth_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test OAuth login and callback storing tokens."""
 
     from fastapi.testclient import TestClient
-    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from marketplace_publisher import db, main
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
@@ -247,6 +247,7 @@ async def test_oauth_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
 
     import importlib
+
     import backend.shared.db as shared_db
 
     importlib.reload(shared_db)

--- a/backend/marketplace-publisher/tests/test_feature_flags.py
+++ b/backend/marketplace-publisher/tests/test_feature_flags.py
@@ -2,18 +2,20 @@
 
 from __future__ import annotations
 
-from fastapi.testclient import TestClient
-import fakeredis.aioredis
-from typing import Any
 from pathlib import Path
+from typing import Any
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
 
 
 def test_society6_flag(monkeypatch: Any, tmp_path: Path) -> None:
     """Return 403 when Society6 integration is disabled."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    from marketplace_publisher import publisher
     from marketplace_publisher.db import Marketplace
     from marketplace_publisher.main import app, rate_limiter
-    from marketplace_publisher import publisher
+
     from backend.shared import feature_flags
 
     rate_limiter._redis = fakeredis.aioredis.FakeRedis()
@@ -47,9 +49,10 @@ def test_society6_flag(monkeypatch: Any, tmp_path: Path) -> None:
 def test_zazzle_flag(monkeypatch: Any, tmp_path: Path) -> None:
     """Return 403 when Zazzle integration is disabled."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    from marketplace_publisher import publisher
     from marketplace_publisher.db import Marketplace
     from marketplace_publisher.main import app, rate_limiter
-    from marketplace_publisher import publisher
+
     from backend.shared import feature_flags
 
     rate_limiter._redis = fakeredis.aioredis.FakeRedis()

--- a/backend/marketplace-publisher/tests/test_listings.py
+++ b/backend/marketplace-publisher/tests/test_listings.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 
-from fastapi.testclient import TestClient
-
 import pytest
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture()

--- a/backend/marketplace-publisher/tests/test_metrics.py
+++ b/backend/marketplace-publisher/tests/test_metrics.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from fastapi.testclient import TestClient
 import importlib
+from pathlib import Path
+
 import pytest
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture()
@@ -15,6 +16,7 @@ def _setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     sync_url = f"sqlite:///{tmp_path}/metrics.db"
     monkeypatch.setenv("DATABASE_URL", async_url)
     from marketplace_publisher.main import app
+
     import backend.shared.db as db
 
     monkeypatch.setenv("DATABASE_URL", sync_url)

--- a/backend/marketplace-publisher/tests/test_notifications.py
+++ b/backend/marketplace-publisher/tests/test_notifications.py
@@ -23,12 +23,12 @@ import asyncio
 import logging
 
 import pytest
-import responses
 import requests
-import backend.shared.http as http
-
+import responses
 from marketplace_publisher import notifications  # noqa: E402
 from monitoring import pagerduty  # noqa: E402
+
+import backend.shared.http as http
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]

--- a/backend/marketplace-publisher/tests/test_policy_failures.py
+++ b/backend/marketplace-publisher/tests/test_policy_failures.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
-from fastapi.testclient import TestClient
 import fakeredis.aioredis
-from marketplace_publisher import publisher, db
+import pytest
+from fastapi.testclient import TestClient
+from marketplace_publisher import db, publisher
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 @pytest.mark.asyncio()

--- a/backend/marketplace-publisher/tests/test_pricing.py
+++ b/backend/marketplace-publisher/tests/test_pricing.py
@@ -4,16 +4,15 @@ import os
 
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"  # noqa: E402
 
+import pytest
+from marketplace_publisher.db import Marketplace  # noqa: E402
 from marketplace_publisher.pricing import (
+    BASE_PRICE,
+    FEE_PERCENT,
+    SCORE_FACTOR,
     adjust_price,
     create_listing_metadata,
-    BASE_PRICE,
-    SCORE_FACTOR,
-    FEE_PERCENT,
 )
-from marketplace_publisher.db import Marketplace  # noqa: E402
-
-import pytest
 
 
 def test_adjust_price_includes_score_and_fee() -> None:

--- a/backend/marketplace-publisher/tests/test_publish_metrics.py
+++ b/backend/marketplace-publisher/tests/test_publish_metrics.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import importlib
+from pathlib import Path
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
 from marketplace_publisher import db, main, publisher
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 @pytest.mark.asyncio()

--- a/backend/marketplace-publisher/tests/test_rate_limit.py
+++ b/backend/marketplace-publisher/tests/test_rate_limit.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import fakeredis.aioredis
 from fastapi.testclient import TestClient
-from typing import Any
-from pathlib import Path
 
 
 def test_rate_limit_exceeded(monkeypatch: Any, tmp_path: Path) -> None:
     """Return 429 when requests exceed the allowed rate."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
     monkeypatch.setenv("RATE_LIMIT_REDBUBBLE", "1")
+    from marketplace_publisher import publisher
     from marketplace_publisher.db import Marketplace
     from marketplace_publisher.main import app, rate_limiter
-    from marketplace_publisher import publisher
 
     rate_limiter._redis = fakeredis.aioredis.FakeRedis()
     rate_limiter._limits[Marketplace.redbubble] = 1  # type: ignore[index]

--- a/backend/marketplace-publisher/tests/test_retry.py
+++ b/backend/marketplace-publisher/tests/test_retry.py
@@ -3,27 +3,25 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from pathlib import Path
 from typing import Any
 
-import sys
 import pytest
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT))
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-import requests
-
 import os
 import warnings
+
+import requests
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
-from marketplace_publisher import notifications
-
-from marketplace_publisher import db, main, publisher
+from marketplace_publisher import db, main, notifications, publisher
 from marketplace_publisher.settings import settings
 
 

--- a/backend/marketplace-publisher/tests/test_rules_reload.py
+++ b/backend/marketplace-publisher/tests/test_rules_reload.py
@@ -6,10 +6,9 @@ import time
 from pathlib import Path
 from typing import Iterator
 
+import pytest
 from marketplace_publisher import rules
 from marketplace_publisher.db import Marketplace
-
-import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/backend/marketplace-publisher/tests/test_selenium_fallback.py
+++ b/backend/marketplace-publisher/tests/test_selenium_fallback.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+import os
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from threading import Thread
 from typing import Iterator
-import os
 
 import pytest
-import yaml
 import selenium.webdriver
-
+import yaml
 from marketplace_publisher import rules
 from marketplace_publisher.clients import SeleniumFallback
 from marketplace_publisher.db import Marketplace

--- a/backend/marketplace-publisher/tests/test_trademark.py
+++ b/backend/marketplace-publisher/tests/test_trademark.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import requests
-
 import pytest
-
+import requests
 from marketplace_publisher.trademark import is_trademarked
 
 

--- a/backend/marketplace-publisher/tests/test_validation.py
+++ b/backend/marketplace-publisher/tests/test_validation.py
@@ -2,20 +2,21 @@
 
 from __future__ import annotations
 
-from fastapi.testclient import TestClient
-import fakeredis.aioredis
-from PIL import Image
-from typing import Any
 from pathlib import Path
+from typing import Any
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+from PIL import Image
 
 
 def test_invalid_dimensions(monkeypatch: Any, tmp_path: Path) -> None:
     """Return 400 for mockups exceeding dimension limits."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    from marketplace_publisher import publisher
     from marketplace_publisher.db import Marketplace
     from marketplace_publisher.main import app, rate_limiter
-    from marketplace_publisher import publisher
 
     rate_limiter._redis = fakeredis.aioredis.FakeRedis()
 

--- a/backend/marketplace-publisher/tests/validators/test_marketplace_settings.py
+++ b/backend/marketplace-publisher/tests/validators/test_marketplace_settings.py
@@ -1,14 +1,13 @@
 """Validation for marketplace_publisher settings."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 
 import pytest  # noqa: E402
-from pydantic import ValidationError  # noqa: E402
-
 from marketplace_publisher.settings import Settings  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
 
 
 def test_blank_unleash_token() -> None:

--- a/backend/mockup-generation/mockup_generation/api.py
+++ b/backend/mockup-generation/mockup_generation/api.py
@@ -9,26 +9,25 @@ from functools import lru_cache
 from typing import Callable, Coroutine
 
 from fastapi import FastAPI, HTTPException, Request, Response
-from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from backend.shared.logging import configure_logging
-from backend.shared.tracing import configure_tracing
-from backend.shared.profiling import add_profiling
 from backend.shared import ServiceName, add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
+from backend.shared.logging import configure_logging
 from backend.shared.metrics import register_metrics
-from backend.shared.security import add_security_headers
+from backend.shared.profiling import add_profiling
 from backend.shared.responses import json_cached
+from backend.shared.security import add_security_headers, require_status_api_key
+from backend.shared.tracing import configure_tracing
 
+from .celery_app import app as celery_app
 from .model_repository import (
     list_generated_mockups,
     list_models,
     register_model,
     set_default,
 )
-from .celery_app import app as celery_app
 
 configure_logging()
 logger = logging.getLogger(__name__)

--- a/backend/mockup-generation/mockup_generation/celery_app.py
+++ b/backend/mockup-generation/mockup_generation/celery_app.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 import os
 from typing import Iterable, cast
 
+import redis
 from celery import Celery
 from celery.signals import worker_ready
 from prometheus_client import REGISTRY
 from prometheus_client.core import GaugeMetricFamily
-import redis
 
 from backend.shared.queue_metrics import register_redis_queue_collector
 
 from .tasks import queue_for_gpu
-
 
 CELERY_BROKER = os.getenv("CELERY_BROKER", "redis")
 if CELERY_BROKER == "redis":

--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
-from .settings import settings
-from .model_repository import get_default_model_id
 import httpx
-import asyncio
+
 from backend.shared.http import get_async_http_client
+
+from .model_repository import get_default_model_id
+from .settings import settings
 
 
 async def get_async_client() -> httpx.AsyncClient:
@@ -21,8 +23,8 @@ async def get_async_client() -> httpx.AsyncClient:
 
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from PIL import Image
     from diffusers import StableDiffusionXLPipeline
+    from PIL import Image
 
 
 logger = logging.getLogger(__name__)
@@ -54,8 +56,8 @@ class MockupGenerator:
         current = model_identifier or get_default_model_id()
         with self._lock:
             if self.pipeline is None or self.model_id != current:
-                from diffusers import StableDiffusionXLPipeline
                 import torch
+                from diffusers import StableDiffusionXLPipeline
 
                 self.model_id = current
                 device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -143,8 +145,9 @@ class MockupGenerator:
         GenerationError
             If all retry attempts fail.
         """
-        from io import BytesIO
         import base64
+        from io import BytesIO
+
         from PIL import Image
 
         provider = settings.fallback_provider.lower()

--- a/backend/mockup-generation/mockup_generation/listing_generator.py
+++ b/backend/mockup-generation/mockup_generation/listing_generator.py
@@ -7,9 +7,9 @@ import os
 from dataclasses import dataclass
 from typing import List
 
-from .settings import settings
-
 import requests
+
+from .settings import settings
 
 
 @dataclass(slots=True)

--- a/backend/mockup-generation/mockup_generation/post_processor.py
+++ b/backend/mockup-generation/mockup_generation/post_processor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from threading import Lock
-from typing import Callable, Mapping, Tuple, cast, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Callable, Mapping, Tuple, TypedDict, cast
 
 from PIL import Image
 

--- a/backend/mockup-generation/mockup_generation/settings.py
+++ b/backend/mockup-generation/mockup_generation/settings.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):  # type: ignore[misc]

--- a/backend/mockup-generation/tests/test_api_generate.py
+++ b/backend/mockup-generation/tests/test_api_generate.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 import types
 import warnings
-from fastapi.testclient import TestClient
+from pathlib import Path
+
 import pytest
+from fastapi.testclient import TestClient
 
 root = Path(__file__).resolve().parents[3]
 sys.path.append(str(root))

--- a/backend/mockup-generation/tests/test_api_mockups.py
+++ b/backend/mockup-generation/tests/test_api_mockups.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import os
 import sys
 import types
-from pathlib import Path
-import asyncio
-from typing import Any, AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator
 
 import pytest
 from fastapi.testclient import TestClient

--- a/backend/mockup-generation/tests/test_api_models.py
+++ b/backend/mockup-generation/tests/test_api_models.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import sys
+import types
 from pathlib import Path
 
-import types
 from fastapi.testclient import TestClient
 
 root = Path(__file__).resolve().parents[3]

--- a/backend/mockup-generation/tests/test_celery_broker.py
+++ b/backend/mockup-generation/tests/test_celery_broker.py
@@ -7,8 +7,8 @@ import os
 import socket
 from typing import Iterator
 
-from celery.contrib.testing.worker import start_worker
 import pytest
+from celery.contrib.testing.worker import start_worker
 
 
 def _port_open(host: str, port: int) -> bool:

--- a/backend/mockup-generation/tests/test_generator.py
+++ b/backend/mockup-generation/tests/test_generator.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 import types
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -19,7 +19,8 @@ sys.modules.setdefault("torch", types.ModuleType("torch"))
 sys.modules["torch"].cuda = types.SimpleNamespace(is_available=lambda: False)  # type: ignore[attr-defined]
 sys.modules.setdefault("torch.nn", types.ModuleType("nn"))
 
-from mockup_generation.generator import MockupGenerator, GenerationError  # noqa: E402
+from mockup_generation.generator import GenerationError  # noqa: E402
+from mockup_generation.generator import MockupGenerator
 from mockup_generation.settings import settings  # noqa: E402
 
 
@@ -72,6 +73,7 @@ async def test_fallback_api_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_fallback_api_openai(monkeypatch: pytest.MonkeyPatch) -> None:
     """Image is returned when OpenAI responds successfully."""
     from io import BytesIO
+
     from PIL import Image
 
     buf = BytesIO()
@@ -115,6 +117,7 @@ async def test_fallback_api_stability(monkeypatch: pytest.MonkeyPatch) -> None:
     """Image is returned when Stability responds successfully."""
     import base64
     from io import BytesIO
+
     from PIL import Image
 
     buf = BytesIO()

--- a/backend/mockup-generation/tests/test_gpu_lock.py
+++ b/backend/mockup-generation/tests/test_gpu_lock.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import sys
 from pathlib import Path
-import contextlib
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
@@ -118,11 +118,11 @@ sys.modules.setdefault(
     types.ModuleType("opentelemetry.exporter.otlp.proto.http.trace_exporter"),
 )
 
-import threading  # noqa: E402
 import asyncio
+import threading  # noqa: E402
+
 import fakeredis.aioredis  # noqa: E402
 import pytest  # noqa: E402
-
 from mockup_generation import tasks  # noqa: E402
 
 

--- a/backend/mockup-generation/tests/test_gpu_metrics.py
+++ b/backend/mockup-generation/tests/test_gpu_metrics.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import importlib
 import sys
-from pathlib import Path
 import types
+from pathlib import Path
 
 import fakeredis
 import pytest

--- a/backend/mockup-generation/tests/test_model_repository.py
+++ b/backend/mockup-generation/tests/test_model_repository.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 import types
 import warnings
+from pathlib import Path
 
 root = Path(__file__).resolve().parents[3]
 sys.path.append(str(root))  # noqa: E402
@@ -102,11 +102,11 @@ sys.modules.setdefault("pgvector.sqlalchemy", types.ModuleType("pgvector.sqlalch
 sys.modules["pgvector.sqlalchemy"].Vector = object
 warnings.filterwarnings("ignore", category=UserWarning)
 
-from mockup_generation.model_repository import (  # noqa: E402
+from mockup_generation.model_repository import get_model  # noqa: E402
+from mockup_generation.model_repository import (
     list_generated_mockups,
-    save_generated_mockup,
     register_model,
-    get_model,
+    save_generated_mockup,
 )
 
 

--- a/backend/mockup-generation/tests/test_nsfw.py
+++ b/backend/mockup-generation/tests/test_nsfw.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from PIL import Image
-
 from mockup_generation.post_processor import ensure_not_nsfw
+from PIL import Image
 
 
 def test_ensure_not_nsfw() -> None:

--- a/backend/mockup-generation/tests/test_performance.py
+++ b/backend/mockup-generation/tests/test_performance.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-import threading
 from pathlib import Path
 
 import pytest
 import torch
-
 from mockup_generation.generator import MockupGenerator
 
 
@@ -24,8 +23,9 @@ def test_generation_speed(tmp_path: Path) -> None:
 
 def test_cleanup_reduces_memory() -> None:
     """Pipeline resources are released after cleanup."""
-    import psutil
     import gc
+
+    import psutil
 
     generator = MockupGenerator()
     generator.pipeline = bytearray(50 * 1024 * 1024)

--- a/backend/mockup-generation/tests/test_post_processor_rules.py
+++ b/backend/mockup-generation/tests/test_post_processor_rules.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
+
 import pytest
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT))  # noqa: E402
 sys.path.append(str(ROOT / "backend" / "mockup-generation"))  # noqa: E402
 
-from PIL import Image
-
 from mockup_generation.post_processor import (
     post_process_image,
     validate_dimensions,
     validate_file_size,
 )
+from PIL import Image
 
 
 def test_validate_dimensions(tmp_path: Path) -> None:

--- a/backend/mockup-generation/tests/test_prompt_builder.py
+++ b/backend/mockup-generation/tests/test_prompt_builder.py
@@ -9,7 +9,8 @@ from random import Random
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from mockup_generation.prompt_builder import PromptContext, build_prompt  # noqa: E402
+from mockup_generation.prompt_builder import PromptContext  # noqa: E402
+from mockup_generation.prompt_builder import build_prompt
 
 
 def test_build_prompt_deterministic() -> None:

--- a/backend/mockup-generation/tests/test_tasks_upload.py
+++ b/backend/mockup-generation/tests/test_tasks_upload.py
@@ -4,14 +4,14 @@
 
 from __future__ import annotations
 
-import types
-from pathlib import Path
-
-import sys
 import asyncio
+import sys
+import types
 import warnings
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import AsyncIterator
+
 import pytest
 
 root = Path(__file__).resolve().parents[1]

--- a/backend/monitoring/src/monitoring/metrics_store.py
+++ b/backend/monitoring/src/monitoring/metrics_store.py
@@ -3,19 +3,18 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import ClassVar, Iterable, Iterator, MutableMapping, cast
 
-from backend.shared.cache import sync_delete, sync_get, sync_set
-
-import requests
-from backend.shared.http import request_with_retry
-
-import sqlite3
 import psycopg2
+import requests
 from psycopg2.pool import SimpleConnectionPool
+
+from backend.shared.cache import sync_delete, sync_get, sync_set
+from backend.shared.http import request_with_retry
 
 LATENCY_CACHE_KEY = "monitoring:latency_avg"
 ACTIVE_USERS_CACHE_KEY = "monitoring:active_users"

--- a/backend/monitoring/src/monitoring/pagerduty.py
+++ b/backend/monitoring/src/monitoring/pagerduty.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import atexit
 import os
 from typing import Any
 
-import atexit
 import requests
 
 from backend.shared.http import request_with_retry
+
 from .settings import settings
 
 PAGERDUTY_URL = "https://events.pagerduty.com/v2/enqueue"

--- a/backend/monitoring/tests/test_monitoring_timeout.py
+++ b/backend/monitoring/tests/test_monitoring_timeout.py
@@ -3,11 +3,11 @@
 from typing import Any
 
 import httpx
+import monitoring.main as main_module
 import pytest
 import respx
 
 from backend.shared.http import DEFAULT_TIMEOUT
-import monitoring.main as main_module
 
 
 class AssertTimeoutClient(httpx.AsyncClient):

--- a/backend/monitoring/tests/test_pagerduty.py
+++ b/backend/monitoring/tests/test_pagerduty.py
@@ -1,10 +1,10 @@
 """Tests for PagerDuty utilities and SLA cooldown logic."""
 
 from __future__ import annotations
-from pathlib import Path
+
 import sys
 import types
-
+from pathlib import Path
 from typing import Any
 
 import fakeredis

--- a/backend/monitoring/tests/test_queue_backlog.py
+++ b/backend/monitoring/tests/test_queue_backlog.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-from pathlib import Path
 import sys
 import types
+from pathlib import Path
+from typing import Any
 
 import fakeredis
 

--- a/backend/monitoring/tests/validators/test_monitoring_settings.py
+++ b/backend/monitoring/tests/validators/test_monitoring_settings.py
@@ -1,14 +1,13 @@
 """Validation for monitoring settings."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 
 import pytest  # noqa: E402
-from pydantic import ValidationError  # noqa: E402
-
 from monitoring.settings import Settings  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
 
 
 def test_invalid_log_file() -> None:

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -2,32 +2,32 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 import asyncio
-import psutil
 import logging
 import os
 import uuid
+from datetime import UTC, datetime
 from functools import lru_cache
 from typing import Callable, Coroutine, List, cast
 
-from fastapi import FastAPI, Request, Response
-from backend.shared.security import require_status_api_key
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+import psutil
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-from backend.shared.tracing import configure_tracing
-from backend.shared.profiling import add_profiling
-from backend.shared.metrics import register_metrics
-from backend.shared.security import add_security_headers
-from backend.shared.responses import json_cached
-from backend.shared.logging import configure_logging
+from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
 from backend.shared import ServiceName, add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
+from backend.shared.logging import configure_logging
+from backend.shared.metrics import register_metrics
+from backend.shared.profiling import add_profiling
+from backend.shared.responses import json_cached
+from backend.shared.security import add_security_headers, require_status_api_key
+from backend.shared.tracing import configure_tracing
+
 from .metrics import MetricsAnalyzer, ResourceMetric
 from .storage import MetricsStore
-
 
 configure_logging()
 logger = logging.getLogger(__name__)

--- a/backend/optimization/metrics.py
+++ b/backend/optimization/metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Iterable, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, List, Optional
 
 import numpy as np
 

--- a/backend/optimization/storage.py
+++ b/backend/optimization/storage.py
@@ -7,9 +7,9 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
 from typing import Iterator, List
+from urllib.parse import urlparse
 
 import psycopg2
-from urllib.parse import urlparse
 
 from .metrics import ResourceMetric
 

--- a/backend/optimization/tests/test_api_routes.py
+++ b/backend/optimization/tests/test_api_routes.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 from fastapi.testclient import TestClient
-
-from pathlib import Path
 
 from backend.optimization import api as opt_api
 from backend.optimization.storage import MetricsStore

--- a/backend/optimization/tests/test_materialized_view.py
+++ b/backend/optimization/tests/test_materialized_view.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+
 import psycopg2
 import pytest
 from fastapi.testclient import TestClient

--- a/backend/optimization/tests/test_scheduler.py
+++ b/backend/optimization/tests/test_scheduler.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import warnings
+
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-import warnings
 from pytest import MonkeyPatch
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/backend/orchestrator/orchestrator/__init__.py
+++ b/backend/orchestrator/orchestrator/__init__.py
@@ -1,16 +1,16 @@
 """Orchestration pipelines using Dagster."""
 
 from .jobs import (
-    cleanup_job,
-    idea_job,
     backup_job,
+    cleanup_job,
     daily_summary_job,
+    idea_job,
     privacy_purge_job,
 )
 from .schedules import (
     daily_backup_schedule,
-    hourly_cleanup_schedule,
     daily_summary_schedule,
+    hourly_cleanup_schedule,
     weekly_privacy_purge_schedule,
 )
 from .sensors import idea_sensor, run_failure_notifier

--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -6,25 +6,25 @@ from dagster import RetryPolicy, job
 
 DEFAULT_JOB_RETRY_POLICY = RetryPolicy(max_retries=3, delay=1)
 
+from .hooks import record_failure, record_success
 from .ops import (
+    analyze_query_plans_op,
     await_approval,
     backup_data,
+    benchmark_score_op,
     cleanup_data,
-    analyze_query_plans_op,
+    generate_content,
+    ingest_signals,
+    maintain_spot_nodes_op,
+    publish_content,
+    purge_pii_rows_op,
     rotate_k8s_secrets_op,
     rotate_s3_keys_op,
     run_daily_summary,
-    generate_content,
-    ingest_signals,
-    publish_content,
     score_signals,
-    update_feedback,
     sync_listing_states_op,
-    purge_pii_rows_op,
-    benchmark_score_op,
-    maintain_spot_nodes_op,
+    update_feedback,
 )
-from .hooks import record_failure, record_success
 
 
 @job(op_retry_policy=DEFAULT_JOB_RETRY_POLICY)  # type: ignore[misc]

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-import asyncio
 import httpx
 from dagster import Failure, RetryPolicy, op
 
 from backend.shared.http import get_async_http_client
-
 from scripts import maintenance
 
 
@@ -280,9 +279,9 @@ def run_daily_summary(  # type: ignore[no-untyped-def]
 ) -> None:
     """Execute the daily summary script and log the result."""
     context.log.info("generating daily summary")
-    from scripts.daily_summary import generate_daily_summary
-
     import asyncio
+
+    from scripts.daily_summary import generate_daily_summary
 
     summary = asyncio.run(generate_daily_summary())
     context.log.debug("summary: %s", summary)
@@ -336,6 +335,7 @@ def purge_pii_rows_op(context) -> None:  # type: ignore[no-untyped-def]
     """Run :func:`signal_ingestion.privacy.purge_pii_rows`."""
     context.log.info("purging stored PII")
     import asyncio
+
     from signal_ingestion.privacy import purge_pii_rows
 
     count = asyncio.run(purge_pii_rows())
@@ -347,8 +347,9 @@ def benchmark_score_op(context) -> None:  # type: ignore[no-untyped-def]
     """Run benchmark_score script and persist results."""
     context.log.info("benchmarking scoring endpoint")
     import asyncio
+
+    from backend.shared.db import models, session_scope
     from scripts import benchmark_score
-    from backend.shared.db import session_scope, models
 
     uncached, cached, runs = asyncio.run(benchmark_score.main())
     with session_scope() as session:

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -5,34 +5,33 @@ from dagster import Definitions
 from .jobs import (
     analyze_query_plans_job,
     backup_job,
-    cleanup_job,
-    idea_job,
-    rotate_secrets_job,
-    rotate_s3_keys_job,
-    daily_summary_job,
-    sync_listings_job,
-    privacy_purge_job,
     benchmark_score_job,
+    cleanup_job,
+    daily_summary_job,
     feedback_update_job,
-    signal_ingestion_job,
-    scoring_job,
+    idea_job,
     mockup_generation_job,
+    privacy_purge_job,
     publishing_job,
+    rotate_s3_keys_job,
+    rotate_secrets_job,
+    scoring_job,
+    signal_ingestion_job,
+    sync_listings_job,
 )
 from .schedules import (
     daily_backup_schedule,
-    hourly_cleanup_schedule,
+    daily_feedback_update_schedule,
+    daily_listing_sync_schedule,
     daily_query_plan_schedule,
     daily_summary_schedule,
+    hourly_cleanup_schedule,
+    hourly_idea_schedule,
     monthly_secret_rotation_schedule,
     rotate_s3_keys_schedule,
-    daily_listing_sync_schedule,
     weekly_privacy_purge_schedule,
-    hourly_idea_schedule,
-    daily_feedback_update_schedule,
 )
 from .sensors import idea_sensor, run_failure_notifier
-
 
 defs = Definitions(
     jobs=[

--- a/backend/orchestrator/orchestrator/schedules.py
+++ b/backend/orchestrator/orchestrator/schedules.py
@@ -3,17 +3,17 @@
 from dagster import ScheduleEvaluationContext, schedule
 
 from .jobs import (
+    analyze_query_plans_job,
     backup_job,
     cleanup_job,
-    analyze_query_plans_job,
     daily_summary_job,
-    rotate_secrets_job,
-    rotate_s3_keys_job,
-    sync_listings_job,
-    privacy_purge_job,
-    idea_job,
     feedback_update_job,
+    idea_job,
     maintain_spot_nodes_job,
+    privacy_purge_job,
+    rotate_s3_keys_job,
+    rotate_secrets_job,
+    sync_listings_job,
 )
 
 

--- a/backend/orchestrator/orchestrator/sensors.py
+++ b/backend/orchestrator/orchestrator/sensors.py
@@ -15,7 +15,6 @@ from dagster import (
     run_failure_sensor,
     sensor,
 )
-
 from monitoring.pagerduty import notify_listing_issue
 
 from .jobs import idea_job

--- a/backend/orchestrator/tests/test_failure_sensor.py
+++ b/backend/orchestrator/tests/test_failure_sensor.py
@@ -12,7 +12,6 @@ ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT))
 
 from dagster import DagsterInstance, build_run_status_sensor_context
-
 from orchestrator.jobs import idea_job  # noqa: E402
 from orchestrator.sensors import run_failure_notifier  # noqa: E402
 

--- a/backend/orchestrator/tests/test_feedback_job.py
+++ b/backend/orchestrator/tests/test_feedback_job.py
@@ -17,10 +17,10 @@ FEEDBACK_SRC = ROOT / "backend" / "feedback-loop"
 sys.path.append(str(FEEDBACK_SRC))  # noqa: E402
 
 from orchestrator.jobs import feedback_update_job  # noqa: E402
-from orchestrator.schedules import (
+from orchestrator.schedules import (  # noqa: E402
     daily_feedback_update_schedule,
     hourly_idea_schedule,
-)  # noqa: E402
+)
 
 
 def test_feedback_update_schedule() -> None:

--- a/backend/orchestrator/tests/test_jobs.py
+++ b/backend/orchestrator/tests/test_jobs.py
@@ -11,25 +11,24 @@ sys.path.append(str(ORCHESTRATOR_PATH))  # noqa: E402
 MONITORING_SRC = ROOT / "backend" / "monitoring" / "src"
 sys.path.append(str(MONITORING_SRC))  # noqa: E402
 
-from orchestrator.jobs import (  # noqa: E402
-    backup_job,
-    cleanup_job,
-    idea_job,
-    rotate_secrets_job,
-    daily_summary_job,
-)
+import httpx  # noqa: E402
 import pytest  # noqa: E402
 from dagster import DagsterInstance, RunRequest, build_sensor_context  # noqa: E402
-
-from orchestrator.schedules import (  # noqa: E402
-    daily_backup_schedule,
+from orchestrator.jobs import cleanup_job  # noqa: E402
+from orchestrator.jobs import (
+    backup_job,
+    daily_summary_job,
+    idea_job,
+    rotate_secrets_job,
+)
+from orchestrator.schedules import daily_backup_schedule  # noqa: E402
+from orchestrator.schedules import (
     daily_query_plan_schedule,
-    hourly_cleanup_schedule,
     daily_summary_schedule,
+    hourly_cleanup_schedule,
     monthly_secret_rotation_schedule,
 )
 from orchestrator.sensors import idea_sensor  # noqa: E402
-import httpx  # noqa: E402
 
 
 def test_job_structure() -> None:

--- a/backend/orchestrator/tests/test_ops_integration.py
+++ b/backend/orchestrator/tests/test_ops_integration.py
@@ -6,12 +6,11 @@ import json
 import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 from typing import Iterator
 
-from pathlib import Path
-
-from dagster import DagsterInstance
 import pytest
+from dagster import DagsterInstance
 
 ROOT = Path(__file__).resolve().parents[3]
 import sys

--- a/backend/scoring-engine/scoring_engine/affinity.py
+++ b/backend/scoring-engine/scoring_engine/affinity.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import hashlib
 from functools import lru_cache
 
-
 import numpy as np
 from numpy.typing import NDArray
-
 
 DIMENSION = 32
 

--- a/backend/scoring-engine/scoring_engine/celery_app.py
+++ b/backend/scoring-engine/scoring_engine/celery_app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from celery import Celery
 
 from backend.shared.queue_metrics import register_redis_queue_collector
+
 from .settings import settings
 
 app = Celery("scoring_engine", broker=settings.celery_broker_url)

--- a/backend/scoring-engine/scoring_engine/centroid_job.py
+++ b/backend/scoring-engine/scoring_engine/centroid_job.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 
+import numpy as np
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-from sqlalchemy import select, desc
-from datetime import datetime
-import numpy as np
+from sqlalchemy import desc, select
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding, Weights

--- a/backend/scoring-engine/scoring_engine/models.py
+++ b/backend/scoring-engine/scoring_engine/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from backend.shared.db.models import Weights
 from backend.shared.db.base import Base
+from backend.shared.db.models import Weights
 
 __all__ = ["Weights", "Base"]

--- a/backend/scoring-engine/scoring_engine/scoring.py
+++ b/backend/scoring-engine/scoring_engine/scoring.py
@@ -16,8 +16,8 @@ except Exception:  # pragma: no cover - fallback on pure Python
 import numpy as np
 from sklearn.preprocessing import StandardScaler
 
+from .affinity import DIMENSION, metadata_embedding
 from .weight_repository import get_centroid, get_weights
-from .affinity import metadata_embedding, DIMENSION
 
 
 class Signal:

--- a/backend/scoring-engine/scoring_engine/tasks.py
+++ b/backend/scoring-engine/scoring_engine/tasks.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-import orjson
 from typing import Mapping, cast
 
+import orjson
 from celery import Task
-from prometheus_client import Counter, Histogram
 from opentelemetry import trace
+from prometheus_client import Counter, Histogram
+from signal_ingestion.embedding import generate_embedding
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding
-from signal_ingestion.embedding import generate_embedding
 
 from .celery_app import app
 

--- a/backend/scoring-engine/scoring_engine/weight_repository.py
+++ b/backend/scoring-engine/scoring_engine/weight_repository.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-import orjson
 from pathlib import Path
+
+import orjson
 from sqlalchemy import select
 
-from .affinity import metadata_embedding
-
 from backend.shared.db import engine, session_scope
-from backend.shared.db.models import Weights
 from backend.shared.db.base import Base
+from backend.shared.db.models import Weights
 
+from .affinity import metadata_embedding
 
 # Weight update smoothing factor for feedback adjustments
 FEEDBACK_SMOOTHING = 0.1

--- a/backend/scoring-engine/tests/test_affinity.py
+++ b/backend/scoring-engine/tests/test_affinity.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import math
 
 import numpy as np
-
 from scoring_engine.affinity import (
     DIMENSION,
     hashtag_embedding,

--- a/backend/scoring-engine/tests/test_cache.py
+++ b/backend/scoring-engine/tests/test_cache.py
@@ -2,8 +2,8 @@
 
 # mypy: ignore-errors
 
-from datetime import UTC, datetime
 import importlib
+from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
 from scoring_engine import app

--- a/backend/scoring-engine/tests/test_centroid.py
+++ b/backend/scoring-engine/tests/test_centroid.py
@@ -3,10 +3,10 @@
 # mypy: ignore-errors
 
 from fastapi.testclient import TestClient
-
 from scoring_engine.app import app as scoring_app
 from scoring_engine.centroid_job import compute_and_store_centroids
 from scoring_engine.weight_repository import get_centroid
+
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding
 

--- a/backend/scoring-engine/tests/test_centroid_job.py
+++ b/backend/scoring-engine/tests/test_centroid_job.py
@@ -6,13 +6,11 @@ from __future__ import annotations
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-
-from scoring_engine.centroid_job import (
-    scheduler as module_scheduler,
-    start_centroid_scheduler,
-    compute_and_store_centroids,
-)
+from scoring_engine.centroid_job import compute_and_store_centroids
+from scoring_engine.centroid_job import scheduler as module_scheduler
+from scoring_engine.centroid_job import start_centroid_scheduler
 from scoring_engine.weight_repository import get_centroid
+
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding
 

--- a/backend/scoring-engine/tests/test_consumer.py
+++ b/backend/scoring-engine/tests/test_consumer.py
@@ -4,17 +4,18 @@
 
 from __future__ import annotations
 
-from threading import Event
-from fastapi.testclient import TestClient
 import warnings
+from threading import Event
+
+from fastapi.testclient import TestClient
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
+import pytest
+from scoring_engine import app as app_module
+from scoring_engine.app import consume_signals
 from sqlalchemy import select
 
-import pytest
-from scoring_engine.app import consume_signals
-from scoring_engine import app as app_module
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding
 

--- a/backend/scoring-engine/tests/test_health.py
+++ b/backend/scoring-engine/tests/test_health.py
@@ -3,7 +3,6 @@
 # mypy: ignore-errors
 
 from fastapi.testclient import TestClient
-
 from scoring_engine.app import app
 
 client = TestClient(app)

--- a/backend/scoring-engine/tests/test_metrics.py
+++ b/backend/scoring-engine/tests/test_metrics.py
@@ -2,13 +2,13 @@
 
 # mypy: ignore-errors
 
-from datetime import UTC, datetime
 import importlib
+import warnings
+from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
 from scoring_engine.app import app
 from scoring_engine.weight_repository import update_weights
-import warnings
 
 scoring_module = importlib.import_module("scoring_engine.app")
 

--- a/backend/scoring-engine/tests/test_score_metrics_store.py
+++ b/backend/scoring-engine/tests/test_score_metrics_store.py
@@ -2,13 +2,12 @@
 
 # mypy: ignore-errors
 
-from datetime import UTC, datetime
-from pathlib import Path
 import importlib
 import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
 
 from fastapi.testclient import TestClient
-
 from scoring_engine.app import app
 from scoring_engine.weight_repository import update_weights
 

--- a/backend/scoring-engine/tests/test_scoring.py
+++ b/backend/scoring-engine/tests/test_scoring.py
@@ -5,10 +5,10 @@
 from datetime import UTC, datetime
 
 import numpy as np
-
+from scoring_engine.centroid_job import compute_and_store_centroids
 from scoring_engine.scoring import Signal, calculate_score, compute_novelty
 from scoring_engine.weight_repository import update_weights
-from scoring_engine.centroid_job import compute_and_store_centroids
+
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding
 

--- a/backend/scoring-engine/tests/test_tasks.py
+++ b/backend/scoring-engine/tests/test_tasks.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from scoring_engine.tasks import batch_embed
 from sqlalchemy import select
 
-from scoring_engine.tasks import batch_embed
 from backend.shared.db import session_scope
 from backend.shared.db.models import Embedding
 

--- a/backend/scoring-engine/tests/test_weights.py
+++ b/backend/scoring-engine/tests/test_weights.py
@@ -2,9 +2,10 @@
 
 # mypy: ignore-errors
 
-from fastapi.testclient import TestClient
 import importlib
 from pathlib import Path
+
+from fastapi.testclient import TestClient
 from scoring_engine.app import app
 
 scoring_module = importlib.import_module("scoring_engine.app")

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -8,22 +8,20 @@ from functools import lru_cache
 from typing import Callable, Coroutine, cast
 
 from fastapi import FastAPI, Request, Response
-from backend.shared.security import require_status_api_key
 from fastapi.middleware.cors import CORSMiddleware
-
-from .logging_config import configure_logging
-from .settings import settings
-from backend.shared.tracing import configure_tracing
-from backend.shared.profiling import add_profiling
-from backend.shared.metrics import register_metrics
-from backend.shared.security import add_security_headers
-from backend.shared.responses import json_cached
-from backend.shared.currency import start_rate_updater
-
-from backend.shared.db import run_migrations_if_needed
 
 from backend.shared import add_error_handlers, configure_sentry
 from backend.shared.config import settings as shared_settings
+from backend.shared.currency import start_rate_updater
+from backend.shared.db import run_migrations_if_needed
+from backend.shared.metrics import register_metrics
+from backend.shared.profiling import add_profiling
+from backend.shared.responses import json_cached
+from backend.shared.security import add_security_headers, require_status_api_key
+from backend.shared.tracing import configure_tracing
+
+from .logging_config import configure_logging
+from .settings import settings
 
 configure_logging()
 logger = logging.getLogger(__name__)
@@ -106,8 +104,9 @@ async def ready(request: Request) -> Response:
 
 if __name__ == "__main__":  # pragma: no cover
     import asyncio
-    import uvloop
+
     import uvicorn
+    import uvloop
 
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 

--- a/backend/service-template/src/settings.py
+++ b/backend/service-template/src/settings.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -1,19 +1,19 @@
 """Shared utilities for backend services."""
 
-from .profiling import add_profiling
-from .tracing import configure_tracing
-from .logging import configure_logging
-from .sentry import configure_sentry
-from .feature_flags import initialize as init_feature_flags, is_enabled
-
-from .errors import add_error_handlers, add_flask_error_handlers
-from .currency import convert_price, start_rate_updater
-from .metrics import register_metrics
-from .responses import cache_header, json_cached, gzip_iter, gzip_aiter
-from .config import settings
-from .service_names import ServiceName
-from .security import add_security_headers
 from .clip import load_clip, open_clip, torch
+from .config import settings
+from .currency import convert_price, start_rate_updater
+from .errors import add_error_handlers, add_flask_error_handlers
+from .feature_flags import initialize as init_feature_flags
+from .feature_flags import is_enabled
+from .logging import configure_logging
+from .metrics import register_metrics
+from .profiling import add_profiling
+from .responses import cache_header, gzip_aiter, gzip_iter, json_cached
+from .security import add_security_headers
+from .sentry import configure_sentry
+from .service_names import ServiceName
+from .tracing import configure_tracing
 
 __all__ = [
     "add_profiling",

--- a/backend/shared/auth/jwt.py
+++ b/backend/shared/auth/jwt.py
@@ -11,18 +11,18 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
-from typing import Any, Dict, Callable, cast
+from typing import Any, Callable, Dict, cast
 from uuid import uuid4
 
+import httpx
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from sqlalchemy import select
-import httpx
 
+from backend.shared.config import settings as shared_settings
 from backend.shared.db import session_scope
 from backend.shared.db.models import RevokedToken
-from backend.shared.config import settings as shared_settings
 
 SECRET_KEY = shared_settings.secret_key or "change_this"
 ALGORITHM = "HS256"

--- a/backend/shared/currency.py
+++ b/backend/shared/currency.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Dict, cast
 
+import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-import requests
 
 from backend.shared.cache import SyncRedis, get_sync_client
 from backend.shared.config import settings

--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -2,24 +2,21 @@
 
 from __future__ import annotations
 
-from contextlib import asynccontextmanager, contextmanager
-from typing import Any, Iterator, AsyncIterator
 import asyncio
 import os
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any, AsyncIterator, Iterator
+
 from alembic import command
 from alembic.config import Config
-
-from sqlalchemy import create_engine, event, text
 from prometheus_client import Gauge
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+
+from backend.shared.config import settings
 
 from .base import Base
-from backend.shared.config import settings
 
 SKIP_MIGRATIONS_ENV = "SKIP_MIGRATIONS"
 

--- a/backend/shared/db/migrations/4ed6b262010c_merge_heads.py
+++ b/backend/shared/db/migrations/4ed6b262010c_merge_heads.py
@@ -8,9 +8,8 @@ Create Date: 2025-07-21 15:15:48.712385
 This merge revision ensures the migration history remains linear.
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "4ed6b262010c"

--- a/backend/shared/db/migrations/abcdef123456_merge_mockup_generation_head.py
+++ b/backend/shared/db/migrations/abcdef123456_merge_mockup_generation_head.py
@@ -1,7 +1,7 @@
 """Merge mockup_generation head with previous heads."""
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "abcdef123456"

--- a/backend/shared/db/migrations/api_gateway/env.py
+++ b/backend/shared/db/migrations/api_gateway/env.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
 from alembic import context
-
-import os
+from sqlalchemy import engine_from_config, pool
 
 target_metadata = None
 

--- a/backend/shared/db/migrations/api_gateway/versions/0002_add_roles_table.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0002_add_roles_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0002"
 down_revision = None

--- a/backend/shared/db/migrations/api_gateway/versions/0003_add_audit_log_table.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0003_add_audit_log_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0003"
 down_revision = "0002"

--- a/backend/shared/db/migrations/api_gateway/versions/0005_add_revoked_tokens.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0005_add_revoked_tokens.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0005"
 down_revision = "0004"

--- a/backend/shared/db/migrations/api_gateway/versions/0006_add_ai_models_table.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0006_add_ai_models_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0006"
 down_revision = "0005"

--- a/backend/shared/db/migrations/api_gateway/versions/0008_add_refresh_tokens.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0008_add_refresh_tokens.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0008"
 down_revision = "0007"

--- a/backend/shared/db/migrations/api_gateway/versions/7165ae776380_empty_revision.py
+++ b/backend/shared/db/migrations/api_gateway/versions/7165ae776380_empty_revision.py
@@ -6,9 +6,8 @@ Revises: 0006
 Create Date: 2025-07-18 19:00:56.795804
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "7165ae776380"

--- a/backend/shared/db/migrations/fedcba987654_merge_rls_heads.py
+++ b/backend/shared/db/migrations/fedcba987654_merge_rls_heads.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "fedcba987654"
 down_revision = ("0017", "0009", "e07f77a52d6f", "0004", "0002", "abcdef123456")

--- a/backend/shared/db/migrations/marketplace_publisher/env.py
+++ b/backend/shared/db/migrations/marketplace_publisher/env.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
 from alembic import context
-
 from marketplace_publisher.settings import settings
+from sqlalchemy import engine_from_config, pool
 
 target_metadata = None
 

--- a/backend/shared/db/migrations/marketplace_publisher/versions/0001_create_publish_task_table.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/0001_create_publish_task_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0001"
 down_revision = None

--- a/backend/shared/db/migrations/marketplace_publisher/versions/0002_create_webhook_event_table.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/0002_create_webhook_event_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0002"
 down_revision = "0001"

--- a/backend/shared/db/migrations/marketplace_publisher/versions/5130a8662f39_empty_revision.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/5130a8662f39_empty_revision.py
@@ -6,9 +6,8 @@ Revises: 0002
 Create Date: 2025-07-18 19:01:07.890668
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "5130a8662f39"

--- a/backend/shared/db/migrations/marketplace_publisher/versions/830537fd941a_add_indexes_for_publish_task_and_listing.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/830537fd941a_add_indexes_for_publish_task_and_listing.py
@@ -6,9 +6,8 @@ Revises: 5130a8662f39
 Create Date: 2025-07-21 02:31:22.922915
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "830537fd941a"

--- a/backend/shared/db/migrations/marketplace_publisher/versions/e07f77a52d6e_add_oauth_token_table.py
+++ b/backend/shared/db/migrations/marketplace_publisher/versions/e07f77a52d6e_add_oauth_token_table.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "e07f77a52d6e"
 down_revision = "830537fd941a"

--- a/backend/shared/db/migrations/mockup_generation/env.py
+++ b/backend/shared/db/migrations/mockup_generation/env.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
 from alembic import context
-
-import os
+from sqlalchemy import engine_from_config, pool
 
 # this metadata is not used directly but required by Alembic
 # because models are created dynamically elsewhere

--- a/backend/shared/db/migrations/mockup_generation/versions/0001_create_generated_mockups_table.py
+++ b/backend/shared/db/migrations/mockup_generation/versions/0001_create_generated_mockups_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0001"
 down_revision = None

--- a/backend/shared/db/migrations/scoring_engine/env.py
+++ b/backend/shared/db/migrations/scoring_engine/env.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
 from alembic import context
-
-import os
+from sqlalchemy import engine_from_config, pool
 
 target_metadata = None
 

--- a/backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0001"
 down_revision = None

--- a/backend/shared/db/migrations/scoring_engine/versions/0002b_add_status_column.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0002b_add_status_column.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0002b"
 down_revision = "0001"

--- a/backend/shared/db/migrations/scoring_engine/versions/0004_add_analytics_tables.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0004_add_analytics_tables.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0004"
 down_revision = "0003"

--- a/backend/shared/db/migrations/scoring_engine/versions/0005_add_ai_models_table.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0005_add_ai_models_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0005"
 down_revision = "0004"

--- a/backend/shared/db/migrations/scoring_engine/versions/0006_add_listing_state_column.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0006_add_listing_state_column.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0006"
 down_revision = "0005"

--- a/backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0007"
 down_revision = "0006"

--- a/backend/shared/db/migrations/scoring_engine/versions/0008_add_embeddings_and_centroid_columns.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0008_add_embeddings_and_centroid_columns.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from pgvector.sqlalchemy import Vector
 
 revision = "0008"
@@ -24,9 +24,7 @@ def upgrade() -> None:
     )
     op.add_column("weights", sa.Column("centroid", Vector(768), nullable=True))
     if op.get_context().dialect.name != "sqlite":
-        op.create_unique_constraint(
-            op.f("uq_weights_source"), "weights", ["source"]
-        )
+        op.create_unique_constraint(op.f("uq_weights_source"), "weights", ["source"])
     op.create_table(
         "embeddings",
         sa.Column("id", sa.Integer, primary_key=True),

--- a/backend/shared/db/migrations/scoring_engine/versions/0009_add_generated_mockups_table.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0009_add_generated_mockups_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0009"
 down_revision = "0008"

--- a/backend/shared/db/migrations/scoring_engine/versions/0011_add_marketplace_performance_table.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0011_add_marketplace_performance_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0011"
 down_revision = "0010"

--- a/backend/shared/db/migrations/scoring_engine/versions/0012_add_uri_and_metadata_to_generated_mockups.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0012_add_uri_and_metadata_to_generated_mockups.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0012"
 down_revision = "cd5ddd60e6bc"

--- a/backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0013_add_rls_policies.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0013"
 down_revision = "0012"

--- a/backend/shared/db/migrations/scoring_engine/versions/0015_add_score_benchmarks_table.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0015_add_score_benchmarks_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0015"
 down_revision = "0014"

--- a/backend/shared/db/migrations/scoring_engine/versions/0016_add_content_hash_to_signals.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0016_add_content_hash_to_signals.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0016"
 down_revision = "0015"

--- a/backend/shared/db/migrations/scoring_engine/versions/0018_add_marketplace_metric_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0018_add_marketplace_metric_index.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0018"
 down_revision = "0017"

--- a/backend/shared/db/migrations/scoring_engine/versions/0019_add_ab_test_result_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0019_add_ab_test_result_index.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0019"
 down_revision = "0018"

--- a/backend/shared/db/migrations/scoring_engine/versions/063f6dbe017c_add_scoremetric_idea_timestamp_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/063f6dbe017c_add_scoremetric_idea_timestamp_index.py
@@ -5,8 +5,8 @@ Revises: 7544cf9b2fd7
 Create Date: 2025-08-14 00:00:00.000000
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "063f6dbe017c"

--- a/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/7544cf9b2fd7_add_marketplace_perf_listing_id_index.py
@@ -6,9 +6,8 @@ Revises: 0019
 Create Date: 2025-07-22 16:30:59.175652
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "7544cf9b2fd7"

--- a/backend/shared/db/migrations/scoring_engine/versions/cd5ddd60e6bc_empty_revision.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/cd5ddd60e6bc_empty_revision.py
@@ -6,9 +6,8 @@ Revises: 0011
 Create Date: 2025-07-18 19:01:05.323587
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "cd5ddd60e6bc"

--- a/backend/shared/db/migrations/signal_ingestion/env.py
+++ b/backend/shared/db/migrations/signal_ingestion/env.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
 from alembic import context
+from sqlalchemy import engine_from_config, pool
 
 from backend.shared.config import settings
 

--- a/backend/shared/db/migrations/signal_ingestion/versions/0001_create_signals_table.py
+++ b/backend/shared/db/migrations/signal_ingestion/versions/0001_create_signals_table.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0001"
 down_revision = None

--- a/backend/shared/db/migrations/signal_ingestion/versions/0002_add_embedding_column.py
+++ b/backend/shared/db/migrations/signal_ingestion/versions/0002_add_embedding_column.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from pgvector.sqlalchemy import Vector
 
 revision = "0002"

--- a/backend/shared/db/migrations/signal_ingestion/versions/0003_add_content_hash_column.py
+++ b/backend/shared/db/migrations/signal_ingestion/versions/0003_add_content_hash_column.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0003"
 down_revision = "08af30763bce"

--- a/backend/shared/db/migrations/signal_ingestion/versions/08af30763bce_empty_revision.py
+++ b/backend/shared/db/migrations/signal_ingestion/versions/08af30763bce_empty_revision.py
@@ -6,9 +6,8 @@ Revises: 0002
 Create Date: 2025-07-18 19:01:02.501080
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "08af30763bce"

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -3,21 +3,20 @@
 from __future__ import annotations
 
 from datetime import datetime
-
 from typing import Any
 
+from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
+    JSON,
     Boolean,
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
-    JSON,
-    Index,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from pgvector.sqlalchemy import Vector
 
 from .base import Base
 

--- a/backend/shared/errors.py
+++ b/backend/shared/errors.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Callable, cast
+from typing import Any, Callable, Dict, cast
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
-from flask import Flask, jsonify, request as flask_request, Response as FlaskResponse
+from flask import Flask
+from flask import Response as FlaskResponse
+from flask import jsonify
+from flask import request as flask_request
+from opentelemetry import trace
 from starlette.responses import Response
 from werkzeug.exceptions import HTTPException as FlaskHTTPException
-from opentelemetry import trace
 
 try:  # pragma: no cover - optional dependency
     import sentry_sdk

--- a/backend/shared/feature_flags.py
+++ b/backend/shared/feature_flags.py
@@ -13,10 +13,10 @@ import time
 from typing import Any, cast
 
 import redis
-from UnleashClient import UnleashClient
 from ldclient import LDClient
 from ldclient.config import Config
 from ldclient.context import Context
+from UnleashClient import UnleashClient
 
 _unleash_client: UnleashClient | None = None
 _ld_client: LDClient | None = None

--- a/backend/shared/http.py
+++ b/backend/shared/http.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import atexit
 import os
 from typing import Any
 
-import asyncio
-import atexit
-
-import requests
-
 import httpx
-
+import requests
 from tenacity import (
     retry,
     retry_if_exception_type,

--- a/backend/shared/kafka/schema_registry.py
+++ b/backend/shared/kafka/schema_registry.py
@@ -6,14 +6,13 @@ import json
 import os
 from typing import Any, Dict, cast
 
+import requests  # type: ignore[import-untyped]
 from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
-
-import requests  # type: ignore[import-untyped]
 
 
 class SchemaRegistryClient:

--- a/backend/shared/metrics.py
+++ b/backend/shared/metrics.py
@@ -2,20 +2,15 @@
 
 from __future__ import annotations
 
+import re
+from collections import defaultdict
 from time import perf_counter
 from typing import Callable, Coroutine, DefaultDict, Iterable
-from collections import defaultdict
-import re
 
 from fastapi import FastAPI, Request, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
 
 from .responses import cache_header
-from prometheus_client import (
-    CONTENT_TYPE_LATEST,
-    Counter,
-    Histogram,
-    generate_latest,
-)
 
 METRICS_CACHE_TTL = 3600
 

--- a/backend/shared/profiling.py
+++ b/backend/shared/profiling.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from logging import getLogger
 import time
+from logging import getLogger
 from typing import Any, Callable, Coroutine
 
 from fastapi import FastAPI, Request, Response
-from flask import Flask, request as flask_request
+from flask import Flask
+from flask import request as flask_request
 
 logger = getLogger(__name__)
 

--- a/backend/shared/queue_metrics.py
+++ b/backend/shared/queue_metrics.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Iterable
 import os
+from typing import Iterable
+
 import redis
 from prometheus_client import REGISTRY
 from prometheus_client.core import GaugeMetricFamily

--- a/backend/shared/responses.py
+++ b/backend/shared/responses.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi.responses import JSONResponse, Response
 import zlib
-from typing import Iterable, AsyncIterator
+from typing import AsyncIterator, Iterable
+
+from fastapi.responses import JSONResponse, Response
 
 CACHE_TTL_SECONDS = 60
 

--- a/backend/shared/security.py
+++ b/backend/shared/security.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Awaitable, Callable
 
-from fastapi import FastAPI, Request, Response
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .config import settings

--- a/backend/shared/tests/test_currency.py
+++ b/backend/shared/tests/test_currency.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import importlib.util
+from pathlib import Path
 from typing import Any
 
 import fakeredis

--- a/backend/shared/tests/test_feature_flags.py
+++ b/backend/shared/tests/test_feature_flags.py
@@ -7,7 +7,6 @@ from typing import Iterator
 from unittest import mock
 
 import fakeredis
-
 import pytest
 
 from backend.shared import feature_flags

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+import os
+from typing import Any, cast
+
 from fastapi import FastAPI
 from flask import Flask
-from typing import Any, cast
-import os
 from opentelemetry import trace
-from pydantic import HttpUrl
-from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # The exporter classes are imported lazily within ``configure_tracing`` to avoid
 # heavy dependencies and noisy warnings during package import.
@@ -17,6 +16,8 @@ from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from pydantic import HttpUrl
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class TraceSettings(BaseSettings):  # type: ignore[misc]
@@ -34,7 +35,11 @@ trace_settings = TraceSettings()
 
 def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     """Configure basic tracing for ``app``."""
-    if trace_settings.sdk_disabled or os.getenv("OTEL_SDK_DISABLED") in {"1", "true", "True"}:
+    if trace_settings.sdk_disabled or os.getenv("OTEL_SDK_DISABLED") in {
+        "1",
+        "true",
+        "True",
+    }:
         return
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
         OTLPSpanExporter as OTLPGrpcSpanExporter,

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/base.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
-import itertools
 import asyncio
 import atexit
+import itertools
 from typing import Any, Iterable, Optional, cast
+
+import httpx
+
+from backend.shared.cache import async_get, async_set
+from backend.shared.http import DEFAULT_TIMEOUT
 
 from ..rate_limit import AdapterRateLimiter
 from ..settings import settings
-from backend.shared.cache import async_get, async_set
-
-import httpx
-from backend.shared.http import DEFAULT_TIMEOUT
 
 _HTTP_CLIENTS: dict[str | None, httpx.AsyncClient] = {}
 

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/events.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/events.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import BaseAdapter
 from ..settings import settings
+from .base import BaseAdapter
 
 
 class EventsAdapter(BaseAdapter):

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/instagram.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/instagram.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import BaseAdapter
 from ..settings import settings
+from .base import BaseAdapter
 
 
 class InstagramAdapter(BaseAdapter):

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/nostalgia.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/nostalgia.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import BaseAdapter
 from ..settings import settings
+from .base import BaseAdapter
 
 
 class NostalgiaAdapter(BaseAdapter):

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/reddit.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/reddit.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import BaseAdapter
 from ..settings import settings
+from .base import BaseAdapter
 
 
 class RedditAdapter(BaseAdapter):

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/tiktok.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/tiktok.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import BaseAdapter
 from ..settings import settings
+from .base import BaseAdapter
 
 
 class TikTokAdapter(BaseAdapter):

--- a/backend/signal-ingestion/src/signal_ingestion/adapters/youtube.py
+++ b/backend/signal-ingestion/src/signal_ingestion/adapters/youtube.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import BaseAdapter
 from ..settings import settings
+from .base import BaseAdapter
 
 
 class YouTubeAdapter(BaseAdapter):

--- a/backend/signal-ingestion/src/signal_ingestion/celery_app.py
+++ b/backend/signal-ingestion/src/signal_ingestion/celery_app.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from celery import Celery
 
 from backend.shared.queue_metrics import register_redis_queue_collector
-from .settings import settings
 
+from .settings import settings
 
 app = Celery("signal_ingestion", broker=settings.celery_broker_url)
 app.conf.result_backend = settings.celery_broker_url

--- a/backend/signal-ingestion/src/signal_ingestion/database.py
+++ b/backend/signal-ingestion/src/signal_ingestion/database.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
 from collections.abc import AsyncGenerator
 
-from .models import Base
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from backend.shared.config import settings
 from backend.shared.db import register_pool_metrics
 
+from .models import Base
 
 DATABASE_URL = str(settings.effective_database_url)
 engine = create_async_engine(DATABASE_URL, echo=False)

--- a/backend/signal-ingestion/src/signal_ingestion/dedup.py
+++ b/backend/signal-ingestion/src/signal_ingestion/dedup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from backend.shared.cache import SyncRedis, get_sync_client
 from backend.shared.config import settings as shared_settings
+
 from .settings import settings
 
 redis_client: SyncRedis = get_sync_client()

--- a/backend/signal-ingestion/src/signal_ingestion/ingestion.py
+++ b/backend/signal-ingestion/src/signal_ingestion/ingestion.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-
 import asyncio
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .retention import purge_old_signals
 from .settings import settings
-from .tasks import ADAPTERS as TASK_ADAPTERS, schedule_ingestion
+from .tasks import ADAPTERS as TASK_ADAPTERS
+from .tasks import schedule_ingestion
 
 
 async def ingest(session: AsyncSession) -> None:

--- a/backend/signal-ingestion/src/signal_ingestion/models.py
+++ b/backend/signal-ingestion/src/signal_ingestion/models.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from pgvector.sqlalchemy import Vector
 from sqlalchemy import DateTime, Integer, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from pgvector.sqlalchemy import Vector
 
 
 class Base(DeclarativeBase):

--- a/backend/signal-ingestion/src/signal_ingestion/normalization.py
+++ b/backend/signal-ingestion/src/signal_ingestion/normalization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import Any, Callable, Dict
 
 

--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import HttpUrl, ValidationError, field_validator, TypeAdapter
+from pydantic import HttpUrl, TypeAdapter, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 

--- a/backend/signal-ingestion/src/signal_ingestion/tasks.py
+++ b/backend/signal-ingestion/src/signal_ingestion/tasks.py
@@ -7,8 +7,8 @@ import json
 from time import perf_counter
 from typing import Iterable
 
-from sqlalchemy.ext.asyncio import AsyncSession
 from prometheus_client import Counter, Histogram
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .adapters.base import BaseAdapter
 from .adapters.events import EventsAdapter
@@ -20,21 +20,21 @@ from .adapters.youtube import YouTubeAdapter
 from .celery_app import app
 from .database import SessionLocal
 from .dedup import add_key, is_duplicate
-from .models import Signal as DBSignal
 from .embedding import generate_embeddings
-from .privacy import purge_row
-from .normalization import Signal as NormalizedSignal, normalize
-from .publisher import publish
-from .retention import purge_old_signals
-from .settings import settings
-from .trending import extract_keywords, store_keywords
 from .errors import (
     AdapterFetchError,
     EmbeddingGenerationError,
     SignalIngestionError,
     UnknownAdapterError,
 )
-
+from .models import Signal as DBSignal
+from .normalization import Signal as NormalizedSignal
+from .normalization import normalize
+from .privacy import purge_row
+from .publisher import publish
+from .retention import purge_old_signals
+from .settings import settings
+from .trending import extract_keywords, store_keywords
 
 EMBEDDING_CHUNK_SIZE = 16
 

--- a/backend/signal-ingestion/src/signal_ingestion/trending.py
+++ b/backend/signal-ingestion/src/signal_ingestion/trending.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import re
-from typing import Iterable
-from typing import Pattern
-import math
-import time
-
 import json
-from typing import cast
+import math
+import re
+import time
+from typing import Iterable, Pattern, cast
 
-from backend.shared.cache import get_sync_client
-from backend.shared.cache import sync_get, sync_set
+from backend.shared.cache import get_sync_client, sync_get, sync_set
 from backend.shared.config import settings
 
 TRENDING_KEY = "trending:keywords"

--- a/backend/signal-ingestion/tests/factories.py
+++ b/backend/signal-ingestion/tests/factories.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import factory
-
 from signal_ingestion.models import Signal
 
 

--- a/backend/signal-ingestion/tests/test_adapter_timeout.py
+++ b/backend/signal-ingestion/tests/test_adapter_timeout.py
@@ -6,9 +6,9 @@ from typing import Any, Optional
 import httpx
 import pytest
 import respx
+from signal_ingestion.adapters.base import BaseAdapter
 
 from backend.shared.http import DEFAULT_TIMEOUT
-from signal_ingestion.adapters.base import BaseAdapter
 
 
 class _DummyAdapter(BaseAdapter):

--- a/backend/signal-ingestion/tests/test_adapters.py
+++ b/backend/signal-ingestion/tests/test_adapters.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
-import warnings
-import asyncio
-from types import TracebackType
 import types
-from typing import cast, Generator
-import pytest
-import fakeredis.aioredis
+import warnings
+from types import TracebackType
+from typing import Generator, cast
+
 import fakeredis
+import fakeredis.aioredis
+import pytest
+import vcr
 
 from backend.shared import cache
-import vcr
 
 warnings.filterwarnings("ignore", category=ResourceWarning)
 import httpx
@@ -89,13 +90,13 @@ class AsyncFakeRedis:
         return None
 
 
+from signal_ingestion.adapters.base import BaseAdapter  # noqa: E402
 from signal_ingestion.adapters.events import EventsAdapter  # noqa: E402
 from signal_ingestion.adapters.instagram import InstagramAdapter  # noqa: E402
 from signal_ingestion.adapters.nostalgia import NostalgiaAdapter  # noqa: E402
 from signal_ingestion.adapters.reddit import RedditAdapter  # noqa: E402
 from signal_ingestion.adapters.tiktok import TikTokAdapter  # noqa: E402
 from signal_ingestion.adapters.youtube import YouTubeAdapter  # noqa: E402
-from signal_ingestion.adapters.base import BaseAdapter  # noqa: E402
 
 ADAPTERS = [
     (TikTokAdapter, "tiktok"),

--- a/backend/signal-ingestion/tests/test_duplicate_detection.py
+++ b/backend/signal-ingestion/tests/test_duplicate_detection.py
@@ -5,8 +5,8 @@ import sys
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/backend/signal-ingestion/tests/test_etag_cache.py
+++ b/backend/signal-ingestion/tests/test_etag_cache.py
@@ -14,12 +14,13 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 )
 
-from backend.shared import cache  # noqa: E402
-from backend.shared.config import settings as shared_settings  # noqa: E402
-import signal_ingestion.rate_limit as rl  # noqa: E402
 import warnings
+
+import signal_ingestion.rate_limit as rl  # noqa: E402
 from signal_ingestion.adapters.base import BaseAdapter  # noqa: E402
 
+from backend.shared import cache  # noqa: E402
+from backend.shared.config import settings as shared_settings  # noqa: E402
 
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="redis.*")
 

--- a/backend/signal-ingestion/tests/test_normalization.py
+++ b/backend/signal-ingestion/tests/test_normalization.py
@@ -14,12 +14,12 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 )
 
-from signal_ingestion.adapters.tiktok import TikTokAdapter
-from signal_ingestion.adapters.instagram import InstagramAdapter
-from signal_ingestion.adapters.reddit import RedditAdapter
-from signal_ingestion.adapters.youtube import YouTubeAdapter
 from signal_ingestion.adapters.events import EventsAdapter
+from signal_ingestion.adapters.instagram import InstagramAdapter
 from signal_ingestion.adapters.nostalgia import NostalgiaAdapter
+from signal_ingestion.adapters.reddit import RedditAdapter
+from signal_ingestion.adapters.tiktok import TikTokAdapter
+from signal_ingestion.adapters.youtube import YouTubeAdapter
 from signal_ingestion.normalization import normalize
 
 ADAPTERS: list[tuple[Type[object], str]] = [

--- a/backend/signal-ingestion/tests/test_parallel_ingestion.py
+++ b/backend/signal-ingestion/tests/test_parallel_ingestion.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
 from signal_ingestion import database, tasks
-from signal_ingestion.normalization import Signal as NormalizedSignal
 from signal_ingestion.adapters.base import BaseAdapter
 from signal_ingestion.models import Signal as DBSignal
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from signal_ingestion.normalization import Signal as NormalizedSignal
 from sqlalchemy import select
-import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 class DummyApp:

--- a/backend/signal-ingestion/tests/test_purge_pii.py
+++ b/backend/signal-ingestion/tests/test_purge_pii.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
 from signal_ingestion import database
 from signal_ingestion.models import Signal
 from signal_ingestion.purge_pii import purge_pii
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 @pytest.mark.asyncio()

--- a/backend/signal-ingestion/tests/test_rate_limit.py
+++ b/backend/signal-ingestion/tests/test_rate_limit.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from time import perf_counter
-import warnings
 import os
 import sys
+import warnings
+from time import perf_counter
 
 import fakeredis.aioredis
 import pytest

--- a/backend/signal-ingestion/tests/test_retention.py
+++ b/backend/signal-ingestion/tests/test_retention.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
 from signal_ingestion import database
 from signal_ingestion.models import Signal
 from signal_ingestion.retention import purge_old_signals
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 @pytest.mark.asyncio()

--- a/backend/signal-ingestion/tests/test_scheduler.py
+++ b/backend/signal-ingestion/tests/test_scheduler.py
@@ -49,6 +49,7 @@ import redis  # noqa: E402
 redis.Redis = _DummyRedis  # type: ignore[attr-defined]
 
 from types import SimpleNamespace
+
 import pytest
 from apscheduler.triggers.cron import CronTrigger  # noqa: E402
 from apscheduler.triggers.interval import IntervalTrigger  # noqa: E402

--- a/backend/signal-ingestion/tests/test_startup.py
+++ b/backend/signal-ingestion/tests/test_startup.py
@@ -1,8 +1,8 @@
 """Tests for service startup logic."""
 
 import sys
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 

--- a/backend/signal-ingestion/tests/test_trending.py
+++ b/backend/signal-ingestion/tests/test_trending.py
@@ -3,20 +3,20 @@
 from __future__ import annotations
 
 import sys
-from types import SimpleNamespace
-from pathlib import Path
 import time
+import warnings
+from pathlib import Path
+from types import SimpleNamespace
 
 import fakeredis
-
 import pytest
 from fastapi.testclient import TestClient
-import warnings
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="fastapi.*")
 
 from signal_ingestion import trending
+
 from backend.shared.config import settings
 
 
@@ -141,7 +141,9 @@ def test_trending_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     from signal_ingestion import main as main_module
 
-    monkeypatch.setattr(trending, "get_top_keywords", lambda limit=10, offset=0: ["foo", "bar"])
+    monkeypatch.setattr(
+        trending, "get_top_keywords", lambda limit=10, offset=0: ["foo", "bar"]
+    )
     client = TestClient(main_module.app)
     resp = client.get("/trending?limit=2&offset=0")
     assert resp.status_code == 200

--- a/backend/signal-ingestion/tests/validators/test_signal_settings.py
+++ b/backend/signal-ingestion/tests/validators/test_signal_settings.py
@@ -1,13 +1,12 @@
 """Validation for signal_ingestion settings."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 
 import pytest  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
-
 from signal_ingestion.settings import Settings  # noqa: E402
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,16 @@
 """Root-level pytest configuration."""
 
-from tests.conftest import *  # noqa: F401,F403
-import warnings
 import os
+import sys
+import warnings
 from types import ModuleType, SimpleNamespace
+
 import redis
+import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-import sqlalchemy
-import sys
+
+from tests.conftest import *  # noqa: F401,F403
 
 sys.modules.setdefault(
     "selenium",

--- a/load_tests/api_gateway_scenarios.py
+++ b/load_tests/api_gateway_scenarios.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+
 from locust import HttpUser, between, task
 
 

--- a/load_tests/baseline_scenarios.py
+++ b/load_tests/baseline_scenarios.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import os
-from locust import HttpUser, task, between
+
+from locust import HttpUser, between, task
 
 
 class IngestionApiUser(HttpUser):

--- a/load_tests/locustfile.py
+++ b/load_tests/locustfile.py
@@ -5,14 +5,11 @@
 from __future__ import annotations
 
 import os
-from locust import HttpUser, task, between, events
 
-from baseline_scenarios import (  # noqa: F401
-    IngestionApiUser,
-    PublishingApiUser,
-    ScoringApiUser,
-)
 from api_gateway_scenarios import ApiGatewayUser  # noqa: F401
+from baseline_scenarios import IngestionApiUser  # noqa: F401
+from baseline_scenarios import PublishingApiUser, ScoringApiUser
+from locust import HttpUser, between, events, task
 
 THRESHOLD_FAILURE_RATIO = float(os.environ.get("THRESHOLD_FAILURE_RATIO", "0.01"))
 THRESHOLD_AVG_RESPONSE_TIME = float(

--- a/load_tests/test_gpu_concurrency.py
+++ b/load_tests/test_gpu_concurrency.py
@@ -2,22 +2,22 @@
 
 from __future__ import annotations
 
-import time
-from pathlib import Path
-from typing import Iterator, AsyncIterator
-from contextlib import contextmanager, asynccontextmanager
 import sys
+import time
+from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path
+from typing import AsyncIterator, Iterator
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT / "backend" / "mockup-generation"))
 
-import fakeredis
 import importlib
+import types
+
+import fakeredis
 import pytest
 from celery import Celery
 from celery.contrib.testing.worker import start_worker
-
-import types
 
 APP = Celery("test", broker="memory://", backend="cache+memory://")
 celery_stub = types.ModuleType("mockup_generation.celery_app")

--- a/load_tests/test_pipeline_compose.py
+++ b/load_tests/test_pipeline_compose.py
@@ -12,7 +12,6 @@ import psycopg2
 import pytest
 import requests
 
-
 COMPOSE_FILES = ["docker-compose.dev.yml", "docker-compose.test.yml"]
 DB_DSN = "postgresql://user:password@localhost:5432/app_test"
 S3_ENDPOINT = "http://localhost:9000"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 flake8
 black
+isort
 mypy
 pydocstyle
 flake8-docstrings

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,13 +1,14 @@
 """Utility scripts."""
 
 from . import maintenance
-from .rotate_secrets import rotate, main as rotate_secrets_main
-from .run_integration_tests import main as run_integration_tests
-from .run_dagster_webserver import main as run_dagster_webserver
-from .rotate_logs import main as rotate_logs
-from .wait_for_services import main as wait_for_services
-from .setup_codex import main as setup_codex
 from .capture_profile import main as capture_profile
+from .rotate_logs import main as rotate_logs
+from .rotate_secrets import main as rotate_secrets_main
+from .rotate_secrets import rotate
+from .run_dagster_webserver import main as run_dagster_webserver
+from .run_integration_tests import main as run_integration_tests
+from .setup_codex import main as setup_codex
+from .wait_for_services import main as wait_for_services
 
 __all__ = [
     "maintenance",

--- a/scripts/analyze_query_plans.py
+++ b/scripts/analyze_query_plans.py
@@ -14,11 +14,10 @@ from __future__ import annotations
 import logging
 from typing import Iterable
 
-from pydantic import AnyUrl, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
 import psycopg2
 from psycopg2.extras import DictCursor
+from pydantic import AnyUrl, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 SLOW_QUERY_SQL = """
     SELECT query

--- a/scripts/approve_job.py
+++ b/scripts/approve_job.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+
 import requests
 
 

--- a/scripts/benchmark_score.py
+++ b/scripts/benchmark_score.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
 import os
+from datetime import UTC, datetime
 from time import perf_counter
 
 import httpx
+
 from backend.shared.http import get_async_http_client
 
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -10,7 +10,6 @@ from typing import List
 
 import typer
 
-
 app = typer.Typer(add_completion=False, help="Operations helpers")
 
 

--- a/scripts/collect_licenses.py
+++ b/scripts/collect_licenses.py
@@ -42,7 +42,12 @@ def _node_licenses() -> list[str]:
 
 def main() -> None:
     """Generate the LICENSES file."""
-    content = ["Python packages:"] + _python_licenses() + ["", "Node packages:"] + _node_licenses()
+    content = (
+        ["Python packages:"]
+        + _python_licenses()
+        + ["", "Node packages:"]
+        + _node_licenses()
+    )
     Path("LICENSES").write_text("\n".join(content) + "\n")
 
 

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import argparse
-from datetime import UTC, datetime
-from typing import Iterable
 import logging
 import tracemalloc
+from datetime import UTC, datetime
+from typing import Iterable
 
 import requests
 

--- a/scripts/daily_summary.py
+++ b/scripts/daily_summary.py
@@ -6,18 +6,17 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from pathlib import Path
-
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Callable, ContextManager, Mapping
-
-from sqlalchemy import func, select
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from backend.shared.db import session_scope
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
+
+from backend.shared.db import session_scope
 from backend.shared.db.models import Idea, Mockup
 from backend.shared.logging import configure_logging
 
@@ -58,11 +57,7 @@ async def _marketplace_stats(since: datetime) -> Mapping[str, int]:
             / "src"
         )
     )
-    from marketplace_publisher.db import (
-        PublishStatus,
-        PublishTask,
-        SessionLocal,
-    )
+    from marketplace_publisher.db import PublishStatus, PublishTask, SessionLocal
 
     async with SessionLocal() as session:
         stmt = (

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -2,22 +2,22 @@
 """Generate OpenAPI specs for microservices."""
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
-import os
-import sys
 import logging
-import hashlib
+import os
 import re
+import sys
 from pathlib import Path
 from typing import Iterable
 
 logging.basicConfig(level=logging.INFO)
 
-from openapi_schema_validator import OAS30Validator
-
 import types
 from typing import Callable, TypeVar
+
+from openapi_schema_validator import OAS30Validator
 
 T = TypeVar("T")
 

--- a/scripts/listing_sync.py
+++ b/scripts/listing_sync.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+
+# Allow importing monitoring utilities
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -12,9 +15,6 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import Listing
-
-# Allow importing monitoring utilities
-import sys
 
 monitoring_path = Path(__file__).resolve().parents[1] / "backend" / "monitoring" / "src"
 sys.path.append(str(monitoring_path))

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -6,8 +6,8 @@ import logging
 import os
 import shutil
 from datetime import datetime, timedelta
-from typing import Any, Dict
 from pathlib import Path
+from typing import Any, Dict
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 

--- a/scripts/register_schemas.py
+++ b/scripts/register_schemas.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import pathlib
+import sys
 from typing import Iterable
 
 from pydantic import HttpUrl, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-import importlib.util
-import sys
 
 MODULE_PATH = (
     pathlib.Path(__file__).resolve().parent.parent

--- a/scripts/rotate_secrets.py
+++ b/scripts/rotate_secrets.py
@@ -8,7 +8,6 @@ import secrets
 import subprocess
 from typing import Iterable
 
-
 SECRET_NAMES: list[str] = [
     "api-gateway",
     "marketplace-publisher",

--- a/scripts/tests/test_cli.py
+++ b/scripts/tests/test_cli.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from contextlib import AsyncExitStack
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from scripts.cli import app
-
 
 runner = CliRunner()
 

--- a/scripts/update_openapi_changelog.py
+++ b/scripts/update_openapi_changelog.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import hashlib
 import json
-import pyjson5
 import subprocess
 from pathlib import Path
+
+import pyjson5
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 OPENAPI_DIR = PROJECT_ROOT / "openapi"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """Package and distribute the desAInz application."""
 
-from setuptools import Extension, find_packages, setup
 import numpy
+from setuptools import Extension, find_packages, setup
 
 ext_modules = [
     Extension(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import os
 import sys
+import time
+import warnings
 from importlib import util as importlib_util
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-import warnings
 
+import fakeredis.aioredis
+import psycopg2
 import pytest
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -16,9 +19,7 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
-import fakeredis.aioredis
-import psycopg2
-import time
+
 import docker
 
 os.environ.setdefault("OTEL_SDK_DISABLED", "true")

--- a/tests/e2e/test_compose_idea_job.py
+++ b/tests/e2e/test_compose_idea_job.py
@@ -2,8 +2,8 @@
 
 import os
 import subprocess
-import time
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Iterator
 
@@ -11,7 +11,6 @@ import psycopg2
 import pytest
 import requests
 from dagster import DagsterInstance
-
 from orchestrator import idea_job
 
 pytestmark = pytest.mark.xdist_group("compose")

--- a/tests/integration/test_alembic_heads.py
+++ b/tests/integration/test_alembic_heads.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -4,15 +4,17 @@
 
 from __future__ import annotations
 
-import sys
-from datetime import UTC, datetime
 import os
+import sys
+import warnings
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
-import warnings
 
 import pytest
+import redis
+import sqlalchemy
 import vcr
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import (
@@ -22,12 +24,11 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-# stub external dependencies before importing services
-from backend.shared.kafka import utils as kafka_utils
-from backend.shared.kafka import schema_registry as kafka_schema
 from backend.shared.config import settings as shared_settings
-import redis
-import sqlalchemy
+
+# stub external dependencies before importing services
+from backend.shared.kafka import schema_registry as kafka_schema
+from backend.shared.kafka import utils as kafka_utils
 
 _orig_async_engine = sqlalchemy.ext.asyncio.create_async_engine
 sqlalchemy.ext.asyncio.create_async_engine = lambda url, *a, **k: _orig_async_engine(
@@ -73,12 +74,14 @@ sys.path.append(str(ROOT / "backend" / "scoring-engine"))
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend" / "mockup-generation"))
 
-from signal_ingestion import ingestion, publisher
-from signal_ingestion import database as ing_db
-from signal_ingestion.adapters.tiktok import TikTokAdapter
+import importlib
+
 from mockup_generation.generator import MockupGenerator
 from scoring_engine import scoring, weight_repository
-import importlib
+from signal_ingestion import database as ing_db
+from signal_ingestion import ingestion, publisher
+from signal_ingestion.adapters.tiktok import TikTokAdapter
+
 from backend.optimization.storage import MetricsStore
 
 opt_api = importlib.import_module("backend.optimization.api")

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -23,8 +23,7 @@ sys.modules.setdefault(
 )
 os.makedirs("/run/secrets", exist_ok=True)
 
-from orchestrator import idea_job
-from orchestrator import ops
+from orchestrator import idea_job, ops
 
 
 class DummyResponse:
@@ -61,7 +60,9 @@ def test_full_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         ops,
         "requests",
-        SimpleNamespace(post=_mock_post, get=lambda *a, **k: DummyResponse({"approved": True})),
+        SimpleNamespace(
+            post=_mock_post, get=lambda *a, **k: DummyResponse({"approved": True})
+        ),
     )
     os.environ["APPROVAL_SERVICE_URL"] = "http://approval"
     result = idea_job.execute_in_process()

--- a/tests/integration/test_pipeline_metrics.py
+++ b/tests/integration/test_pipeline_metrics.py
@@ -11,10 +11,11 @@ sys.path.append(str(ROOT / "backend" / "scoring-engine"))
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend" / "mockup-generation"))
 
-from unittest.mock import MagicMock  # noqa: E402
 from types import ModuleType, SimpleNamespace  # noqa: E402
-from backend.shared.kafka import utils as kafka_utils  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
 from backend.shared.kafka import schema_registry as kafka_schema  # noqa: E402
+from backend.shared.kafka import utils as kafka_utils  # noqa: E402
 
 diffusers_stub = ModuleType("diffusers")
 setattr(diffusers_stub, "StableDiffusionXLPipeline", object)
@@ -31,25 +32,21 @@ kafka_utils.KafkaProducer = kafka_producer_mock  # type: ignore[assignment]
 kafka_schema.SchemaRegistryClient.register = MagicMock()  # type: ignore[assignment]
 kafka_schema.SchemaRegistryClient.fetch = MagicMock(return_value={})  # type: ignore[assignment]
 
-import psutil  # noqa: E402
+import importlib  # noqa: E402
 import time  # noqa: E402
 from datetime import UTC, datetime  # noqa: E402
+from typing import Any, cast  # noqa: E402
 
+import psutil  # noqa: E402
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy.ext.asyncio import (  # noqa: E402
-    AsyncSession,
-    AsyncEngine,
-    async_sessionmaker,
-)
-from sqlalchemy import select  # noqa: E402
-
-from signal_ingestion import ingestion, publisher  # noqa: E402
-from signal_ingestion import database as ing_db  # noqa: E402
 from mockup_generation.generator import MockupGenerator  # noqa: E402
 from scoring_engine import weight_repository  # noqa: E402
-import importlib  # noqa: E402
-from typing import Any, cast  # noqa: E402
+from signal_ingestion import database as ing_db  # noqa: E402
+from signal_ingestion import ingestion, publisher  # noqa: E402
+from sqlalchemy import select  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
 opt_api = cast(Any, importlib.import_module("backend.optimization.api"))
 from backend.optimization.storage import MetricsStore  # noqa: E402

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 from pathlib import Path
-import importlib
 
+import pytest
 from fastapi import FastAPI
 from opentelemetry import trace
-import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT))

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -7,14 +7,15 @@ from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
 import pytest
 import vcr
 from PIL import Image
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 # Stub external dependencies before importing service modules
-from backend.shared.kafka import utils as kafka_utils
 from backend.shared.kafka import schema_registry as kafka_schema
+from backend.shared.kafka import utils as kafka_utils
 
 kafka_utils.KafkaProducer = MagicMock(
     return_value=SimpleNamespace(send=lambda *a, **k: None, flush=lambda: None)
@@ -36,10 +37,10 @@ sys.path.append(str(ROOT / "backend" / "scoring-engine"))
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend" / "mockup-generation"))  # noqa: E402
 
-from signal_ingestion import ingestion, publisher  # type: ignore  # noqa: E402
-from signal_ingestion import database as ing_db  # type: ignore  # noqa: E402
 from mockup_generation.generator import MockupGenerator  # type: ignore  # noqa: E402
 from scoring_engine import scoring, weight_repository  # noqa: E402
+from signal_ingestion import database as ing_db  # type: ignore  # noqa: E402
+from signal_ingestion import ingestion, publisher  # type: ignore  # noqa: E402
 
 
 @vcr.use_cassette(

--- a/tests/performance/test_adapter_performance.py
+++ b/tests/performance/test_adapter_performance.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import sys
 import time
-from pathlib import Path
-import importlib
-
 import types
+from pathlib import Path
 
 import pytest
 from sqlalchemy import select
@@ -33,7 +32,7 @@ def _patched_create_async_engine(url: str, *args: object, **kwargs: object) -> A
 
 sa_async.create_async_engine = _patched_create_async_engine  # type: ignore[assignment]
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     shared_config: Any = None
@@ -41,7 +40,8 @@ else:  # pragma: no cover - runtime import and reload
     shared_config = importlib.import_module("backend.shared.config")  # type: ignore[assignment]
     importlib.reload(shared_config)  # type: ignore[arg-type]
 
-from signal_ingestion import database as database_mod, tasks as tasks_mod  # noqa: E402
+from signal_ingestion import database as database_mod  # noqa: E402
+from signal_ingestion import tasks as tasks_mod
 from signal_ingestion.adapters.base import BaseAdapter  # noqa: E402
 from signal_ingestion.models import Signal as DBSignal  # noqa: E402
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
+
 from backend.analytics import api
 from backend.analytics.auth import create_access_token
 from backend.shared.db import Base, SessionLocal, engine, models

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 """Tests for the optimization API."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "optimization")
@@ -12,7 +12,6 @@ from datetime import UTC, datetime  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from backend.optimization.api import app  # noqa: E402
-
 
 client = TestClient(app)
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1,17 +1,18 @@
 """Tests for model management API endpoints."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")
 )  # noqa: E402
 
-from fastapi.testclient import TestClient  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
 from api_gateway.main import app  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
 from backend.shared.db import session_scope  # noqa: E402
 from backend.shared.db.models import AIModel, UserRole  # noqa: E402
-from api_gateway.auth import create_access_token  # noqa: E402
 
 client = TestClient(app)
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
 import warnings
+from pathlib import Path
 
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,9 +1,10 @@
 """Tests for the PostgreSQL backup script."""
 
 from __future__ import annotations
+
 import sys
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+import sys
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
-import sys
 
 import fakeredis.aioredis
-from PIL import Image
-
-from fastapi.testclient import TestClient
 import pytest
-import warnings
+from fastapi.testclient import TestClient
+from PIL import Image
 
 # Ensure the scoring engine package can be imported when running this test alone.
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,10 +19,10 @@ sys.path.insert(0, str(ROOT / "backend" / "scoring-engine"))
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "backend" / "mockup-generation"))
 warnings.filterwarnings("ignore", category=DeprecationWarning)
-from scoring_engine.app import app as scoring_app
 import scoring_engine.app as scoring_module
-from scoring_engine.weight_repository import get_weights, update_weights
 from mockup_generation.generator import MockupGenerator
+from scoring_engine.app import app as scoring_app
+from scoring_engine.weight_repository import get_weights, update_weights
 
 
 def _setup_scoring(redis_client: fakeredis.aioredis.FakeRedis) -> ThreadPoolExecutor:

--- a/tests/test_daily_summary.py
+++ b/tests/test_daily_summary.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
-import json
 
 sys.path.append(
     str(
@@ -15,8 +15,9 @@ sys.path.append(
     )
 )
 
-import pytest
 from contextlib import contextmanager
+
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 

--- a/tests/test_error_responses.py
+++ b/tests/test_error_responses.py
@@ -9,17 +9,17 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT / "backend" / "scoring-engine"))  # noqa: E402
 
 from fastapi.testclient import TestClient  # noqa: E402
+from scoring_engine import app as scoring_app  # noqa: E402
+
 from backend.analytics import api as analytics_api  # noqa: E402
-from backend.optimization import api as optimization_api  # noqa: E402
-from backend.monitoring.src.monitoring import main as monitoring_main  # noqa: E402
-from backend.marketplace_publisher.src import (  # noqa: E402
+from backend.api_gateway.src.api_gateway import main as gateway_main  # noqa: E402
+from backend.marketplace_publisher.src import (
     marketplace_publisher as mp_main,
 )  # noqa: E402
-from backend.signal_ingestion import main as ingestion_main  # noqa: E402
-from backend.api_gateway.src.api_gateway import main as gateway_main  # noqa: E402
+from backend.monitoring.src.monitoring import main as monitoring_main  # noqa: E402
+from backend.optimization import api as optimization_api  # noqa: E402
 from backend.service_template import main as template_main  # noqa: E402
-
-from scoring_engine import app as scoring_app  # noqa: E402
+from backend.signal_ingestion import main as ingestion_main  # noqa: E402
 
 
 def _assert_error(body: dict) -> None:

--- a/tests/test_gpu_temperature_metric.py
+++ b/tests/test_gpu_temperature_metric.py
@@ -1,10 +1,10 @@
-from typing import Any
+"""Tests for GPU temperature metric update logic."""
 
 import subprocess
-
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import Any
 
 sys.path.insert(
     0, str(Path(__file__).resolve().parents[1] / "backend/mockup-generation")
@@ -31,7 +31,7 @@ sys.modules["celery.signals"] = signals_mod
 def test_gpu_temperature_metric(monkeypatch: Any) -> None:
     """GPU temperature gauge should use output from ``nvidia-smi``."""
 
-    from mockup_generation.tasks import _update_gpu_temperature, GPU_TEMPERATURE
+    from mockup_generation.tasks import GPU_TEMPERATURE, _update_gpu_temperature
 
     class Result:
         stdout = "55\n"

--- a/tests/test_latency_cache.py
+++ b/tests/test_latency_cache.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
 import types
+from pathlib import Path
 
 import fakeredis
 

--- a/tests/test_listing_sync.py
+++ b/tests/test_listing_sync.py
@@ -22,7 +22,7 @@ def setup_module(module: object) -> None:
     """Create tables for tests."""
     Base.metadata.create_all(engine)
     with session_scope() as session:
-        from datetime import datetime, UTC
+        from datetime import UTC, datetime
 
         session.add(
             Listing(

--- a/tests/test_maintenance_s3.py
+++ b/tests/test_maintenance_s3.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timedelta
 
 import boto3
 import pytest
 from moto import mock_aws
 
-from scripts import maintenance
 from backend.shared import config
-import warnings
+from scripts import maintenance
 
 
 @mock_aws

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -1,13 +1,12 @@
 """Test the Timescale metrics storage utilities."""
 
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from contextlib import contextmanager
 
 import fakeredis
-
-import pytest
 import psycopg2
+import pytest
 
 import backend.monitoring.src.monitoring.metrics_store as metrics_store
 from backend.monitoring.src.monitoring.metrics_store import (

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(REPO_ROOT))
@@ -11,9 +11,10 @@ sys.path.append(str(REPO_ROOT / "backend" / "api-gateway" / "src"))
 sys.path.append(str(REPO_ROOT / "backend" / "marketplace-publisher" / "src"))
 sys.path.append(str(REPO_ROOT / "backend" / "signal-ingestion" / "src"))
 
+import pytest
 from alembic import command
 from alembic.config import Config
-import pytest
+
 from tests.utils import assert_single_head
 
 

--- a/tests/test_model_repository.py
+++ b/tests/test_model_repository.py
@@ -1,13 +1,15 @@
 """Unit tests for model repository helpers."""
 
+from pathlib import Path
+
 from mockup_generation.model_repository import (
     get_default_model_id,
-    set_default,
     list_models,
+    set_default,
 )
+
 from backend.shared.db import session_scope
 from backend.shared.db.models import AIModel
-from pathlib import Path
 
 
 def test_default_model_switch(tmp_path: Path) -> None:

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,7 +1,7 @@
 """Tests for the monitoring service."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Any
 
 sys.path.append(
@@ -9,7 +9,6 @@ sys.path.append(
 )  # noqa: E402
 
 from fastapi.testclient import TestClient  # noqa: E402
-
 from monitoring.main import app  # noqa: E402
 
 client = TestClient(app)

--- a/tests/test_pagerduty.py
+++ b/tests/test_pagerduty.py
@@ -1,8 +1,9 @@
 """Tests for PagerDuty utility functions."""
 
 from __future__ import annotations
-from pathlib import Path
+
 import sys
+from pathlib import Path
 from typing import Any
 
 # Add monitoring src to path
@@ -11,7 +12,6 @@ sys.path.append(
 )
 
 from monitoring import pagerduty  # noqa: E402
-
 
 PAGERDUTY_URL = pagerduty.PAGERDUTY_URL
 

--- a/tests/test_revoked_token.py
+++ b/tests/test_revoked_token.py
@@ -2,22 +2,20 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-import sys
 
 from fastapi.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "backend" / "analytics"))
 
+from fastapi.security import HTTPAuthorizationCredentials
+
 from backend.analytics import api  # noqa: E402
-from backend.analytics.auth import (
-    create_access_token,
-    verify_token,
-)
+from backend.analytics.auth import create_access_token, verify_token
 from backend.shared.db import SessionLocal  # noqa: E402
 from backend.shared.db.models import RevokedToken, UserRole  # noqa: E402
-from fastapi.security import HTTPAuthorizationCredentials
 
 client = TestClient(api.app)
 

--- a/tests/test_rls.py
+++ b/tests/test_rls.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 from typing import Callable, Iterable, Iterator, List
 
@@ -10,7 +11,6 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy import Connection, create_engine, text
 from sqlalchemy.orm import Session, sessionmaker
-import uuid
 
 ADMIN_URL = "postgresql://postgres@localhost/postgres"
 

--- a/tests/test_rules_watcher.py
+++ b/tests/test_rules_watcher.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import sys
 import time
-from pathlib import Path
-from typing import Iterator
 import types
 from enum import Enum
+from pathlib import Path
+from typing import Iterator
 
 sys.path.append(
     str(
@@ -28,7 +28,6 @@ stub_db.Marketplace = _Marketplace  # type: ignore[attr-defined]
 sys.modules["marketplace_publisher.db"] = stub_db
 
 import pytest
-
 from marketplace_publisher import rules
 
 Marketplace = _Marketplace

--- a/tests/test_schema_registry_client.py
+++ b/tests/test_schema_registry_client.py
@@ -5,8 +5,8 @@ import pathlib
 import sys
 from types import ModuleType
 
-import requests
 import pytest
+import requests
 
 MODULE_PATH = (
     pathlib.Path(__file__).resolve().parents[1]

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -2,12 +2,12 @@
 
 # mypy: ignore-errors
 
-from pathlib import Path
+import importlib
 import os
 import sys
-import importlib
-from unittest import mock
 import warnings
+from pathlib import Path
+from unittest import mock
 
 from fastapi.testclient import TestClient
 

--- a/tests/test_selenium_e2e.py
+++ b/tests/test_selenium_e2e.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-import yaml
-import pytest
 
-from marketplace_publisher.clients import SeleniumFallback
-from marketplace_publisher import rules
-from marketplace_publisher.db import Marketplace
+import pytest
 import selenium.webdriver
+import yaml
+from marketplace_publisher import rules
+from marketplace_publisher.clients import SeleniumFallback
+from marketplace_publisher.db import Marketplace
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from types import ModuleType
-import os
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_sla.py
+++ b/tests/test_sla.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
 import sys
 import types
-import os
 from datetime import UTC, datetime
+from pathlib import Path
 
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "monitoring" / "src")

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -11,7 +11,6 @@ import fakeredis.aioredis
 import httpx
 from fastapi.testclient import TestClient
 
-
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")
 )

--- a/tests/test_tracing_profiling.py
+++ b/tests/test_tracing_profiling.py
@@ -7,8 +7,8 @@ import sys
 from pathlib import Path
 
 import pytest
-from opentelemetry import trace
 from fastapi.testclient import TestClient
+from opentelemetry import trace
 
 SERVICES = [
     (

--- a/tests/test_trending_route.py
+++ b/tests/test_trending_route.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import importlib
 import sys
+import warnings
 from pathlib import Path
 from typing import Any, Optional, Type
-from pydantic import RedisDsn
-import warnings
 
+import fakeredis.aioredis
 import httpx
 from fastapi.testclient import TestClient
-import fakeredis.aioredis
+from pydantic import RedisDsn
 
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -13,8 +13,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")
 )
-from api_gateway.main import app as gateway_app  # noqa: E402
 from api_gateway.auth import create_access_token  # noqa: E402
+from api_gateway.main import app as gateway_app  # noqa: E402
+
 from backend.shared.db import session_scope  # noqa: E402
 from backend.shared.db.models import UserRole  # noqa: E402
 


### PR DESCRIPTION
## Summary
- integrate isort into the pre-commit config
- document isort usage
- ensure imports are consistently sorted
- fix docstring warning in `test_gpu_temperature_metric`
- add isort to dev requirements

## Testing
- `isort --check-only .`
- `flake8 .`
- `black . --check`
- `pytest tests/test_gpu_temperature_metric.py -q` *(fails: Coverage failure: total of 8 is less than fail-under=15)*

------
https://chatgpt.com/codex/tasks/task_b_68801abb9bb4833192d67e0a2d81f3ba