### PR TITLE
Implement pagination in MetricsStore.get_metrics

### DIFF
--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -184,21 +184,21 @@ def get_recent_metrics(limit: int = 10) -> List[ResourceMetric]:
 @app.get("/optimizations")
 def get_optimizations() -> List[str]:
     """Return recommended cost optimizations."""
-    analyzer = MetricsAnalyzer(store.get_metrics())
+    analyzer = MetricsAnalyzer(list(store.get_metrics()))
     return analyzer.recommend_optimizations()
 
 
 @app.get("/recommendations")
 def get_recommendations() -> List[str]:
     """Return top optimization actions."""
-    analyzer = MetricsAnalyzer(store.get_metrics())
+    analyzer = MetricsAnalyzer(list(store.get_metrics()))
     return analyzer.top_recommendations()
 
 
 @app.get("/cost_alerts")
 def get_cost_alerts() -> List[str]:
     """Return alerts when usage or cost thresholds are exceeded."""
-    analyzer = MetricsAnalyzer(store.get_metrics())
+    analyzer = MetricsAnalyzer(list(store.get_metrics()))
     return analyzer.cost_alerts()
 
 

--- a/backend/optimization/metrics.py
+++ b/backend/optimization/metrics.py
@@ -31,7 +31,7 @@ class MetricsAnalyzer:
     ) -> "MetricsAnalyzer":
         """Create analyzer from a :class:`MetricsStore` instance."""
         if limit is None:
-            metrics = store.get_metrics()
+            metrics = list(store.get_metrics())
         else:
             metrics = store.get_recent_metrics(limit)
         return cls(metrics)

--- a/backend/optimization/tests/test_metrics_memory.py
+++ b/backend/optimization/tests/test_metrics_memory.py
@@ -1,0 +1,36 @@
+"""Tests for memory usage when fetching metrics."""
+
+from __future__ import annotations
+
+import gc
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psutil
+
+from backend.optimization.metrics import ResourceMetric
+from backend.optimization.storage import MetricsStore
+
+
+def test_get_metrics_memory_usage(tmp_path: Path) -> None:
+    """Ensure get_metrics does not load all rows into memory at once."""
+    store = MetricsStore(f"sqlite:///{tmp_path/'metrics.db'}")
+    for i in range(5000):
+        store.add_metric(
+            ResourceMetric(
+                timestamp=datetime.now(UTC),
+                cpu_percent=float(i),
+                memory_mb=float(i),
+                disk_usage_mb=float(i),
+            )
+        )
+
+    proc = psutil.Process()
+    before = proc.memory_info().rss
+    count = 0
+    for _ in store.get_metrics(batch_size=250):
+        count += 1
+    gc.collect()
+    after = proc.memory_info().rss
+    assert count == 5000
+    assert after - before < 5 * 1024 * 1024

--- a/backend/optimization/tests/test_metrics_store.py
+++ b/backend/optimization/tests/test_metrics_store.py
@@ -12,11 +12,9 @@ from backend.optimization.storage import MetricsStore
 def test_sqlite_metrics_store(tmp_path: Path) -> None:
     """Verify metrics are persisted in a temporary SQLite database."""
     store = MetricsStore(f"sqlite:///{tmp_path/'metrics.db'}")
-    metric = ResourceMetric(
-        datetime.utcnow().replace(tzinfo=UTC), 50.0, 128.0, disk_usage_mb=256.0
-    )
+    metric = ResourceMetric(datetime.now(UTC), 50.0, 128.0, disk_usage_mb=256.0)
     store.add_metric(metric)
