### PR TITLE
Add approval rejection handling and UI

### DIFF
--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -481,6 +481,17 @@ async def approve_run(
     return StatusResponse(status="approved")
 
 
+@approvals_router.delete("/{run_id}", summary="Reject job run")
+async def reject_run(
+    run_id: str,
+    payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> StatusResponse:
+    """Reject the Dagster run identified by ``run_id``."""
+    await get_async_client().srem(PENDING_RUNS_KEY, run_id)
+    log_admin_action(payload.get("sub", "unknown"), "reject_run", {"run_id": run_id})
+    return StatusResponse(status="rejected")
+
+
 @approvals_router.get("/{run_id}", summary="Check approval status")
 async def check_approval(run_id: str) -> ApprovalStatus:
     """Return ``True`` if ``run_id`` has been approved."""

--- a/backend/api-gateway/tests/test_approvals.py
+++ b/backend/api-gateway/tests/test_approvals.py
@@ -67,3 +67,34 @@ def test_list_pending_runs(monkeypatch):
     resp = client.get("/approvals")
     assert resp.status_code == 200
     assert resp.json() == {"runs": ["run123"]}
+
+
+def test_reject_run(monkeypatch):
+    """Reject a run and ensure it is removed from pending."""
+    import api_gateway.main as main_module
+    import api_gateway.routes as routes
+
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    import backend.shared.config as shared_config
+
+    shared_config.settings.redis_url = "redis://localhost:6379/0"
+    redis_client = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr("backend.shared.cache.get_async_client", lambda: redis_client)
+    importlib.reload(main_module)
+    importlib.reload(routes)
+
+    main_module.rate_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.optimization_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.monitoring_limiter._redis = fakeredis.aioredis.FakeRedis()
+    routes.analytics_limiter._redis = fakeredis.aioredis.FakeRedis()
+
+    client = TestClient(main_module.app)
+    token = create_access_token({"sub": "admin"})
+    run_id = "run123"
+    redis_client.sadd("pending_runs", run_id)
+    resp = client.delete(
+        f"/approvals/{run_id}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "rejected"}
+    assert not redis_client.sismember("pending_runs", run_id)

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -248,7 +248,7 @@ async def await_approval(context) -> None:  # type: ignore[no-untyped-def]
     headers = _auth_headers(context)
 
     client = await get_async_http_client()
-    for _ in range(30):
+    while True:
         try:
             resp = await client.get(url, headers=headers, timeout=5)
             resp.raise_for_status()
@@ -258,7 +258,6 @@ async def await_approval(context) -> None:  # type: ignore[no-untyped-def]
         except httpx.HTTPError as exc:  # noqa: BLE001
             context.log.warning("approval check failed: %s", exc)
         await asyncio.sleep(10)
-    raise Failure("publishing not approved")
 
 
 @op(retry_policy=RetryPolicy(max_retries=3, delay=1))  # type: ignore[misc]

--- a/frontend/admin-dashboard/app/approvals/page.tsx
+++ b/frontend/admin-dashboard/app/approvals/page.tsx
@@ -1,32 +1,67 @@
 'use client';
-import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '../../src/components/Button';
 import { trpc } from '../../src/trpc';
+import { usePendingRuns } from '../../src/lib/trpc/hooks';
 
 export default function ApprovalsPage() {
-  const [runId, setRunId] = useState('');
-  const [status, setStatus] = useState('');
+  const { t } = useTranslation();
+  const { data: runs, isLoading } = usePendingRuns();
+  const queryClient = useQueryClient();
 
-  async function approve() {
+  const removeRun = (id: string) => {
+    queryClient.setQueryData<string[] | undefined>(['pendingRuns'], (old) =>
+      old?.filter((r) => r !== id)
+    );
+  };
+
+  async function approve(id: string) {
+    removeRun(id);
     try {
-      await trpc.approvals.approve(runId);
-      setStatus('Approved');
+      await trpc.approvals.approve(id);
     } catch {
-      setStatus('Approval failed');
+      await queryClient.invalidateQueries({ queryKey: ['pendingRuns'] });
+      alert(t('approvalFailed'));
+    }
+  }
+
+  async function reject(id: string) {
+    removeRun(id);
+    try {
+      await trpc.approvals.reject(id);
+    } catch {
+      await queryClient.invalidateQueries({ queryKey: ['pendingRuns'] });
+      alert(t('rejectionFailed'));
     }
   }
 
   return (
     <div className="space-y-2">
-      <h1>Approvals</h1>
-      <input
-        className="border p-2"
-        value={runId}
-        onChange={(e) => setRunId(e.target.value)}
-        placeholder="Run ID"
-      />
-      <Button onClick={approve}>Approve</Button>
-      {status && <p>{status}</p>}
+      <h1>{t('approvals')}</h1>
+      {isLoading || !runs ? (
+        <div>{t('loading')}</div>
+      ) : runs.length === 0 ? (
+        <div>{t('noPendingRuns')}</div>
+      ) : (
+        <ul>
+          {runs.map((id) => (
+            <li key={id} className="space-x-2">
+              <span>{id}</span>
+              <Button onClick={() => approve(id)} ariaLabel={t('approve')}>
+                {t('approve')}
+              </Button>
+              <Button
+                onClick={() => reject(id)}
+                ariaLabel={t('reject')}
+                className="bg-red-600"
+              >
+                {t('reject')}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/admin-dashboard/e2e/approvals.spec.ts
+++ b/frontend/admin-dashboard/e2e/approvals.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { server } from './msw-server';
+import { rest } from 'msw';
+
+test.beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+test.afterAll(() => server.close());
+test.afterEach(() => server.resetHandlers());
+
+test('approve and reject runs', async ({ page }) => {
+  server.use(
+    rest.get('http://localhost:8000/approvals', (_req, res, ctx) =>
+      res(ctx.json({ runs: ['run123'] }))
+    ),
+    rest.post('http://localhost:8000/approvals/run123', (_req, res, ctx) =>
+      res(ctx.json({ status: 'approved' }))
+    )
+  );
+
+  await page.goto('/approvals');
+  await expect(page.getByText('run123')).toBeVisible();
+  await page.getByRole('button', { name: /approve/i }).click();
+  await expect(page.getByText('run123')).not.toBeVisible();
+
+  server.use(
+    rest.get('http://localhost:8000/approvals', (_req, res, ctx) =>
+      res(ctx.json({ runs: ['run456'] }))
+    ),
+    rest.delete('http://localhost:8000/approvals/run456', (_req, res, ctx) =>
+      res(ctx.json({ status: 'rejected' }))
+    )
+  );
+
+  await page.reload();
+  await expect(page.getByText('run456')).toBeVisible();
+  await page.getByRole('button', { name: /reject/i }).click();
+  await expect(page.getByText('run456')).not.toBeVisible();
+});

--- a/frontend/admin-dashboard/src/pages/approvals.tsx
+++ b/frontend/admin-dashboard/src/pages/approvals.tsx
@@ -14,12 +14,29 @@ function ApprovalsPage() {
   const { data: runs, isLoading } = usePendingRuns();
   const queryClient = useQueryClient();
 
+  const removeRun = (id: string) => {
+    queryClient.setQueryData<string[] | undefined>(['pendingRuns'], (old) =>
+      old?.filter((r) => r !== id)
+    );
+  };
+
   const approve = async (runId: string) => {
+    removeRun(runId);
     try {
       await trpc.approvals.approve(runId);
-      await queryClient.invalidateQueries({ queryKey: ['pendingRuns'] });
     } catch {
+      await queryClient.invalidateQueries({ queryKey: ['pendingRuns'] });
       alert(t('approvalFailed'));
+    }
+  };
+
+  const reject = async (runId: string) => {
+    removeRun(runId);
+    try {
+      await trpc.approvals.reject(runId);
+    } catch {
+      await queryClient.invalidateQueries({ queryKey: ['pendingRuns'] });
+      alert(t('rejectionFailed'));
     }
   };
 
@@ -37,6 +54,13 @@ function ApprovalsPage() {
               <span>{id}</span>
               <Button onClick={() => approve(id)} ariaLabel={t('approve')}>
                 {t('approve')}
+              </Button>
+              <Button
+                onClick={() => reject(id)}
+                ariaLabel={t('reject')}
+                className="bg-red-600"
+              >
+                {t('reject')}
               </Button>
             </li>
           ))}

--- a/frontend/admin-dashboard/src/trpc.ts
+++ b/frontend/admin-dashboard/src/trpc.ts
@@ -120,6 +120,13 @@ async function post(path: string, body?: unknown): Promise<void> {
   }
 }
 
+async function del(path: string): Promise<void> {
+  const res = await fetch(`${API_URL}${path}`, { method: 'DELETE' });
+  if (!res.ok) {
+    throw new Error(`request failed: ${res.status}`);
+  }
+}
+
 export const trpc = {
   ping: {
     mutate: () => call<{ message: string; user: string }>('ping'),
@@ -148,6 +155,7 @@ export const trpc = {
   },
   approvals: {
     approve: (runId: string) => post(`/approvals/${encodeURIComponent(runId)}`),
+    reject: (runId: string) => del(`/approvals/${encodeURIComponent(runId)}`),
     list: () => getJson<string[]>('/approvals'),
   },
   analytics: {


### PR DESCRIPTION
## Summary
- poll for approval indefinitely in orchestrator
- add rejection endpoint in API gateway
- provide UI to approve or reject runs
- expose TRPC rejection method
- cover UI with Playwright spec
- test rejection route

## Testing
- `npm test`
- `npm run test:e2e` *(fails: playwright not found)*
- `pytest backend/api-gateway/tests/test_approvals.py -k reject_run` *(fails: ModuleNotFoundError)*
- `pre-commit run --files backend/orchestrator/orchestrator/ops.py backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_approvals.py frontend/admin-dashboard/src/trpc.ts frontend/admin-dashboard/src/pages/approvals.tsx frontend/admin-dashboard/app/approvals/page.tsx frontend/admin-dashboard/e2e/approvals.spec.ts` *(fails: authentication required)*

------
https://chatgpt.com/codex/tasks/task_b_68806bf8b47483318467fdede9ef0ac8