### PR TITLE
Add docstrings to alembic configs

### DIFF
--- a/backend/shared/db/alembic_api_gateway.ini
+++ b/backend/shared/db/alembic_api_gateway.ini
@@ -1,3 +1,9 @@
+# API Gateway environment configuration for Alembic.
+#
+# This file configures migrations for the API Gateway service.
+# Migration scripts are stored in backend/shared/db/migrations/api_gateway.
+# The default database URL is sqlite:///shared.db.
+
 [alembic]
 script_location = backend/shared/db/migrations/api_gateway
 sqlalchemy.url = sqlite:///shared.db

--- a/backend/shared/db/alembic_marketplace_publisher.ini
+++ b/backend/shared/db/alembic_marketplace_publisher.ini
@@ -1,3 +1,9 @@
+# Marketplace Publisher environment configuration for Alembic.
+#
+# This file configures migrations for the Marketplace Publisher service.
+# Migration scripts are stored in backend/shared/db/migrations/marketplace_publisher.
+# The default database URL is sqlite:///shared.db.
+
 [alembic]
 script_location = backend/shared/db/migrations/marketplace_publisher
 sqlalchemy.url = sqlite:///shared.db

--- a/backend/shared/db/alembic_mockup_generation.ini
+++ b/backend/shared/db/alembic_mockup_generation.ini
@@ -1,3 +1,9 @@
+# Mockup Generation environment configuration for Alembic.
+#
+# This file configures migrations for the Mockup Generation service.
+# Migration scripts are stored in backend/shared/db/migrations/mockup_generation.
+# The default database URL is sqlite:///shared.db.
+
 [alembic]
 script_location = backend/shared/db/migrations/mockup_generation
 sqlalchemy.url = sqlite:///shared.db

--- a/backend/shared/db/alembic_scoring_engine.ini
+++ b/backend/shared/db/alembic_scoring_engine.ini
@@ -1,3 +1,9 @@
+# Scoring Engine environment configuration for Alembic.
+#
+# This file configures migrations for the Scoring Engine service.
+# Migration scripts are stored in backend/shared/db/migrations/scoring_engine.
+# The default database URL is sqlite:///shared.db.
+
 [alembic]
 script_location = backend/shared/db/migrations/scoring_engine
 sqlalchemy.url = sqlite:///shared.db

--- a/backend/shared/db/alembic_signal_ingestion.ini
+++ b/backend/shared/db/alembic_signal_ingestion.ini
@@ -1,3 +1,9 @@
+# Signal Ingestion environment configuration for Alembic.
+#
+# This file configures migrations for the Signal Ingestion service.
+# Migration scripts are stored in backend/shared/db/migrations/signal_ingestion.
+# The default database URL is sqlite:///shared.db.
+
 [alembic]
 script_location = backend/shared/db/migrations/signal_ingestion
 sqlalchemy.url = sqlite:///shared.db


### PR DESCRIPTION
## Summary
- document alembic environments in each alembic_*.ini

## Testing
- `make lint` *(fails: flake8 error)*
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880495168c88331a5eeaff62e344d30