### PR TITLE
Add blue-green overlay and smoke test color check

### DIFF
--- a/infrastructure/k8s/README.md
+++ b/infrastructure/k8s/README.md
@@ -21,3 +21,22 @@ Use `minikube service <service-name>` to access the service on your host machine
 If you have the Prometheus Operator installed in your cluster, the included
 `ServiceMonitor` will scrape metrics from the service's `/metrics` endpoint.
 
+
+## Blue-Green Deployments
+
+The `overlays/blue-green` directory defines separate `blue` and `green`
+Deployments for the API Gateway and the Admin Dashboard. The Service
+selectors default to the `blue` version.
+
+To switch traffic to the other color simply patch the Service selector:
+
+```bash
+# Switch API Gateway to green
+kubectl patch service api-gateway -p '{"spec":{"selector":{"app":"api-gateway","color":"green"}}}'
+
+# Switch Admin Dashboard to green
+kubectl patch service admin-dashboard -p '{"spec":{"selector":{"app":"admin-dashboard","color":"green"}}}'
+```
+
+New deployments can be rolled out with `scripts/deploy.sh`, which
+performs a gradual blue-green update and runs health checks.

--- a/infrastructure/k8s/overlays/blue-green/admin-dashboard-blue-deployment.yaml
+++ b/infrastructure/k8s/overlays/blue-green/admin-dashboard-blue-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-dashboard-blue
+  labels:
+    app: admin-dashboard
+    color: blue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: admin-dashboard
+      color: blue
+  template:
+    metadata:
+      labels:
+        app: admin-dashboard
+        color: blue
+    spec:
+      containers:
+        - name: admin-dashboard
+          image: example/admin-dashboard:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/overlays/blue-green/admin-dashboard-green-deployment.yaml
+++ b/infrastructure/k8s/overlays/blue-green/admin-dashboard-green-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-dashboard-green
+  labels:
+    app: admin-dashboard
+    color: green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: admin-dashboard
+      color: green
+  template:
+    metadata:
+      labels:
+        app: admin-dashboard
+        color: green
+    spec:
+      containers:
+        - name: admin-dashboard
+          image: example/admin-dashboard:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/overlays/blue-green/admin-dashboard-service.yaml
+++ b/infrastructure/k8s/overlays/blue-green/admin-dashboard-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admin-dashboard
+spec:
+  type: ClusterIP
+  selector:
+    app: admin-dashboard
+    color: blue
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/infrastructure/k8s/overlays/blue-green/api-gateway-blue-deployment.yaml
+++ b/infrastructure/k8s/overlays/blue-green/api-gateway-blue-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway-blue
+  labels:
+    app: api-gateway
+    color: blue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+      color: blue
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+        color: blue
+    spec:
+      containers:
+        - name: api-gateway
+          image: example/api-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/overlays/blue-green/api-gateway-green-deployment.yaml
+++ b/infrastructure/k8s/overlays/blue-green/api-gateway-green-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway-green
+  labels:
+    app: api-gateway
+    color: green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+      color: green
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+        color: green
+    spec:
+      containers:
+        - name: api-gateway
+          image: example/api-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/overlays/blue-green/api-gateway-service-selector-blue.yaml
+++ b/infrastructure/k8s/overlays/blue-green/api-gateway-service-selector-blue.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: api-gateway
+    color: blue
+  ports:
+    - port: 80
+      targetPort: 8000

--- a/infrastructure/k8s/overlays/blue-green/kustomization.yaml
+++ b/infrastructure/k8s/overlays/blue-green/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - ../../base
+  - api-gateway-blue-deployment.yaml
+  - api-gateway-green-deployment.yaml
+  - admin-dashboard-blue-deployment.yaml
+  - admin-dashboard-green-deployment.yaml
+  - admin-dashboard-service.yaml
+patchesStrategicMerge:
+  - api-gateway-service-selector-blue.yaml

--- a/scripts/smoke_compose.sh
+++ b/scripts/smoke_compose.sh
@@ -49,5 +49,15 @@ for svc in "${SERVICES[@]}"; do
   echo "$svc is ready"
 done
 
-echo "All services are ready."
+expected_color="${ACTIVE_COLOR:-blue}"
+actual_color=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$(docker compose $COMPOSE_FILES ps -q api-gateway)" | grep '^COLOR=' | cut -d= -f2 || true)
+if [[ -n "$actual_color" ]]; then
+  if [[ "$actual_color" != "$expected_color" ]]; then
+    echo "Active color $actual_color does not match expected $expected_color" >&2
+    exit 1
+  fi
+  echo "All services are ready with color $actual_color."
+else
+  echo "All services are ready."
+fi
 


### PR DESCRIPTION
## Summary
- add API gateway and admin dashboard blue/green deployments
- update smoke test to verify active color
- document switching colors in the Kubernetes README

## Testing
- `pre-commit run --files infrastructure/k8s/overlays/blue-green/kustomization.yaml infrastructure/k8s/overlays/blue-green/api-gateway-blue-deployment.yaml infrastructure/k8s/overlays/blue-green/api-gateway-green-deployment.yaml infrastructure/k8s/overlays/blue-green/api-gateway-service-selector-blue.yaml infrastructure/k8s/overlays/blue-green/admin-dashboard-blue-deployment.yaml infrastructure/k8s/overlays/blue-green/admin-dashboard-green-deployment.yaml infrastructure/k8s/overlays/blue-green/admin-dashboard-service.yaml infrastructure/k8s/README.md scripts/smoke_compose.sh` *(fails: Username for 'https://github.com')*
- `pytest -q` *(fails: 71 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68805f7214cc833194aaa4f6e783c92c