### PR TITLE
Add analytics service routes

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -313,3 +313,18 @@ async def ready(request: Request) -> Response:
     """Return service readiness."""
     require_status_api_key(request)
     return json_cached({"status": "ready"})
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    import asyncio
+    import uvicorn
+    import uvloop
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+    uvicorn.run(
+        "backend.analytics.api:app",
+        host="0.0.0.0",
+        port=8000,
+        log_level="info",
+    )

--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -559,6 +559,56 @@ async def monitoring_overview() -> Dict[str, Any]:
     return cast(Dict[str, Any], resp.json())
 
 
+@analytics_router.get(
+    "/marketplace_metrics/{listing_id}",
+    summary="Marketplace metrics",
+)
+async def marketplace_metrics(listing_id: int) -> Dict[str, Any]:
+    """Proxy aggregated marketplace metrics."""
+    url = f"{ANALYTICS_URL}/marketplace_metrics/{listing_id}"
+    client = _get_client("analytics")
+    resp = await client.get(url)
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, resp.text)
+    return cast(Dict[str, Any], resp.json())
+
+
+@analytics_router.get(
+    "/marketplace_metrics/{listing_id}/export",
+    summary="Export marketplace metrics",
+)
+async def export_marketplace_metrics(listing_id: int) -> Response:
+    """Stream CSV marketplace metrics for ``listing_id``."""
+    url = f"{ANALYTICS_URL}/marketplace_metrics/{listing_id}/export"
+    client = _get_client("analytics")
+    resp = await client.get(url)
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, resp.text)
+    return Response(
+        content=resp.content,
+        media_type=resp.headers.get("content-type", "text/csv"),
+        headers={"Content-Disposition": resp.headers.get("content-disposition", "")},
+    )
+
+
+@analytics_router.get(
+    "/performance_metrics/{listing_id}/export",
+    summary="Export performance metrics",
+)
+async def export_performance_metrics(listing_id: int) -> Response:
+    """Stream CSV performance metrics for ``listing_id``."""
+    url = f"{ANALYTICS_URL}/performance_metrics/{listing_id}/export"
+    client = _get_client("analytics")
+    resp = await client.get(url)
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, resp.text)
+    return Response(
+        content=resp.content,
+        media_type=resp.headers.get("content-type", "text/csv"),
+        headers={"Content-Disposition": resp.headers.get("content-disposition", "")},
+    )
+
+
 @monitoring_router.get("/status", summary="Service status")
 async def monitoring_status() -> Dict[str, Any]:
     """Proxy service status from the monitoring service."""
@@ -593,6 +643,24 @@ async def ab_test_results(ab_test_id: int) -> Dict[str, Any]:
     if resp.status_code != 200:
         raise HTTPException(resp.status_code, resp.text)
     return cast(Dict[str, Any], resp.json())
+
+
+@analytics_router.get(
+    "/ab_test_results/{ab_test_id}/export",
+    summary="Export A/B test results",
+)
+async def export_ab_test_results(ab_test_id: int) -> Response:
+    """Stream CSV export for an A/B test."""
+    url = f"{ANALYTICS_URL}/ab_test_results/{ab_test_id}/export"
+    client = _get_client("analytics")
+    resp = await client.get(url)
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, resp.text)
+    return Response(
+        content=resp.content,
+        media_type=resp.headers.get("content-type", "text/csv"),
+        headers={"Content-Disposition": resp.headers.get("content-disposition", "")},
+    )
 
 
 @analytics_router.get("/low_performers", summary="Lowest performing listings")

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,6 +32,10 @@ This guide explains how to run desAInz locally with Docker Compose, deploy it to
 
 5. Secrets can be stored in files under `secrets/` and referenced as Docker secrets. The services read them from `/run/secrets`.
 
+6. The analytics service becomes available on `http://localhost:8006` when using
+   Docker Compose. Aggregated metrics can also be retrieved through the API
+   Gateway at `http://localhost:8000/analytics`.
+
 ## Kubernetes
 
 1. Base manifests live in `infrastructure/k8s`. Apply them to a cluster:

--- a/infrastructure/k8s/base/analytics-deployment.yaml
+++ b/infrastructure/k8s/base/analytics-deployment.yaml
@@ -19,7 +19,7 @@ spec:
           image: example/analytics:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8001
+            - containerPort: 8000
           env:
             - name: LOKI_URL
               value: http://loki:3100

--- a/infrastructure/k8s/base/analytics-service.yaml
+++ b/infrastructure/k8s/base/analytics-service.yaml
@@ -8,4 +8,4 @@ spec:
     app: analytics
   ports:
     - port: 80
-      targetPort: 8001
+      targetPort: 8000


### PR DESCRIPTION
## Summary
- run analytics app via uvicorn
- expose analytics service on port 8000 in k8s
- proxy analytics endpoints through API Gateway
- document analytics service usage

## Testing
- `flake8 backend/analytics/api.py backend/api-gateway/src/api_gateway/routes.py`
- `mypy backend/analytics/api.py --ignore-missing-imports`
- `mypy backend/api-gateway/src/api_gateway/routes.py --ignore-missing-imports --disable-error-code=no-untyped-def`
- `pydocstyle backend/analytics/api.py backend/api-gateway/src/api_gateway/routes.py`
- `docformatter --in-place docs/deployment.md`
- `flake8 backend/analytics/api.py backend/api-gateway/src/api_gateway/routes.py`
- `pydocstyle docs/deployment.md`
- ❌ `pip install -r requirements.txt` (failed: canceled due to heavy download)


------
https://chatgpt.com/codex/tasks/task_b_6880f1171d9483319a93c4549ac1b6f4