### PR TITLE
Add API docs with sphinx-apidoc

### DIFF
--- a/docs/api/backend.analytics.rst
+++ b/docs/api/backend.analytics.rst
@@ -1,0 +1,26 @@
+backend.analytics package
+=========================
+
+.. automodule:: backend.analytics
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.analytics.api module
+----------------------------
+
+.. automodule:: backend.analytics.api
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.analytics.auth module
+-----------------------------
+
+.. automodule:: backend.analytics.auth
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.optimization.rst
+++ b/docs/api/backend.optimization.rst
@@ -1,0 +1,42 @@
+backend.optimization package
+============================
+
+.. automodule:: backend.optimization
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   backend.optimization.tests
+
+Submodules
+----------
+
+backend.optimization.api module
+-------------------------------
+
+.. automodule:: backend.optimization.api
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.optimization.metrics module
+-----------------------------------
+
+.. automodule:: backend.optimization.metrics
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.optimization.storage module
+-----------------------------------
+
+.. automodule:: backend.optimization.storage
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.optimization.tests.rst
+++ b/docs/api/backend.optimization.tests.rst
@@ -1,6 +1,11 @@
 backend.optimization.tests package
 ==================================
 
+.. automodule:: backend.optimization.tests
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Submodules
 ----------
 
@@ -48,14 +53,6 @@ backend.optimization.tests.test\_scheduler module
 -------------------------------------------------
 
 .. automodule:: backend.optimization.tests.test_scheduler
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-Module contents
----------------
-
-.. automodule:: backend.optimization.tests
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/api/backend.orchestrator.orchestrator.rst
+++ b/docs/api/backend.orchestrator.orchestrator.rst
@@ -1,0 +1,66 @@
+backend.orchestrator.orchestrator package
+=========================================
+
+.. automodule:: backend.orchestrator.orchestrator
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.orchestrator.orchestrator.hooks module
+----------------------------------------------
+
+.. automodule:: backend.orchestrator.orchestrator.hooks
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.orchestrator.jobs module
+---------------------------------------------
+
+.. automodule:: backend.orchestrator.orchestrator.jobs
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.orchestrator.metrics module
+------------------------------------------------
+
+.. automodule:: backend.orchestrator.orchestrator.metrics
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.orchestrator.ops module
+--------------------------------------------
+
+.. automodule:: backend.orchestrator.orchestrator.ops
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.orchestrator.repository module
+---------------------------------------------------
+
+.. automodule:: backend.orchestrator.orchestrator.repository
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.orchestrator.schedules module
+--------------------------------------------------
+
+.. automodule:: backend.orchestrator.orchestrator.schedules
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.orchestrator.sensors module
+------------------------------------------------
+
+.. automodule:: backend.orchestrator.orchestrator.sensors
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.orchestrator.rst
+++ b/docs/api/backend.orchestrator.rst
@@ -1,0 +1,16 @@
+backend.orchestrator package
+============================
+
+.. automodule:: backend.orchestrator
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   backend.orchestrator.orchestrator
+   backend.orchestrator.tests

--- a/docs/api/backend.orchestrator.tests.rst
+++ b/docs/api/backend.orchestrator.tests.rst
@@ -1,0 +1,58 @@
+backend.orchestrator.tests package
+==================================
+
+.. automodule:: backend.orchestrator.tests
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.orchestrator.tests.test\_failure\_sensor module
+-------------------------------------------------------
+
+.. automodule:: backend.orchestrator.tests.test_failure_sensor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.tests.test\_feedback\_job module
+-----------------------------------------------------
+
+.. automodule:: backend.orchestrator.tests.test_feedback_job
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.tests.test\_jobs module
+--------------------------------------------
+
+.. automodule:: backend.orchestrator.tests.test_jobs
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.tests.test\_listings\_job module
+-----------------------------------------------------
+
+.. automodule:: backend.orchestrator.tests.test_listings_job
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.tests.test\_ops\_integration module
+--------------------------------------------------------
+
+.. automodule:: backend.orchestrator.tests.test_ops_integration
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.orchestrator.tests.test\_privacy\_job module
+----------------------------------------------------
+
+.. automodule:: backend.orchestrator.tests.test_privacy_job
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.rst
+++ b/docs/api/backend.rst
@@ -1,0 +1,18 @@
+backend package
+===============
+
+.. automodule:: backend
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   backend.analytics
+   backend.optimization
+   backend.orchestrator
+   backend.shared

--- a/docs/api/backend.shared.auth.rst
+++ b/docs/api/backend.shared.auth.rst
@@ -1,0 +1,18 @@
+backend.shared.auth package
+===========================
+
+.. automodule:: backend.shared.auth
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.shared.auth.jwt module
+------------------------------
+
+.. automodule:: backend.shared.auth.jwt
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.shared.db.rst
+++ b/docs/api/backend.shared.db.rst
@@ -1,0 +1,26 @@
+backend.shared.db package
+=========================
+
+.. automodule:: backend.shared.db
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.shared.db.base module
+-----------------------------
+
+.. automodule:: backend.shared.db.base
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.shared.db.models module
+-------------------------------
+
+.. automodule:: backend.shared.db.models
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.shared.kafka.rst
+++ b/docs/api/backend.shared.kafka.rst
@@ -1,0 +1,26 @@
+backend.shared.kafka package
+============================
+
+.. automodule:: backend.shared.kafka
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.shared.kafka.schema\_registry module
+--------------------------------------------
+
+.. automodule:: backend.shared.kafka.schema_registry
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.shared.kafka.utils module
+---------------------------------
+
+.. automodule:: backend.shared.kafka.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.shared.rst
+++ b/docs/api/backend.shared.rst
@@ -1,6 +1,11 @@
 backend.shared package
 ======================
 
