### PR TITLE
Document backend env vars

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,5 @@
+# Example base environment variables for backend services.
+# See `docs/configuration.md` for guidance on managing secrets via Vault.
 # PostgreSQL connection string
 DATABASE_URL=postgresql://user:password@db:5432/backend_db
 DB_POOL_SIZE=5

--- a/backend/analytics/.env.example
+++ b/backend/analytics/.env.example
@@ -1,24 +1,30 @@
-# Database
+# Example environment for the Analytics service.
+# See `docs/configuration.md` for details on configuring secrets
+# through Vault or another secret store.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/api-gateway/.env.example
+++ b/backend/api-gateway/.env.example
@@ -1,28 +1,33 @@
-# Database
+# Environment for the API Gateway service.
+# Secrets should be injected from Vault or similar in production. Refer to
+# `docs/configuration.md` for more information.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=
 
-# WebSocket update interval in milliseconds
+# WebSocket update interval in milliseconds (default: 5000)
 API_GATEWAY_WS_INTERVAL_MS=5000

--- a/backend/feedback-loop/.env.example
+++ b/backend/feedback-loop/.env.example
@@ -1,27 +1,32 @@
-# Database
+# Example environment for the Feedback Loop service.
+# Secrets should be provided via a secure store such as Vault; see
+# `docs/configuration.md` for details.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 MODEL_CACHE_DIR=prebuilt/models
 DATASET_DIR=prebuilt/datasets
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/marketplace-publisher/.env.example
+++ b/backend/marketplace-publisher/.env.example
@@ -1,25 +1,30 @@
-# Database
+# Environment for the Marketplace Publisher service.
+# Use a secret manager such as Vault in production. See
+# `docs/configuration.md` for details.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/mockup-generation/.env.example
+++ b/backend/mockup-generation/.env.example
@@ -1,8 +1,15 @@
-# Database
+# Environment for the Mockup Generation service.
+# Use Vault or a similar secret store for secrets in production.
+# See `docs/configuration.md` for instructions.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
-# Broker configuration
+
+# Celery broker configuration
 CELERY_BROKER=redis
 REDIS_HOST=localhost
 REDIS_PORT=6379
@@ -12,25 +19,24 @@ RABBITMQ_PORT=5672
 RABBITMQ_USER=guest
 RABBITMQ_PASSWORD=guest
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 MODEL_CACHE_DIR=prebuilt/models
 DATASET_DIR=prebuilt/datasets
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/monitoring/.env.example
+++ b/backend/monitoring/.env.example
@@ -1,27 +1,32 @@
-# Database
+# Environment for the Monitoring service.
+# Secrets should be sourced from Vault in production. Consult
+# `docs/configuration.md` for instructions.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 MODEL_CACHE_DIR=prebuilt/models
 DATASET_DIR=prebuilt/datasets
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/optimization/.env.example
+++ b/backend/optimization/.env.example
@@ -1,25 +1,30 @@
-# Database
+# Environment for the Optimization service.
+# For production deployments use Vault or another secret store.
+# See `docs/configuration.md` for configuration guidance.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/orchestrator/.env.example
+++ b/backend/orchestrator/.env.example
@@ -1,27 +1,32 @@
-# Database
+# Example environment for the Orchestrator service.
+# For production, provide secrets via a tool like Vault; see
+# `docs/configuration.md` for guidance.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 MODEL_CACHE_DIR=prebuilt/models
 DATASET_DIR=prebuilt/datasets
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/scoring-engine/.env.example
+++ b/backend/scoring-engine/.env.example
@@ -1,26 +1,32 @@
-# Database
+# Environment for the Scoring Engine service.
+# Secrets must come from a secure source like Vault in production.
+# Refer to `docs/configuration.md` for more information.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
+# TimescaleDB URL for metrics storage
 METRICS_DB_URL=postgresql://postgres:postgres@localhost:5432/metrics
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/service-template/.env.example
+++ b/backend/service-template/.env.example
@@ -1,25 +1,30 @@
-# Database
+# Template environment for new services.
+# Secrets should be loaded from Vault in production; see
+# `docs/configuration.md` for details.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/shared/.env.example
+++ b/backend/shared/.env.example
@@ -1,27 +1,32 @@
-# Database
+# Shared settings used by multiple services.
+# Secrets are expected to be provided via Vault when deployed to production.
+# See `docs/configuration.md` for the full list of variables.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 MODEL_CACHE_DIR=prebuilt/models
 DATASET_DIR=prebuilt/datasets
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/signal-ingestion/.env.example
+++ b/backend/signal-ingestion/.env.example
@@ -1,38 +1,56 @@
-# Database
+# Environment for the Signal Ingestion service.
+# Use Vault or a similar secret manager in production. See
+# `docs/configuration.md` for more details.
+
+# Database connection URL
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/design_idea_engine
+# Connection pool size (default: 5)
 DB_POOL_SIZE=5
+# Redis connection string
 REDIS_URL=redis://localhost:6379
 
-# AI Services
+# AI service credentials
 OPENAI_API_KEY=your_openai_key
 HUGGINGFACE_TOKEN=your_hf_token
 
-# Auth0
+# Auth0 tenant information
 AUTH0_DOMAIN=your-auth0-domain
 AUTH0_CLIENT_ID=your-client-id
 
-
-# Storage
+# Object storage settings
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=design-idea-engine
 
-# Kafka
+# Kafka broker list
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+# Instagram API token
 INSTAGRAM_TOKEN=
+# Instagram account ID
 INSTAGRAM_USER_ID=
+# How many posts to fetch from Instagram (default: 1)
 INSTAGRAM_FETCH_LIMIT=1
+# User agent for Reddit requests
 REDDIT_USER_AGENT=signal-bot
+# How many posts to fetch from Reddit (default: 1)
 REDDIT_FETCH_LIMIT=1
+# YouTube API key
 YOUTUBE_API_KEY=
+# How many videos to fetch from YouTube (default: 1)
 YOUTUBE_FETCH_LIMIT=1
+# Comma-separated TikTok URLs
 TIKTOK_VIDEO_URLS=
+# How many TikTok videos to retrieve (default: 1)
 TIKTOK_FETCH_LIMIT=1
+# Query for Nostalgia data
 NOSTALGIA_QUERY='subject:"nostalgia"'
+# Number of Nostalgia items to retrieve (default: 1)
 NOSTALGIA_FETCH_LIMIT=1
+# Country code for events API
 EVENTS_COUNTRY_CODE=US
+# Number of events to retrieve (default: 1)
 EVENTS_FETCH_LIMIT=1
 
-# Error Tracking
+# Optional Sentry DSN for error tracking
 SENTRY_DSN=


### PR DESCRIPTION
## Summary
- expand env variable explanations for all backend services
- mention docs/configuration.md so secrets can be set via Vault

## Testing
- `make lint` *(fails: flake8 unrecognized argument --cache)*
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68804b0f69a08331a7d4576959bc24ab