### PR TITLE
Add zustand stores with hooks

### DIFF
--- a/frontend/admin-dashboard/__tests__/store.test.ts
+++ b/frontend/admin-dashboard/__tests__/store.test.ts
@@ -1,0 +1,19 @@
+import { act } from '@testing-library/react';
+import { useUserStore } from '../src/store/useUserStore';
+import { usePreferencesStore } from '../src/store/usePreferencesStore';
+
+test('updates auth state', () => {
+  expect(useUserStore.getState().isAuthenticated).toBe(false);
+  act(() => {
+    useUserStore.getState().setAuthenticated(true);
+  });
+  expect(useUserStore.getState().isAuthenticated).toBe(true);
+});
+
+test('toggles preference', () => {
+  expect(usePreferencesStore.getState().notifyOnFail).toBe(false);
+  act(() => {
+    usePreferencesStore.getState().toggleNotify();
+  });
+  expect(usePreferencesStore.getState().notifyOnFail).toBe(true);
+});

--- a/frontend/admin-dashboard/src/pages/_app.tsx
+++ b/frontend/admin-dashboard/src/pages/_app.tsx
@@ -6,11 +6,11 @@ import AdminLayout from '../layouts/AdminLayout';
 import { I18nProvider } from '../i18n';
 import { TrpcProvider } from '../lib/trpc';
 import { useEffect } from 'react';
-import { useStore } from '../hooks/useStore';
+import { useUserStore } from '../store/useUserStore';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const { user } = useUser();
-  const setAuth = useStore((s) => s.setAuthenticated);
+  const setAuth = useUserStore((s) => s.setAuthenticated);
 
   useEffect(() => {
     setAuth(Boolean(user));

--- a/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
@@ -2,16 +2,16 @@
 import React, { useEffect } from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import { useTranslation } from 'react-i18next';
-import { useStore } from '../../hooks/useStore';
+import { usePreferencesStore } from '../../store/usePreferencesStore';
 
 function PreferencesPage() {
   const { t } = useTranslation();
-  const notify = useStore((s) => s.notifyOnFail);
-  const toggleNotify = useStore((s) => s.toggleNotify);
+  const notify = usePreferencesStore((s) => s.notifyOnFail);
+  const toggleNotify = usePreferencesStore((s) => s.toggleNotify);
 
   useEffect(() => {
     // hydrate persisted state on mount
-    useStore.persist.rehydrate();
+    usePreferencesStore.persist.rehydrate();
   }, []);
 
   const toggle = () => {

--- a/frontend/admin-dashboard/src/store/usePreferencesStore.ts
+++ b/frontend/admin-dashboard/src/store/usePreferencesStore.ts
@@ -1,0 +1,18 @@
+// @flow
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface PreferencesState {
+  notifyOnFail: boolean;
+  toggleNotify: () => void;
+}
+
+export const usePreferencesStore = create<PreferencesState>()(
+  persist(
+    (set) => ({
+      notifyOnFail: false,
+      toggleNotify: () => set((s) => ({ notifyOnFail: !s.notifyOnFail })),
+    }),
+    { name: 'preferences-store' }
+  )
+);

--- a/frontend/admin-dashboard/src/store/useUserStore.ts
+++ b/frontend/admin-dashboard/src/store/useUserStore.ts
@@ -1,21 +1,18 @@
+// @flow
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export interface StoreState {
+export interface UserState {
   isAuthenticated: boolean;
-  notifyOnFail: boolean;
   setAuthenticated: (auth: boolean) => void;
-  toggleNotify: () => void;
 }
 
-export const useStore = create<StoreState>()(
+export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
       isAuthenticated: false,
-      notifyOnFail: false,
       setAuthenticated: (auth: boolean) => set({ isAuthenticated: auth }),
-      toggleNotify: () => set((s) => ({ notifyOnFail: !s.notifyOnFail })),
     }),
-    { name: 'admin-dashboard-store' }
+    { name: 'user-store' }
   )
 );


### PR DESCRIPTION
## Summary
- add `useUserStore` and `usePreferencesStore` with Zustand
- refactor pages to use new stores
- test store logic with Jest

## Testing
- `npm ci --legacy-peer-deps`
- `npm ci --prefix frontend/admin-dashboard --legacy-peer-deps`
- `npm test --prefix frontend/admin-dashboard`


------
https://chatgpt.com/codex/tasks/task_b_6880d0de3d2083318b88ef86cdd13159