### PR TITLE
Add type hints and mypy config

### DIFF
--- a/backend/marketplace-publisher/tests/test_trademark.py
+++ b/backend/marketplace-publisher/tests/test_trademark.py
@@ -40,6 +40,8 @@ db_stub = types.ModuleType("marketplace_publisher.db")
 
 
 class Marketplace(enum.Enum):
+    """Enumeration of supported marketplaces."""
+
     redbubble = "redbubble"
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.12
+ignore_missing_imports = true
+disallow_untyped_defs = true
+files = scripts/*.py, backend/analytics/api.py


### PR DESCRIPTION
## Summary
- enable strict checking for scripts and analytics API via mypy.ini
- document the Marketplace enum used in unit tests

## Testing
- `mypy scripts/apply_s3_lifecycle.py backend/analytics/api.py --follow-imports=skip`
- `pytest tests/test_backup.py tests/test_analytics.py tests/test_schema_registry_client.py tests/test_ready_auth.py -W error` *(fails: ModuleNotFoundError: No module named 'pgvector')*

------
https://chatgpt.com/codex/tasks/task_b_68805f72ce0083319dcba904b50cfae9