### PR TITLE
Add PagerDuty alerts for policy rejections

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -88,4 +88,4 @@ keeps label cardinality low even for dynamic endpoints.
 
 ## PagerDuty Alerts
 
-Set `PAGERDUTY_ROUTING_KEY` and `ENABLE_PAGERDUTY=true` in the environment to enable alerting. The monitoring service triggers alerts when the average publish latency breaches the configured SLA and when listing synchronization detects issues.
+Set `PAGERDUTY_ROUTING_KEY` and `ENABLE_PAGERDUTY=true` in the environment to enable alerting. The monitoring service triggers alerts when the average publish latency breaches the configured SLA and when listing synchronization detects issues. Rejections during publishing emit a `notify_listing_issue` event with a `nsfw` or `trademarked` state.


### PR DESCRIPTION
## Summary
- trigger `monitoring.pagerduty.notify_listing_issue` when publishing fails for NSFW or trademark reasons
- test pagerduty alerts when policy checks fail
- document policy alert behaviour

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/tests/test_policy_failures.py`
- `pydocstyle backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/tests/test_policy_failures.py`
- `mypy backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/tests/test_policy_failures.py --install-types --non-interactive --ignore-missing-imports`
- `npm ci --legacy-peer-deps` *(fails: could not run jest)*
- `npm run test:e2e` *(fails: docker not found)*
- `pytest -n auto -W error -vv` *(failed: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_b_68806bf42ca48331806e57c7914c9dc2