### PR TITLE
Add Dagster scheduler deployment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,10 +25,24 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Build orchestrator image
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/orchestrator
+          tags: orchestrator:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: mockup-generation:latest
+          severity: CRITICAL,HIGH
+          exit-code: 1
+      - name: Scan orchestrator image with Trivy
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          image-ref: orchestrator:latest
           severity: CRITICAL,HIGH
           exit-code: 1
       - name: Smoke test core services

--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -169,6 +169,7 @@ HEALTH_ENDPOINTS: dict[str, str] = {
     "monitoring": f"{MONITORING_URL}/health",
     "analytics": f"{ANALYTICS_URL}/health",
     "feedback_loop": "http://feedback-loop:8000/health",
+    "orchestrator": "http://orchestrator:3000/health",
 }
 auth_scheme = HTTPBearer()
 

--- a/backend/orchestrator/tests/test_failure_sensor.py
+++ b/backend/orchestrator/tests/test_failure_sensor.py
@@ -10,6 +10,8 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend" / "orchestrator"))
+sys.path.append(str(ROOT / "backend" / "monitoring" / "src"))
 
 from dagster import DagsterInstance, build_run_status_sensor_context
 

--- a/backend/orchestrator/tests/test_privacy_job.py
+++ b/backend/orchestrator/tests/test_privacy_job.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+import os
 
 import pytest
 from dagster import DagsterInstance
@@ -17,6 +18,11 @@ MONITORING_SRC = ROOT / "backend" / "monitoring" / "src"
 sys.path.append(str(MONITORING_SRC))  # noqa: E402
 SIGNAL_SRC = ROOT / "backend" / "signal-ingestion" / "src"
 sys.path.append(str(SIGNAL_SRC))  # noqa: E402
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
+from backend.shared.config import settings
+settings.database_url = "sqlite+aiosqlite:///:memory:"
+settings.pgbouncer_url = ""
+settings.__dict__.pop("effective_database_url", None)
 
 from orchestrator.jobs import privacy_purge_job  # noqa: E402
 from signal_ingestion import database  # noqa: E402

--- a/backend/orchestrator/tests/test_spot_nodes_job.py
+++ b/backend/orchestrator/tests/test_spot_nodes_job.py
@@ -1,0 +1,37 @@
+"""Tests for the maintain spot nodes job."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from dagster import DagsterInstance
+
+ROOT = Path(__file__).resolve().parents[3]
+ORCHESTRATOR_PATH = ROOT / "backend" / "orchestrator"
+sys.path.append(str(ORCHESTRATOR_PATH))  # noqa: E402
+MONITORING_SRC = ROOT / "backend" / "monitoring" / "src"
+sys.path.append(str(MONITORING_SRC))  # noqa: E402
+
+from orchestrator.jobs import maintain_spot_nodes_job  # noqa: E402
+
+
+def test_maintain_spot_nodes_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the maintain nodes utility is invoked."""
+    calls: list[str] = []
+
+    def fake_maintain(*args: object, **kwargs: object) -> None:
+        calls.append("called")
+
+    monkeypatch.setattr("scripts.manage_spot_instances.maintain_nodes", fake_maintain)
+    monkeypatch.setenv("SPOT_AMI_ID", "ami-1")
+    monkeypatch.setenv("SPOT_INSTANCE_TYPE", "t3.micro")
+    monkeypatch.setenv("SPOT_KEY_NAME", "k")
+    monkeypatch.setenv("SPOT_SECURITY_GROUP", "sg")
+    monkeypatch.setenv("SPOT_SUBNET_ID", "sn")
+
+    instance = DagsterInstance.ephemeral()
+    result = maintain_spot_nodes_job.execute_in_process(instance=instance)
+    assert result.success
+    assert calls == ["called"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -384,6 +384,20 @@ services:
     - openai_api_key
     - stability_ai_api_key
     - huggingface_token
+  orchestrator-scheduler:
+    build:
+      context: .
+      dockerfile: backend/orchestrator/Dockerfile
+    command: dagster-daemon run
+    mem_limit: 512m
+    cpus: 0.25
+    depends_on:
+    - orchestrator
+    secrets:
+    - secret_key
+    - openai_api_key
+    - stability_ai_api_key
+    - huggingface_token
   backup:
     image: ghcr.io/example/backup:latest
     mem_limit: 512m

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Welcome to desAInz's documentation!
    mocking
    maintenance
    operations
+   orchestrator
    listing_sync
    publish_tasks
    security

--- a/docs/orchestrator.rst
+++ b/docs/orchestrator.rst
@@ -1,0 +1,12 @@
+Dagster Orchestrator
+====================
+
+This service runs all scheduled workflows. Start it locally with two processes:
+
+.. code-block:: bash
+
+   ./scripts/setup_codex.sh
+   ./scripts/run_dagster_webserver.sh
+   ./scripts/run_dagster_daemon.sh
+
+The web interface listens on http://localhost:3000.

--- a/infrastructure/helm/orchestrator/templates/deployment.yaml
+++ b/infrastructure/helm/orchestrator/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       labels: {{- include "orchestrator.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: webserver
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -37,7 +37,24 @@ spec:
             - name: tmpfs-volume
               mountPath: /tmpfs
           resources:
-{{ toYaml .Values.resources | nindent 12 }}
+            {{ toYaml .Values.resources | nindent 12 }}
+        - name: scheduler
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["dagster-daemon", "run"]
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+          volumeMounts:
+            - name: secret-volume
+              mountPath: /run/secrets
+              readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
+          resources:
+            {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: secret-volume
           secret:

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -4,6 +4,7 @@ from . import maintenance
 from .rotate_secrets import rotate, main as rotate_secrets_main
 from .run_integration_tests import main as run_integration_tests
 from .run_dagster_webserver import main as run_dagster_webserver
+from .run_dagster_daemon import main as run_dagster_daemon
 from .rotate_logs import main as rotate_logs
 from .wait_for_services import main as wait_for_services
 from .setup_codex import main as setup_codex
@@ -15,6 +16,7 @@ __all__ = [
     "rotate_secrets_main",
     "run_integration_tests",
     "run_dagster_webserver",
+    "run_dagster_daemon",
     "rotate_logs",
     "wait_for_services",
     "setup_codex",

--- a/scripts/run_dagster_daemon.py
+++ b/scripts/run_dagster_daemon.py
@@ -1,0 +1,22 @@
+"""Start the Dagster scheduler daemon."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    """Run ``dagster-daemon`` with the default configuration."""
+    root_dir = Path(__file__).resolve().parents[1]
+    os.chdir(root_dir)
+    dagster_home = os.environ.get(
+        "DAGSTER_HOME", str(root_dir / "backend" / "orchestrator")
+    )
+    os.environ["DAGSTER_HOME"] = dagster_home
+    subprocess.run(["dagster-daemon", "run"], check=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/run_dagster_daemon.sh
+++ b/scripts/run_dagster_daemon.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Start Dagster scheduler daemon.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+export DAGSTER_HOME="${DAGSTER_HOME:-$ROOT_DIR/backend/orchestrator}"
+exec dagster-daemon run


### PR DESCRIPTION
## Summary
- build orchestrator Docker image in CI
- deploy orchestrator scheduler via docker-compose and Helm
- expose orchestrator health in API gateway
- document local Dagster startup
- add unit test for `maintain_spot_nodes_job`

## Testing
- `pytest backend/orchestrator/tests/test_spot_nodes_job.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_68806be7e04483319bb3128a9362c102