### PR TITLE
Add environment variable docs

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -1,4 +1,12 @@
-"""API Gateway FastAPI application."""
+"""
+API Gateway FastAPI application.
+
+Environment variables
+---------------------
+SERVICE_NAME:
+    Name reported to tracing and logging backends. Defaults to
+    :data:`~backend.shared.ServiceName.API_GATEWAY`.
+"""
 
 import logging
 import os

--- a/backend/marketplace-publisher/src/marketplace_publisher/clients.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/clients.py
@@ -1,4 +1,12 @@
-"""Marketplace API clients with Selenium fallback and OAuth support."""
+"""
+Marketplace API clients with Selenium fallback and OAuth support.
+
+Environment variables
+---------------------
+SELENIUM_SKIP:
+    Set to ``"1"`` to disable Selenium-based features during tests. Defaults to
+    ``"0"``.
+"""
 
 from __future__ import annotations
 

--- a/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
@@ -1,4 +1,11 @@
-"""Notification helpers for publisher errors."""
+"""
+Notification helpers for publisher errors.
+
+Environment variables
+---------------------
+SLACK_WEBHOOK_URL:
+    Webhook URL used to dispatch failure notifications. Optional.
+"""
 
 from __future__ import annotations
 

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -1,4 +1,14 @@
-"""Expose Prometheus metrics and logs via FastAPI."""
+"""
+Expose Prometheus metrics and logs via FastAPI.
+
+Environment variables
+---------------------
+CELERY_BROKER_URL:
+    Connection string for the Celery broker. Defaults to
+    ``"redis://localhost:6379/0"``.
+CELERY_QUEUES:
+    Comma-separated list of queues to consume. Defaults to ``"celery"``.
+"""
 
 from __future__ import annotations
 

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -1,4 +1,12 @@
-"""FastAPI application exposing optimization endpoints."""
+"""
+FastAPI application exposing optimization endpoints.
+
+Environment variables
+---------------------
+SERVICE_NAME:
+    Name reported to tracing and logging backends. Defaults to
+    :data:`~backend.shared.ServiceName.OPTIMIZATION`.
+"""
 
 from __future__ import annotations
 

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -1,4 +1,48 @@
-"""Dagster operations for the orchestration pipeline."""
+"""
+Dagster operations for the orchestration pipeline.
+
+Environment variables
+---------------------
+SERVICE_AUTH_TOKEN:
+    Bearer token for authenticating service-to-service calls. Optional.
+SIGNAL_INGESTION_URL:
+    Base URL for the signal ingestion service. Defaults to
+    ``"http://signal-ingestion:8004"``.
+SCORING_ENGINE_URL:
+    Base URL for the scoring engine. Defaults to
+    ``"http://scoring-engine:5002"``.
+MOCKUP_GENERATION_URL:
+    Base URL for the mockup generation service. Defaults to
+    ``"http://mockup-generation:8000"``.
+APPROVAL_SERVICE_URL:
+    Base URL for the approval service. Defaults to
+    ``"http://api-gateway:8000"``.
+PUBLISHER_URL:
+    Base URL for the marketplace publisher. Defaults to
+    ``"http://marketplace-publisher:8001"``.
+SLACK_WEBHOOK_URL:
+    Slack webhook for notifications. Optional.
+S3_IAM_USER:
+    AWS IAM user for S3 rotation. Defaults to ``"deploy"``.
+S3_SECRET_NAME:
+    Name of the Kubernetes secret containing S3 credentials. Defaults to
+    ``"s3-creds"``.
+SPOT_AMI_ID:
+    AMI ID for spot instances. Required.
+SPOT_INSTANCE_TYPE:
+    Instance type for spot nodes. Required.
+SPOT_KEY_NAME:
+    SSH key name for spot nodes. Required.
+SPOT_SECURITY_GROUP:
+    Security group for spot nodes. Required.
+SPOT_SUBNET_ID:
+    Subnet ID for spot nodes. Required.
+SPOT_LABEL:
+    Kubernetes node label used to identify spot nodes. Defaults to
+    ``"node-role.kubernetes.io/spot=yes"``.
+SPOT_COUNT:
+    Number of spot nodes to maintain. Defaults to ``"1"``.
+"""
 
 from __future__ import annotations
 

--- a/backend/orchestrator/orchestrator/sensors.py
+++ b/backend/orchestrator/orchestrator/sensors.py
@@ -1,4 +1,11 @@
-"""Dagster sensors for conditional job triggers."""
+"""
+Dagster sensors for conditional job triggers.
+
+Environment variables
+---------------------
+AUTO_RUN_IDEA:
+    When set to ``"true"`` the :func:`idea_job` is triggered automatically.
+"""
 
 from __future__ import annotations
 

--- a/backend/signal-ingestion/src/signal_ingestion/publisher.py
+++ b/backend/signal-ingestion/src/signal_ingestion/publisher.py
@@ -1,4 +1,11 @@
-"""Kafka publisher using typed schemas."""
+"""
+Kafka publisher using typed schemas.
+
+Environment variables
+---------------------
+KAFKA_SKIP:
+    When set to ``"1"`` Kafka connections are skipped. Defaults to ``"0"``.
+"""
 
 from __future__ import annotations
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,22 @@
-"""Sphinx configuration for the desAInz project."""
+"""
+Sphinx configuration for the desAInz project.
+
+Environment variables
+---------------------
+SKIP_DOC_LINT:
+    Skip docstring linting when set to ``"1"``. Defaults to ``"0"``.
+SKIP_APIDOC:
+    Skip API documentation generation when set to ``"1"``. Defaults to ``"0"``.
+SKIP_OPENAPI:
+    Skip OpenAPI specification generation when set to ``"1"``. Defaults to
+    ``"0"``.
+KAFKA_SKIP:
+    Set to ``"1"`` while generating OpenAPI specs to disable Kafka connections.
+    Defaults to ``"0"``.
+SELENIUM_SKIP:
+    Set to ``"1"`` while generating OpenAPI specs to disable Selenium usage.
+    Defaults to ``"0"``.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document environment variables at module level
- keep docstring linters happy

## Testing
- `pydocstyle docs/conf.py backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/sensors.py backend/signal-ingestion/src/signal_ingestion/publisher.py backend/optimization/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/marketplace-publisher/src/marketplace_publisher/clients.py`
- `flake8 --select=D docs/conf.py backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/sensors.py backend/signal-ingestion/src/signal_ingestion/publisher.py backend/optimization/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/marketplace-publisher/src/marketplace_publisher/clients.py`
- `black docs/conf.py backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/sensors.py backend/signal-ingestion/src/signal_ingestion/publisher.py backend/optimization/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/marketplace-publisher/src/marketplace_publisher/clients.py`
- `mypy docs/conf.py backend/monitoring/src/monitoring/main.py backend/orchestrator/orchestrator/ops.py backend/orchestrator/orchestrator/sensors.py backend/signal-ingestion/src/signal_ingestion/publisher.py backend/optimization/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/marketplace-publisher/src/marketplace_publisher/clients.py` *(fails: Class cannot subclass "BaseModel")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68805f74cb388331a6731574bcdd6cd3