### PR TITLE
Improve scoring engine embed insertion

### DIFF
--- a/backend/scoring-engine/scoring_engine/tasks.py
+++ b/backend/scoring-engine/scoring_engine/tasks.py
@@ -35,6 +35,7 @@ def batch_embed(self: Task, signals: list[Mapping[str, object]]) -> int:
 
     with tracer.start_as_current_span("batch_embed"):
         with session_scope() as session:
+            objects: list[Embedding] = []
             for msg in signals:
                 embedding = msg.get("embedding")
                 if embedding is None:
@@ -47,6 +48,7 @@ def batch_embed(self: Task, signals: list[Mapping[str, object]]) -> int:
                 else:
                     embedding_value = list(cast(list[float], embedding))
                 source = str(msg.get("source", "global"))
-                session.add(Embedding(source=source, embedding=embedding_value))
+                objects.append(Embedding(source=source, embedding=embedding_value))
+            session.bulk_save_objects(objects)
             session.flush()
         return len(signals)

--- a/backend/scoring-engine/tests/test_tasks.py
+++ b/backend/scoring-engine/tests/test_tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from scoring_engine.tasks import batch_embed
 from backend.shared.db import session_scope
@@ -22,3 +23,22 @@ def test_batch_embed_persists_embeddings(monkeypatch) -> None:
         assert row is not None
         assert row.source == "s"
         assert row.embedding[0] == 1.0
+
+
+def test_batch_embed_bulk_insertion(monkeypatch) -> None:
+    """Embeddings are inserted using ``bulk_save_objects``."""
+
+    monkeypatch.setattr(
+        "signal_ingestion.embedding.generate_embedding", lambda *_: [0.0, 0.0]
+    )
+    captured: dict[str, list[Embedding] | None] = {"objs": None}
+
+    def fake_bulk(self: Session, objs: list[Embedding], **_: object) -> None:
+        captured["objs"] = list(objs)
+
+    monkeypatch.setattr(Session, "bulk_save_objects", fake_bulk)
+    signals = [{"id": i} for i in range(5)]
+    batch_embed(signals)
+    assert captured["objs"] is not None
+    assert len(captured["objs"] or []) == 5
+    assert isinstance((captured["objs"] or [])[0], Embedding)

--- a/backend/shared/currency.py
+++ b/backend/shared/currency.py
@@ -28,7 +28,11 @@ scheduler = BackgroundScheduler()
 
 def _fetch_rates(base: str = BASE_CURRENCY) -> Dict[str, float]:
     """Fetch latest exchange rates from external API."""
-    response = requests.get(EXCHANGE_API_URL, params={"base": base}, timeout=10)
+    response = requests.get(
+        str(EXCHANGE_API_URL),
+        params={"base": base},
+        timeout=10,
+    )
     response.raise_for_status()
     data = response.json()
     rates = cast(dict[str, float], data.get("rates", {}))

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -186,7 +186,7 @@ def _patch_shared_dependencies() -> None:
         def _db_url(self: _config.Settings) -> str:
             return str(self.pgbouncer_url or self.database_url)
 
-        _config.Settings.effective_database_url = property(_db_url)
+        setattr(_config.Settings, "effective_database_url", property(_db_url))
         _config.settings = _config.Settings()
     except Exception:  # pragma: no cover - best effort
         pass

--- a/tests/performance/test_adapter_performance.py
+++ b/tests/performance/test_adapter_performance.py
@@ -14,7 +14,13 @@ import types
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+import math
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT / "backend" / "signal-ingestion" / "src"))


### PR DESCRIPTION
## Summary
- optimize scoring engine embedding insertion using bulk insert
- silence typing errors in currency exchange API call
- fix mock settings property assignment in generate_openapi
- update performance test imports
- test bulk insertion via session.bulk_save_objects

## Testing
- `flake8`
- `mypy`
- `pydocstyle backend/scoring-engine/scoring_engine/tasks.py`
- `pytest backend/scoring-engine/tests/test_tasks.py -q` *(fails: ModuleNotFoundError: No module named 'tests.test_tasks')*
- `PYTHONPATH=. python scripts/benchmark_metrics_store.py --runs 100`

------
https://chatgpt.com/codex/tasks/task_b_6880f0048c748331a49087b2d0471e79