### PR TITLE
Add analytics container deployment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,21 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Scan image with Trivy
+      - name: Build analytics image
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/analytics
+          tags: analytics:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Scan analytics image with Trivy
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          image-ref: analytics:latest
+          severity: CRITICAL,HIGH
+          exit-code: 1
+      - name: Scan mockup-generation image with Trivy
         uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: mockup-generation:latest

--- a/backend/analytics/Dockerfile
+++ b/backend/analytics/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY requirements.txt ./
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
+
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONPATH=/app
+RUN useradd --create-home --uid 1000 appuser
+COPY --from=builder /usr/local /usr/local
+COPY LICENSES /licenses/LICENSES
+COPY . .
+USER appuser
+HEALTHCHECK --interval=30s --timeout=5s CMD curl -f http://localhost:8000/health || exit 1
+CMD ["python", "-m", "analytics.api"]

--- a/backend/analytics/requirements.txt
+++ b/backend/analytics/requirements.txt
@@ -1,0 +1,14 @@
+fastapi
+uvicorn[standard]
+uvloop
+pydantic
+pydantic-settings
+sqlalchemy
+psycopg2-binary
+prometheus-client
+opentelemetry-sdk
+opentelemetry-instrumentation-fastapi
+sentry-sdk
+orjson
+pandas
+requests

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -184,6 +184,7 @@ services:
     - 8000:8000
     environment:
       LOKI_URL: http://loki:3100
+      ANALYTICS_URL: http://analytics:8000
     depends_on:
     - loki
     labels:
@@ -256,6 +257,25 @@ services:
     - openai_api_key
     - stability_ai_api_key
     - huggingface_token
+  analytics:
+    build: ./backend/analytics
+    mem_limit: 512m
+    cpus: 0.50
+    ports:
+    - 8006:8000
+    depends_on:
+    - postgres
+    labels:
+    - prometheus.scrape=true
+    - prometheus.path=/metrics
+    - prometheus.port=8000
+
+    secrets:
+    - secret_key
+    - openai_api_key
+    - stability_ai_api_key
+    - huggingface_token
+
   api-gateway:
     build: ./backend/api-gateway
     mem_limit: 512m
@@ -264,6 +284,7 @@ services:
     - 8001:8000
     environment:
       LOKI_URL: http://loki:3100
+      ANALYTICS_URL: http://analytics:8000
     depends_on:
     - kafka
     - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,6 +257,20 @@ services:
       - "prometheus.path=/metrics"
       - "prometheus.port=8000"
 
+  analytics:
+    build: ./backend/analytics
+    mem_limit: 512m
+    cpus: 0.50
+    command: python -m analytics.api
+    ports:
+      - "8006:8000"
+    depends_on:
+      - postgres
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=8000"
+
   feedback-loop:
     build: ./backend/feedback-loop
     mem_limit: 512m

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,6 +31,7 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
    ```
 
 5. Secrets can be stored in files under `secrets/` and referenced as Docker secrets. The services read them from `/run/secrets`.
+6. The new analytics container listens on port `8000`. When deploying the API Gateway set `ANALYTICS_URL` to the analytics service URL.
 
 ## Kubernetes
 
@@ -72,11 +73,13 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
      -f infrastructure/helm/orchestrator/values-dev.yaml
    helm install backup-jobs infrastructure/helm/backup-jobs \
      -f infrastructure/helm/backup-jobs/values-dev.yaml
-   helm install logrotate-jobs infrastructure/helm/logrotate-jobs \
-     -f infrastructure/helm/logrotate-jobs/values-dev.yaml
-   helm install monitoring infrastructure/helm/monitoring \
-     -f infrastructure/helm/monitoring/values.yaml
-   ```
+  helm install logrotate-jobs infrastructure/helm/logrotate-jobs \
+    -f infrastructure/helm/logrotate-jobs/values-dev.yaml
+  helm install monitoring infrastructure/helm/monitoring \
+    -f infrastructure/helm/monitoring/values.yaml
+  helm install analytics infrastructure/helm/analytics \
+    -f infrastructure/helm/analytics/values-dev.yaml
+  ```
 
 Production deployments use the corresponding `values-production.yaml` files under
 each chart directory.

--- a/infrastructure/helm/analytics/Chart.yaml
+++ b/infrastructure/helm/analytics/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: analytics
+version: 0.1.0
+description: Helm chart for analytics microservice
+type: application
+appVersion: "1.0"

--- a/infrastructure/helm/analytics/templates/_helpers.tpl
+++ b/infrastructure/helm/analytics/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "analytics.fullname" -}}
+{{ include "analytics.name" . }}
+{{- end -}}
+
+{{- define "analytics.name" -}}
+{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "analytics.labels" -}}
+app.kubernetes.io/name: {{ include "analytics.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "analytics.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "analytics.name" . }}
+{{- end -}}

--- a/infrastructure/helm/analytics/templates/deployment.yaml
+++ b/infrastructure/helm/analytics/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "analytics.fullname" . }}
+  labels: {{- include "analytics.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "analytics.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "analytics.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.service.port }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+          volumeMounts:
+            - name: secret-volume
+              mountPath: /run/secrets
+              readOnly: true
+            - name: tmpfs-volume
+              mountPath: /tmpfs
+          resources:
+{{ toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: {{ .Values.secretName }}
+        - name: tmpfs-volume
+          emptyDir:
+            medium: Memory

--- a/infrastructure/helm/analytics/templates/hpa.yaml
+++ b/infrastructure/helm/analytics/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "analytics.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "analytics.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infrastructure/helm/analytics/templates/service-monitor.yaml
+++ b/infrastructure/helm/analytics/templates/service-monitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "analytics.fullname" . }}
+  labels: {{- include "analytics.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "analytics.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - path: /metrics
+      targetPort: {{ .Values.service.port }}
+      interval: 30s

--- a/infrastructure/helm/analytics/templates/service.yaml
+++ b/infrastructure/helm/analytics/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "analytics.fullname" . }}
+  labels: {{- include "analytics.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.service.port }}"
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{- include "analytics.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/infrastructure/helm/analytics/values-dev.yaml
+++ b/infrastructure/helm/analytics/values-dev.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+image:
+  repository: example/analytics
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}

--- a/infrastructure/helm/analytics/values-prod.yaml
+++ b/infrastructure/helm/analytics/values-prod.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+image:
+  repository: example/analytics
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}

--- a/infrastructure/helm/analytics/values-production.yaml
+++ b/infrastructure/helm/analytics/values-production.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+image:
+  repository: example/analytics
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}

--- a/infrastructure/helm/analytics/values-staging.yaml
+++ b/infrastructure/helm/analytics/values-staging.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+image:
+  repository: example/analytics
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}

--- a/infrastructure/helm/analytics/values.yaml
+++ b/infrastructure/helm/analytics/values.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+image:
+  repository: example/analytics
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}


### PR DESCRIPTION
## Summary
- add Dockerfile for backend analytics service
- build analytics image in GitHub Actions
- run analytics container in docker-compose files
- expose ANALYTICS_URL to api-gateway
- create analytics Helm chart and document deployment

## Testing
- `pytest -W error -vv tests/test_analytics.py`


------
https://chatgpt.com/codex/tasks/task_b_68806beabe6c8331883b399bbd97e1a5