### PR TITLE
Monitor deployment health

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -107,6 +107,20 @@ jobs:
           TAG: ${{ github.sha }}
           ENV: prod
         run: make helm-deploy REGISTRY=$REGISTRY TAG=$TAG ENV=$ENV
+      - name: Wait for health checks
+        env:
+          SERVICES: >-
+            orchestrator ai-mockup-generation data-storage signal-ingestion
+            scoring-engine marketplace-publisher feedback-loop
+          REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          PREVIOUS_TAG: ${{ github.event.before }}
+          ENV: prod
+        run: |
+          if ! ./scripts/check_k8s_health.sh "$ENV" $SERVICES; then
+            echo "Health check failed, rolling back" >&2
+            make helm-deploy REGISTRY=$REGISTRY TAG=$PREVIOUS_TAG ENV=$ENV
+            exit 1
+          fi
 
   docs:
     runs-on: ubuntu-latest

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -200,3 +200,10 @@ Run the script with the service name, target image and namespace:
 ```bash
 ./scripts/deploy.sh <service> ghcr.io/example/<service>:<tag> <namespace>
 ```
+
+## Pipeline Health Monitoring
+
+The CI pipeline checks that every service responds successfully to `/ready`
+after deploying the new images. If any health check fails, the workflow
+reverts to the previous image tag by running `make helm-deploy` with the prior
+commit SHA. Health checks are performed via `scripts/check_k8s_health.sh`.


### PR DESCRIPTION
## Summary
- check service readiness in pipeline
- rollback to previous image tag when health checks fail
- document the new pipeline behaviour

## Testing
- `pre-commit run --files .github/workflows/pipeline.yml docs/deployment.md` *(fails: requires network)*
- `pytest -n auto -W error -vv` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_b_68805f706ee48331929a373ff81e0d68