### PR TITLE
Improve merge migrations

### DIFF
--- a/backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from alembic import op
+import sqlalchemy as sa
+
 revision = "0003"
 down_revision = ("0002a", "0002b")
 branch_labels = None
@@ -9,10 +12,83 @@ depends_on = None
 
 
 def upgrade() -> None:
-    """Merge branches by creating empty revision."""
-    pass
+    """Merge branch heads by applying missing operations."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("ideas")]
+    if "status" not in columns:
+        op.add_column(
+            "ideas",
+            sa.Column(
+                "status",
+                sa.String(length=50),
+                nullable=False,
+                server_default="pending",
+            ),
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("signals")]
+    if "ix_signals_idea_id" not in indexes:
+        op.create_index(
+            op.f("ix_signals_idea_id"), "signals", ["idea_id"], unique=False
+        )
+    if "ix_signals_timestamp" not in indexes:
+        op.create_index(
+            op.f("ix_signals_timestamp"),
+            "signals",
+            ["timestamp"],
+            unique=False,
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("mockups")]
+    if "ix_mockups_idea_id" not in indexes:
+        op.create_index(
+            op.f("ix_mockups_idea_id"), "mockups", ["idea_id"], unique=False
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("listings")]
+    if "ix_listings_mockup_id" not in indexes:
+        op.create_index(
+            op.f("ix_listings_mockup_id"),
+            "listings",
+            ["mockup_id"],
+            unique=False,
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("ab_tests")]
+    if "ix_ab_tests_listing_id" not in indexes:
+        op.create_index(
+            op.f("ix_ab_tests_listing_id"),
+            "ab_tests",
+            ["listing_id"],
+            unique=False,
+        )
 
 
 def downgrade() -> None:
-    """Downgrade by doing nothing."""
-    pass
+    """Revert operations applied in :func:`upgrade`."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("ab_tests")]
+    if "ix_ab_tests_listing_id" in indexes:
+        op.drop_index(op.f("ix_ab_tests_listing_id"), table_name="ab_tests")
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("listings")]
+    if "ix_listings_mockup_id" in indexes:
+        op.drop_index(op.f("ix_listings_mockup_id"), table_name="listings")
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("mockups")]
+    if "ix_mockups_idea_id" in indexes:
+        op.drop_index(op.f("ix_mockups_idea_id"), table_name="mockups")
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("signals")]
+    if "ix_signals_timestamp" in indexes:
+        op.drop_index(op.f("ix_signals_timestamp"), table_name="signals")
+    if "ix_signals_idea_id" in indexes:
+        op.drop_index(op.f("ix_signals_idea_id"), table_name="signals")
+
+    columns = [col["name"] for col in inspector.get_columns("ideas")]
+    if "status" in columns:
+        op.drop_column("ideas", "status")

--- a/backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from alembic import op
+import sqlalchemy as sa
+
 revision = "0010"
 down_revision = "0009"
 branch_labels = None
@@ -9,10 +12,29 @@ depends_on = None
 
 
 def upgrade() -> None:
-    """Merge branches."""
-    pass
+    """Merge branches by applying missing tables."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "generated_mockups" not in inspector.get_table_names():
+        op.create_table(
+            "generated_mockups",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("prompt", sa.String(), nullable=False),
+            sa.Column("num_inference_steps", sa.Integer, nullable=False),
+            sa.Column("seed", sa.Integer, nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
 
 
 def downgrade() -> None:
-    """Downgrade merge revision."""
-    pass
+    """Drop tables added in :func:`upgrade`."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "generated_mockups" in inspector.get_table_names():
+        op.drop_table("generated_mockups")

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -58,6 +58,13 @@ The new revision should live in `backend/shared/db/migrations` and replace
 `scripts/validate_migrations.sh` to confirm that only a single head exists
 and that no divergent branches remain.
 
+### Current Merge Revisions
+
+The scoring engine service currently contains the following merge revisions:
+
+* `0003` merges `0002a` and `0002b`.
+* `0010` merges the `generated_mockups` branch with the main line.
+
 ## Verifying Migrations
 
 Run the migration tests to ensure each service's migrations apply cleanly on an


### PR DESCRIPTION
## Summary
- flesh out upgrade/downgrade logic for scoring_engine merge migrations
- document merge revisions in the migration docs

## Testing
- `flake8 backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py`
- `mypy --ignore-missing-imports --follow-imports=skip backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py`
- `pydocstyle backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py`
- `docformatter -i docs/migrations.md`
- `./scripts/validate_migrations.sh` *(fails: Divergent migration branches detected)*
- `pytest -k 'migrations or 0003_merge_heads or 0010_merge_heads' -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_b_68805f6f0af88331a3df9b3958745c7b