+.. automodule:: backend.shared
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Subpackages
 -----------
 
@@ -146,14 +151,6 @@ backend.shared.tracing module
 -----------------------------
 
 .. automodule:: backend.shared.tracing
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-Module contents
----------------
-
-.. automodule:: backend.shared
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,6 @@
+frontend
+========
+
+.. toctree::
+   :maxdepth: 4
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,16 @@ nitpick_ignore = [
     ("py:class", "datetime.datetime"),
     ("py:class", "ConfigDict"),
     ("py:class", "pathlib.Path"),
+    ("py:class", "dagster.HookContext"),
+    ("py:class", "dagster.ScheduleEvaluationContext"),
+    ("py:class", "dagster.SensorEvaluationContext"),
+    ("py:class", "dagster.RunRequest"),
+    ("py:class", "dagster.SkipReason"),
+    ("py:class", "dagster.RunFailureSensorContext"),
+    ("py:class", "_pytest.monkeypatch.MonkeyPatch"),
+    ("py:func", "signal_ingestion.privacy.purge_pii_rows"),
+    ("py:mod", "scripts.rotate_secrets"),
+    ("py:func", "idea_job"),
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,27 @@ Kafka Utilities
     :members:
 
 .. automodule:: backend.shared.kafka.schema_registry
-    :members:
+   :members:
+   :noindex:
+
+
+Queue Metrics
+-------------
+.. automodule:: backend.shared.queue_metrics
+   :members:
+   :noindex:
+
+Regex Utilities
+---------------
+.. automodule:: backend.shared.regex_utils
+   :members:
+   :noindex:
+
+Service Names
+-------------
+.. automodule:: backend.shared.service_names
+   :members:
+   :noindex:
 
 
 Admin Dashboard

--- a/docs/source/generated/api_gateway.api_gateway.rst
+++ b/docs/source/generated/api_gateway.api_gateway.rst
@@ -1,0 +1,6 @@
+﻿api\_gateway.api\_gateway
+=========================
+
+.. currentmodule:: api_gateway
+
+.. autodata:: api_gateway

--- a/docs/source/generated/backend.analytics.backend.analytics.rst
+++ b/docs/source/generated/backend.analytics.backend.analytics.rst
@@ -1,0 +1,6 @@
+﻿backend.analytics.backend.analytics
+===================================
+
+.. currentmodule:: backend.analytics.backend
+
+.. autodata:: analytics

--- a/docs/source/generated/backend.optimization.backend.optimization.rst
+++ b/docs/source/generated/backend.optimization.backend.optimization.rst
@@ -1,0 +1,6 @@
+﻿backend.optimization.backend.optimization
+=========================================
+
+.. currentmodule:: backend.optimization.backend
+
+.. autodata:: optimization

--- a/docs/source/generated/marketplace_publisher.marketplace_publisher.rst
+++ b/docs/source/generated/marketplace_publisher.marketplace_publisher.rst
@@ -1,0 +1,6 @@
+﻿marketplace\_publisher.marketplace\_publisher
+=============================================
+
+.. currentmodule:: marketplace_publisher
+
+.. autodata:: marketplace_publisher

--- a/docs/source/generated/mockup_generation.mockup_generation.rst
+++ b/docs/source/generated/mockup_generation.mockup_generation.rst
@@ -1,0 +1,6 @@
+﻿mockup\_generation.mockup\_generation
+=====================================
+
+.. currentmodule:: mockup_generation
+
+.. autodata:: mockup_generation

--- a/docs/source/generated/monitoring.monitoring.rst
+++ b/docs/source/generated/monitoring.monitoring.rst
@@ -1,0 +1,6 @@
+﻿monitoring.monitoring
+=====================
+
+.. currentmodule:: monitoring
+
+.. autodata:: monitoring

--- a/docs/source/generated/orchestrator.orchestrator.rst
+++ b/docs/source/generated/orchestrator.orchestrator.rst
@@ -1,0 +1,6 @@
+﻿orchestrator.orchestrator
+=========================
+
+.. currentmodule:: orchestrator
+
+.. autodata:: orchestrator

--- a/docs/source/generated/scoring_engine.scoring_engine.rst
+++ b/docs/source/generated/scoring_engine.scoring_engine.rst
@@ -1,0 +1,6 @@
+﻿scoring\_engine.scoring\_engine
+===============================
+
+.. currentmodule:: scoring_engine
+
+.. autodata:: scoring_engine

--- a/docs/source/generated/signal_ingestion.signal_ingestion.rst
+++ b/docs/source/generated/signal_ingestion.signal_ingestion.rst
@@ -1,0 +1,6 @@
+﻿signal\_ingestion.signal\_ingestion
+===================================
+
+.. currentmodule:: signal_ingestion
+
+.. autodata:: signal_ingestion


### PR DESCRIPTION
## Summary
- reference backend utilities in docs index
- document missing modules via sphinx-apidoc
- ignore dagster and pytest types for nitpicky Sphinx

## Testing
- `flake8 --select=D docs | head`
- `docformatter --check docs/index.rst`
- `SKIP_DOC_LINT=1 SKIP_OPENAPI=1 make -C docs html` *(fails: duplicate object description)*

------
https://chatgpt.com/codex/tasks/task_b_68806bf335908331990696db22c4a4c1