-    metrics = store.get_metrics()
+    metrics = list(store.get_metrics())
     assert len(metrics) == 1
     assert metrics[0].cpu_percent == 50.0
     assert metrics[0].memory_mb == 128.0

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -167,4 +167,4 @@ async def test_full_flow(
     assert response.status_code == 200
     response = client.get("/optimizations")
     assert response.status_code == 200
-    assert len(opt_api.store.get_metrics()) == 1
+    assert len(list(opt_api.store.get_metrics())) == 1

--- a/tests/integration/test_pipeline_metrics.py
+++ b/tests/integration/test_pipeline_metrics.py
@@ -183,6 +183,6 @@ async def test_pipeline_with_metrics(
     response = client.get("/optimizations")
     assert response.status_code == 200
     metrics_time = time.perf_counter() - start
-    assert len(opt_api.store.get_metrics()) == 1
+    assert len(list(opt_api.store.get_metrics())) == 1
     assert metrics_time < thresholds["metrics"]
     assert proc.memory_info().rss / 1024**2 < thresholds["memory_mb"]

--- a/tests/test_metrics_ingestion.py
+++ b/tests/test_metrics_ingestion.py
@@ -9,9 +9,9 @@ from backend.optimization.storage import MetricsStore
 def test_record_resource_usage(tmp_path: Path) -> None:
     """Metrics are captured and stored using the helper function."""
     store = MetricsStore(f"sqlite:///{tmp_path/'metrics.db'}")
-    assert store.get_metrics() == []
+    assert list(store.get_metrics()) == []
     record_resource_usage(store)
-    metrics = store.get_metrics()
+    metrics = list(store.get_metrics())
     assert len(metrics) == 1
     assert metrics[0].timestamp.tzinfo is not None
     assert metrics[0].disk_usage_mb is not None

--- a/tests/test_resource_metrics_store.py
+++ b/tests/test_resource_metrics_store.py
@@ -7,12 +7,16 @@ from pathlib import Path
 
 import pytest
 
+from typing import Any
+
 from backend.optimization.metrics import ResourceMetric
 from backend.optimization.storage import MetricsStore
 
 
 @pytest.mark.parametrize("use_postgres", [False, True])
-def test_add_and_get_metrics(use_postgres: bool, tmp_path: Path, postgresql) -> None:
+def test_add_and_get_metrics(
+    use_postgres: bool, tmp_path: Path, postgresql: Any
+) -> None:
     """Ensure metrics are persisted and fetched using different backends."""
     if not use_postgres:
         db_path = tmp_path / "metrics.db"
@@ -24,13 +28,13 @@ def test_add_and_get_metrics(use_postgres: bool, tmp_path: Path, postgresql) -> 
         store = MetricsStore(postgresql.info.dsn)
 
     metric = ResourceMetric(
-        timestamp=datetime.utcnow().replace(tzinfo=UTC),
+        timestamp=datetime.now(UTC),
         cpu_percent=1.0,
         memory_mb=2.0,
         disk_usage_mb=3.0,
     )
     store.add_metric(metric)
-    metrics = store.get_metrics()
+    metrics = list(store.get_metrics())
     assert len(metrics) == 1
     assert metrics[0].cpu_percent == 1.0
     assert metrics[0].memory_mb == 2.0


### PR DESCRIPTION
## Summary
- enable paginated iteration in `get_metrics`
- adapt `MetricsAnalyzer` and API to use the iterator
- update tests for iterator behaviour
- add regression test checking memory usage

## Testing
- `flake8 backend/optimization/storage.py backend/optimization/metrics.py backend/optimization/api.py tests/test_metrics_ingestion.py tests/test_resource_metrics_store.py backend/optimization/tests/test_metrics_store.py tests/integration/test_pipeline_metrics.py tests/integration/test_full_flow.py backend/optimization/tests/test_metrics_memory.py`
- `pydocstyle backend/optimization/storage.py`
- `docformatter -i backend/optimization/metrics.py backend/optimization/api.py tests/test_metrics_ingestion.py tests/test_resource_metrics_store.py backend/optimization/tests/test_metrics_store.py tests/integration/test_pipeline_metrics.py tests/integration/test_full_flow.py backend/optimization/tests/test_metrics_memory.py`
- `black backend/optimization/storage.py backend/optimization/metrics.py backend/optimization/api.py tests/test_metrics_ingestion.py tests/test_resource_metrics_store.py backend/optimization/tests/test_metrics_store.py tests/integration/test_pipeline_metrics.py tests/integration/test_full_flow.py backend/optimization/tests/test_metrics_memory.py -q`
- `mypy --follow-imports=skip backend/optimization/storage.py backend/optimization/metrics.py backend/optimization/api.py tests/test_metrics_ingestion.py tests/test_resource_metrics_store.py backend/optimization/tests/test_metrics_store.py tests/integration/test_pipeline_metrics.py tests/integration/test_full_flow.py backend/optimization/tests/test_metrics_memory.py`
- `pytest backend/optimization/tests/test_metrics_store.py backend/optimization/tests/test_metrics_memory.py -q` *(fails: coverage threshold not reached)*

------
https://chatgpt.com/codex/tasks/task_b_6880d63658d4833196fe1d6016322948