### PR TITLE
Fix migration validation script

### DIFF
--- a/scripts/validate_migrations.sh
+++ b/scripts/validate_migrations.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Validate that the Alembic migration chain has a single head and no branches.
+# Validate that the Alembic migration chain has a single head.
 
 set -euo pipefail
 
@@ -7,13 +7,6 @@ HEADS=$(alembic -c backend/shared/db/alembic.ini heads | wc -l)
 if [ "$HEADS" -ne 1 ]; then
   echo "Multiple migration heads detected:" >&2
   alembic -c backend/shared/db/alembic.ini heads >&2
-  exit 1
-fi
-
-BRANCHES=$(alembic -c backend/shared/db/alembic.ini branches | wc -l)
-if [ "$BRANCHES" -ne 0 ]; then
-  echo "Divergent migration branches detected:" >&2
-  alembic -c backend/shared/db/alembic.ini branches >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- relax `validate_migrations.sh` to ignore historical branchpoints
- keep migration validation step in CI

## Testing
- `scripts/validate_migrations.sh`
- `flake8`
- `black --check .` *(fails: would reformat)*
- `mypy` *(fails: missing type stubs)*
- `pytest -W error -vv` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68806bf0aef883318127b3bd79174886