### PR TITLE
Fix Selenium backoff to use asyncio.sleep

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/clients.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/clients.py
@@ -407,4 +407,4 @@ class SeleniumFallback:
                     pass
                 if attempts >= max_attempts:
                     raise
-                time.sleep(min(2**attempts, 30))
+                await asyncio.sleep(min(2**attempts, 30))


### PR DESCRIPTION
## Summary
- use `asyncio.sleep` when retrying Selenium automation
- test that async backoff yields control

## Testing
- `PYTHONPATH=$PYTHONPATH:backend/marketplace-publisher/src SKIP_HEAVY_DEPS=1 pytest tests/test_selenium_e2e.py::test_selenium_publish_waits_async -vv`

------
https://chatgpt.com/codex/tasks/task_b_6880d633d8f88331a357c21b99950250