### PR TITLE
Add SQLite idea_job integration test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
           npm test
           npm run test:e2e
           docker compose -f docker-compose.dev.yml -f docker-compose.test.yml down
+      - name: Run integration tests
+        run: ./scripts/run-integration-tests.sh
       - name: Check package coverage
         run: python scripts/check_package_coverage.py
       - name: Smoke test docker compose services

--- a/tests/integration/cassettes/idea_job.yaml
+++ b/tests/integration/cassettes/idea_job.yaml
@@ -1,0 +1,618 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - localhost:44945
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - ce845505-c9ec-4f0f-ba89-f705f5d5015f
+    method: GET
+    uri: http://localhost:44945/approvals/ce845505-c9ec-4f0f-ba89-f705f5d5015f
+  response:
+    body:
+      string: '{"approved": true}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:04:41 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      host:
+      - localhost:44945
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - ce845505-c9ec-4f0f-ba89-f705f5d5015f
+    method: POST
+    uri: http://localhost:44945/ingest
+  response:
+    body:
+      string: '{"signals": ["s1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:04:41 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - localhost:39667
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - b4de76ca-145e-414a-9879-8a00486f8df8
+    method: GET
+    uri: http://localhost:39667/approvals/b4de76ca-145e-414a-9879-8a00486f8df8
+  response:
+    body:
+      string: '{"approved": true}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:05:14 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      host:
+      - localhost:39667
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - b4de76ca-145e-414a-9879-8a00486f8df8
+    method: POST
+    uri: http://localhost:39667/ingest
+  response:
+    body:
+      string: '{"signals": ["s1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:05:14 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - localhost:35657
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - 0d9139ce-77ec-42e5-a5c9-73695ef3f914
+    method: GET
+    uri: http://localhost:35657/approvals/0d9139ce-77ec-42e5-a5c9-73695ef3f914
+  response:
+    body:
+      string: '{"approved": true}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:05:39 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      host:
+      - localhost:35657
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - 0d9139ce-77ec-42e5-a5c9-73695ef3f914
+    method: POST
+    uri: http://localhost:35657/ingest
+  response:
+    body:
+      string: '{"signals": ["s1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:05:40 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"timestamp":"2025-07-23T05:05:40.116315+00:00","engagement_rate":0.0,"embedding":[0.0]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '88'
+      content-type:
+      - application/json
+      host:
+      - localhost:35657
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - 0d9139ce-77ec-42e5-a5c9-73695ef3f914
+    method: POST
+    uri: http://localhost:35657/score
+  response:
+    body:
+      string: '{"score": 1}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:05:40 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"scores":[1.0]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '16'
+      content-type:
+      - application/json
+      host:
+      - localhost:35657
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - 0d9139ce-77ec-42e5-a5c9-73695ef3f914
+    method: POST
+    uri: http://localhost:35657/generate
+  response:
+    body:
+      string: '{"items": ["i1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:05:40 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"marketplace":"redbubble","design_path":"i1"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '46'
+      content-type:
+      - application/json
+      host:
+      - localhost:35657
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - 0d9139ce-77ec-42e5-a5c9-73695ef3f914
+    method: POST
+    uri: http://localhost:35657/publish
+  response:
+    body:
+      string: '{"task_id": 1}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:05:40 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - localhost:34301
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - dce1777c-6f2e-4c6f-b5db-6c5593e92eb7
+    method: GET
+    uri: http://localhost:34301/approvals/dce1777c-6f2e-4c6f-b5db-6c5593e92eb7
+  response:
+    body:
+      string: '{"approved": true}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:04 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      host:
+      - localhost:34301
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - dce1777c-6f2e-4c6f-b5db-6c5593e92eb7
+    method: POST
+    uri: http://localhost:34301/ingest
+  response:
+    body:
+      string: '{"signals": ["s1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:05 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"timestamp":"2025-07-23T05:06:05.114833+00:00","engagement_rate":0.0,"embedding":[0.0]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '88'
+      content-type:
+      - application/json
+      host:
+      - localhost:34301
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - dce1777c-6f2e-4c6f-b5db-6c5593e92eb7
+    method: POST
+    uri: http://localhost:34301/score
+  response:
+    body:
+      string: '{"score": 1}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:05 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"scores":[1.0]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '16'
+      content-type:
+      - application/json
+      host:
+      - localhost:34301
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - dce1777c-6f2e-4c6f-b5db-6c5593e92eb7
+    method: POST
+    uri: http://localhost:34301/generate
+  response:
+    body:
+      string: '{"items": ["i1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:05 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"marketplace":"redbubble","design_path":"i1"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '46'
+      content-type:
+      - application/json
+      host:
+      - localhost:34301
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - dce1777c-6f2e-4c6f-b5db-6c5593e92eb7
+    method: POST
+    uri: http://localhost:34301/publish
+  response:
+    body:
+      string: '{"task_id": 1}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:05 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - localhost:36599
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - b1bfa9a0-82ec-4884-b82f-d84dca106e1d
+    method: GET
+    uri: http://localhost:36599/approvals/b1bfa9a0-82ec-4884-b82f-d84dca106e1d
+  response:
+    body:
+      string: '{"approved": true}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:25 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      host:
+      - localhost:36599
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - b1bfa9a0-82ec-4884-b82f-d84dca106e1d
+    method: POST
+    uri: http://localhost:36599/ingest
+  response:
+    body:
+      string: '{"signals": ["s1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:25 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"timestamp":"2025-07-23T05:06:25.211078+00:00","engagement_rate":0.0,"embedding":[0.0]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '88'
+      content-type:
+      - application/json
+      host:
+      - localhost:36599
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - b1bfa9a0-82ec-4884-b82f-d84dca106e1d
+    method: POST
+    uri: http://localhost:36599/score
+  response:
+    body:
+      string: '{"score": 1}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:25 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"scores":[1.0]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '16'
+      content-type:
+      - application/json
+      host:
+      - localhost:36599
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - b1bfa9a0-82ec-4884-b82f-d84dca106e1d
+    method: POST
+    uri: http://localhost:36599/generate
+  response:
+    body:
+      string: '{"items": ["i1"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:25 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"marketplace":"redbubble","design_path":"i1"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '46'
+      content-type:
+      - application/json
+      host:
+      - localhost:36599
+      user-agent:
+      - python-httpx/0.28.1
+      x-correlation-id:
+      - b1bfa9a0-82ec-4884-b82f-d84dca106e1d
+    method: POST
+    uri: http://localhost:36599/publish
+  response:
+    body:
+      string: '{"task_id": 1}'
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Jul 2025 05:06:25 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.12.10
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/test_idea_sqlite.py
+++ b/tests/integration/test_idea_sqlite.py
@@ -1,0 +1,100 @@
+"""Integration tests for ``idea_job`` with a SQLite Dagster instance."""
+
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Iterator
+
+import vcr
+import pytest
+from dagster import DagsterInstance
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+ROOT = Path(__file__).resolve().parents[2]
+import sys
+
+ORCH_PATH = ROOT / "backend" / "orchestrator"
+MONITORING_SRC = ROOT / "backend" / "monitoring" / "src"
+sys.path.append(str(ORCH_PATH))
+sys.path.append(str(MONITORING_SRC))
+
+from orchestrator.jobs import idea_job
+
+
+@contextmanager
+def _mock_server() -> Iterator[tuple[str, list[str]]]:
+    """Run a simple HTTP server and record request paths."""
+    calls: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: D401 - helper
+            calls.append(self.path)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            payload: dict[str, object]
+            if self.path == "/ingest":
+                payload = {"signals": ["s1"]}
+            elif self.path == "/score":
+                payload = {"score": 1}
+            elif self.path == "/generate":
+                payload = {"items": ["i1"]}
+            elif self.path == "/publish":
+                payload = {"task_id": 1}
+            else:
+                payload = {}
+            self.wfile.write(json.dumps(payload).encode())
+
+        def do_GET(self) -> None:  # noqa: D401 - helper
+            calls.append(self.path)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"approved": true}')
+
+        def log_message(self, *args: object) -> None:  # noqa: D401 - silence
+            return
+
+    server = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    url = f"http://localhost:{server.server_port}"
+    try:
+        yield url, calls
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@vcr.use_cassette(
+    "tests/integration/cassettes/idea_job.yaml",
+    record_mode="new_episodes",
+)
+@pytest.mark.usefixtures("monkeypatch")
+def test_idea_job_sqlite(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Run ``idea_job`` using a SQLite Dagster instance."""
+    with _mock_server() as (url, calls):
+        monkeypatch.setenv("SIGNAL_INGESTION_URL", url)
+        monkeypatch.setenv("SCORING_ENGINE_URL", url)
+        monkeypatch.setenv("MOCKUP_GENERATION_URL", url)
+        monkeypatch.setenv("PUBLISHER_URL", url)
+        monkeypatch.setenv("APPROVAL_SERVICE_URL", url)
+        instance = DagsterInstance.local_temp(str(tmp_path))
+        result = idea_job.execute_in_process(instance=instance)
+        assert result.success
+        assert sorted(calls) == sorted(
+            [
+                "/ingest",
+                "/score",
+                "/generate",
+                f"/approvals/{result.dagster_run.run_id}",
+                "/publish",
+            ]
+        )


### PR DESCRIPTION
## Summary
- add integration test for idea_job with SQLite Dagster instance
- record external HTTP interactions via VCR
- ensure tests.yml executes integration tests

## Testing
- `pytest tests/integration/test_idea_sqlite.py::test_idea_job_sqlite -vv -s`
- `flake8 tests/integration/test_idea_sqlite.py`
- `mypy tests/integration/test_idea_sqlite.py`
- `docformatter --check tests/integration/test_idea_sqlite.py`

------
https://chatgpt.com/codex/tasks/task_b_68806bf674a883319eac0f6a31f7f3cb