### PR TITLE
Add offline testing guide

### DIFF
--- a/docs/frontend/offline.md
+++ b/docs/frontend/offline.md
@@ -10,3 +10,16 @@ The service worker is automatically generated during `next build` and
 served from the `public` directory. When a new version is deployed,
 the worker skips the waiting phase so clients receive updates on the
 next load.
+
+## Testing offline mode
+
+To verify offline support locally:
+
+1. Run `npm run build` inside `frontend/admin-dashboard`.
+2. Start the production server with `npm start` or serve the exported `out` directory using `npx serve out`.
+3. Open the application in Chrome and go to **Application > Service Workers** in DevTools.
+   Confirm that `service-worker.js` is installed and activated.
+4. In the **Network** tab, enable the **Offline** checkbox.
+5. Reload the page; the dashboard should load normally using cached assets.
+
+Disable offline mode to restore normal connectivity.


### PR DESCRIPTION
## Summary
- document how to verify the dashboard works offline

## Testing
- `npx prettier -w docs/frontend/offline.md`
- `docformatter -i docs/frontend/offline.md`
- `python3 -m pytest -W error -vv` *(fails: ModuleNotFoundError: No module named '...')*


------
https://chatgpt.com/codex/tasks/task_b_68805f779eb08331b845d76d17669f96