### PR TITLE
Document staging QA attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ The `docker-compose.prod.yml` file uses prebuilt images and is intended for use 
 
 Use the following checklist to verify a release candidate in the staging environment:
 
-- [ ] Ingestion workflow completes successfully
-- [ ] Scoring jobs finish and persist results
-- [ ] Mock-up creation produces downloadable previews
-- [ ] Publishing pipeline uploads items and invalidates caches
-- [ ] Dashboard pages load and manual job triggers work
-- [ ] No errors appear in logs
-- [ ] Documentation and tests pass
-- [ ] Stakeholders sign off on the release
+- [ ] Ingestion workflow completes successfully *(blocked by network restrictions on 2025-07-23)*
+- [ ] Scoring jobs finish and persist results *(blocked by network restrictions)*
+- [ ] Mock-up creation produces downloadable previews *(blocked by network restrictions)*
+- [ ] Publishing pipeline uploads items and invalidates caches *(blocked by network restrictions)*
+- [ ] Dashboard pages load and manual job triggers work *(blocked by network restrictions)*
+- [ ] No errors appear in logs *(unable to verify in staging)*
+- [ ] Documentation and tests pass *(lint checks reported issues)*
+- [ ] Stakeholders sign off on the release *(pending)*
 
 ## Implementation Plan
 

--- a/docs/staging_manual_qa.md
+++ b/docs/staging_manual_qa.md
@@ -33,7 +33,7 @@ This document describes the steps for verifying new changes in the staging envir
 3. Confirm charts render and manual job triggers succeed.
 
 ## Results
-Attempted execution on 2024-08-14. Deployment and curl commands were blocked by network restrictions in the Codex environment, so workflows could not be fully validated. Dashboard access was also unavailable. No application issues were observed locally, but staging results remain unverified.
+Attempted execution on 2025-07-23. Deployment and curl commands were blocked by network restrictions in the Codex environment, so workflows could not be fully validated. Dashboard access was also unavailable. No application issues were observed locally, but staging results remain unverified.
 
 ## Reporting
 Record any defects in GitHub issues with logs or screenshots. Include references to the steps above for reproducibility.


### PR DESCRIPTION
## Summary
- document the latest attempt at staging QA in the manual instructions
- record blocked checklist items in the README

## Testing
- `flake8 . --docstring-convention=numpy` *(fails: undefined names)*
- `mypy backend --explicit-package-bases --exclude "tests"` *(fails: found 76 errors)*
- `pydocstyle .` *(fails: D202 violations)*
- `docformatter --check --recursive .` *(fails: files need reformatting)*
- `interrogate backend` *(fails: 80% < 100% required)*
- `pip-audit -r requirements.txt -r requirements-dev.txt` *(fails: py 1.11.0 vulnerability)*
- `npm run lint` *(fails: 225 errors)*
- `npm run lint:css`
- `npm run flow`
- `pytest -n auto -W error -vv` *(fails: ModuleNotFoundError: 'sqlalchemy')*
- `npm test` *(fails: cannot find jest module)*

------
https://chatgpt.com/codex/tasks/task_b_6880f11916988331b3750bd804469c27