### PR TITLE
Add HPA queue metrics support

### DIFF
--- a/docs/mockup_generation.md
+++ b/docs/mockup_generation.md
@@ -30,5 +30,10 @@ redis-cli set gpu_slots 2
 An example HPA manifest lives in `infrastructure/k8s/examples/gpu-worker-hpa.yaml`
 and scales the `mockup-generation` deployment according to queue length.
 
+The Helm chart exposes an ``hpa.queueAverageValue`` parameter which controls the
+desired backlog size before scaling out. When used with the Prometheus adapter or
+KEDA, this value maps to the ``celery_queue_length`` metric exported by the
+workers.
+
 The metadata generation service uses OpenAI's GPT‑4 model by default. The
 model can be changed by setting the `OPENAI_MODEL` environment variable.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -83,6 +83,12 @@ directly from Redis and exposed via Prometheus. When the average queue length
 exceeds 30 pending tasks a PagerDuty alert is triggered and additional workers
 are spawned automatically.
 
+Queue lengths are exported at each service's `/metrics` endpoint by the
+``register_redis_queue_collector`` helper. A Prometheus adapter (or KEDA with the
+Prometheus scaler) exposes this metric as ``celery_queue_length`` so the HPA can
+scale based on backlog size. The Helm charts include optional values to set the
+desired average queue length.
+
 ## GPU Slot Metrics
 
 GPU-bound workloads now expose lock usage information through Prometheus.

--- a/infrastructure/helm/marketplace-publisher/templates/hpa.yaml
+++ b/infrastructure/helm/marketplace-publisher/templates/hpa.yaml
@@ -23,4 +23,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- if .Values.hpa.queueAverageValue }}
+    - type: External
+      external:
+        metric:
+          name: celery_queue_length
+        target:
+          type: AverageValue
+          averageValue: "{{ .Values.hpa.queueAverageValue }}"
+{{- end }}
 {{- end }}

--- a/infrastructure/helm/marketplace-publisher/values-dev.yaml
+++ b/infrastructure/helm/marketplace-publisher/values-dev.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/marketplace-publisher/values-prod.yaml
+++ b/infrastructure/helm/marketplace-publisher/values-prod.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/marketplace-publisher/values-production.yaml
+++ b/infrastructure/helm/marketplace-publisher/values-production.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/marketplace-publisher/values-staging.yaml
+++ b/infrastructure/helm/marketplace-publisher/values-staging.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/marketplace-publisher/values.yaml
+++ b/infrastructure/helm/marketplace-publisher/values.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/signal-ingestion/templates/hpa.yaml
+++ b/infrastructure/helm/signal-ingestion/templates/hpa.yaml
@@ -23,4 +23,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- if .Values.hpa.queueAverageValue }}
+    - type: External
+      external:
+        metric:
+          name: celery_queue_length
+        target:
+          type: AverageValue
+          averageValue: "{{ .Values.hpa.queueAverageValue }}"
+{{- end }}
 {{- end }}

--- a/infrastructure/helm/signal-ingestion/values-dev.yaml
+++ b/infrastructure/helm/signal-ingestion/values-dev.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/signal-ingestion/values-prod.yaml
+++ b/infrastructure/helm/signal-ingestion/values-prod.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/signal-ingestion/values-production.yaml
+++ b/infrastructure/helm/signal-ingestion/values-production.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/signal-ingestion/values-staging.yaml
+++ b/infrastructure/helm/signal-ingestion/values-staging.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/helm/signal-ingestion/values.yaml
+++ b/infrastructure/helm/signal-ingestion/values.yaml
@@ -21,3 +21,4 @@ hpa:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  queueAverageValue: 30

--- a/infrastructure/k8s/base/marketplace-publisher-hpa.yaml
+++ b/infrastructure/k8s/base/marketplace-publisher-hpa.yaml
@@ -22,3 +22,10 @@ spec:
         target:
           type: Utilization
           averageUtilization: 70
+    - type: External
+      external:
+        metric:
+          name: celery_queue_length
+        target:
+          type: AverageValue
+          averageValue: "30"


### PR DESCRIPTION
## Summary
- autoscale `marketplace-publisher` on `celery_queue_length`
- expose queue scaling values in Helm charts for `signal-ingestion` and `marketplace-publisher`
- document Prometheus adapter/KEDA setup for queue metrics

## Testing
- `flake8`
- `pydocstyle docs/performance.md docs/mockup_generation.md`
- `docformatter --check --recursive .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_b_68806bf25ae4833197ab3eea81b478ae