### PR TITLE
Make Kafka flush optional

### DIFF
--- a/backend/shared/kafka/utils.py
+++ b/backend/shared/kafka/utils.py
@@ -23,10 +23,13 @@ class KafkaProducerWrapper:
         self._registry = registry
 
     def produce(self, topic: str, message: Dict[str, Any]) -> None:
-        """Validate and produce ``message`` to ``topic``."""
+        """Validate and send ``message`` to ``topic`` without flushing."""
         schema = self._registry.fetch(f"{topic}-value")
         validate(message, schema)
         self._producer.send(topic, message)
+
+    def flush(self) -> None:
+        """Flush buffered messages to Kafka."""
         self._producer.flush()
 
 


### PR DESCRIPTION
## Summary
- adjust KafkaProducerWrapper so `produce()` no longer flushes
- add an explicit `flush()` method
- update Kafka unit tests to confirm flushing is optional

## Testing
- `black backend/shared/kafka/utils.py tests/test_kafka_utils.py`
- `flake8 backend/shared/kafka/utils.py tests/test_kafka_utils.py`
- `mypy backend/shared/kafka/utils.py tests/test_kafka_utils.py`
- `docformatter -i backend/shared/kafka/utils.py tests/test_kafka_utils.py`
- `pytest -c /tmp/pytest.ini tests/test_kafka_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6880efff48d483318b9eb7826901d047