### PR TITLE
Make mockup generation async

### DIFF
--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -366,7 +366,7 @@ def generate_single_mockup(
             prompt = build_prompt(context)
             output_path = Path(output_dir) / f"mockup_{index}.png"
             try:
-                gen_result = generator.generate(
+                gen_result = await generator.generate(
                     prompt,
                     str(output_path),
                     num_inference_steps=num_inference_steps,

--- a/backend/mockup-generation/tests/test_generator_comfyui.py
+++ b/backend/mockup-generation/tests/test_generator_comfyui.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Iterator
 
 import pytest
+import asyncio
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))  # noqa: E402
@@ -44,7 +45,9 @@ def test_generate_with_diffusers(
     )
     gen = MockupGenerator()
     gen.pipeline = DummyPipeline()
-    result = gen.generate("test", str(tmp_path / "img.png"), num_inference_steps=1)
+    result = asyncio.run(
+        gen.generate("test", str(tmp_path / "img.png"), num_inference_steps=1)
+    )
     assert Path(result.image_path).exists()
 
 
@@ -66,6 +69,6 @@ def test_generate_with_comfyui(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     )
     monkeypatch.setattr(MockupGenerator, "load", lambda *a, **k: None)
     gen = MockupGenerator()
-    result = gen.generate("prompt", str(tmp_path / "img.png"))
+    result = asyncio.run(gen.generate("prompt", str(tmp_path / "img.png")))
     assert called
     assert Path(result.image_path).exists()

--- a/backend/mockup-generation/tests/test_performance.py
+++ b/backend/mockup-generation/tests/test_performance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import threading
 from pathlib import Path
@@ -17,7 +18,9 @@ def test_generation_speed(tmp_path: Path) -> None:
     """Ensure generation completes within a reasonable timeframe."""
     generator = MockupGenerator()
     start = time.perf_counter()
-    generator.generate("test", str(tmp_path / "img.png"), num_inference_steps=1)
+    asyncio.run(
+        generator.generate("test", str(tmp_path / "img.png"), num_inference_steps=1)
+    )
     duration = time.perf_counter() - start
     assert duration < 30
 
@@ -70,10 +73,8 @@ def test_concurrent_generation_gpu_utilization(tmp_path: Path) -> None:
     with ThreadPoolExecutor(max_workers=3) as executor:
         for prompt, path in zip(prompts, paths):
             executor.submit(
-                generator.generate,
-                prompt,
-                str(path),
-                num_inference_steps=1,
+                asyncio.run,
+                generator.generate(prompt, str(path), num_inference_steps=1),
             )
 
     done.set()

--- a/scripts/benchmark_mockup.py
+++ b/scripts/benchmark_mockup.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import asyncio
 from time import perf_counter
 
 from mockup_generation.generator import MockupGenerator
 
 
-def main(prompt: str, output_dir: Path, steps: int, runs: int) -> float:
+async def main(prompt: str, output_dir: Path, steps: int, runs: int) -> float:
     """Return total duration in seconds for generating ``runs`` mock-ups."""
     generator = MockupGenerator()
     generator.load()
@@ -23,7 +24,7 @@ def main(prompt: str, output_dir: Path, steps: int, runs: int) -> float:
 
     start = perf_counter()
     for i in range(runs):
-        generator.generate(
+        await generator.generate(
             prompt,
             str(output_dir / f"mockup_{i}.png"),
             num_inference_steps=steps,
@@ -45,4 +46,4 @@ if __name__ == "__main__":
     parser.add_argument("--steps", type=int, default=30, help="inference steps")
     parser.add_argument("--runs", type=int, default=1, help="number of mock-ups")
     args = parser.parse_args()
-    main(args.prompt, args.output_dir, args.steps, args.runs)
+    asyncio.run(main(args.prompt, args.output_dir, args.steps, args.runs))

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -55,11 +55,15 @@ def generate_mockups(
     from mockup_generation.generator import MockupGenerator
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    generator = MockupGenerator()
-    result = generator.generate(
-        prompt, str(output_dir / "mockup.png"), num_inference_steps=steps
-    )
-    typer.echo(str(result.image_path))
+
+    async def _run() -> None:
+        generator = MockupGenerator()
+        result = await generator.generate(
+            prompt, str(output_dir / "mockup.png"), num_inference_steps=steps
+        )
+        typer.echo(str(result.image_path))
+
+    asyncio.run(_run())
 
 
 @app.command()

--- a/tests/integration/test_pipeline_metrics.py
+++ b/tests/integration/test_pipeline_metrics.py
@@ -33,6 +33,7 @@ kafka_schema.SchemaRegistryClient.fetch = MagicMock(return_value={})  # type: ig
 
 import psutil  # noqa: E402
 import time  # noqa: E402
+import asyncio
 from datetime import UTC, datetime  # noqa: E402
 
 import pytest  # noqa: E402
@@ -158,7 +159,9 @@ async def test_pipeline_with_metrics(
 
     generator = MockupGenerator()
     start = time.perf_counter()
-    result = generator.generate("cat", str(tmp_path / "img.png"), num_inference_steps=1)
+    result = asyncio.run(
+        generator.generate("cat", str(tmp_path / "img.png"), num_inference_steps=1)
+    )
     gen_time = time.perf_counter() - start
     assert Path(result.image_path).exists()
     assert gen_time < thresholds["generate"]


### PR DESCRIPTION
## Summary
- convert `MockupGenerator.generate` to async
- await `MockupGenerator.generate` in Celery task
- update CLI helper scripts for async API
- adjust tests to use asyncio

## Testing
- `flake8 backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/tasks.py scripts/cli.py scripts/benchmark_mockup.py backend/mockup-generation/tests/test_performance.py backend/mockup-generation/tests/test_generator_comfyui.py tests/integration/test_pipeline_metrics.py`
- `mypy backend/mockup-generation/mockup_generation/generator.py` *(fails: Library stubs not installed for "requests")*
- `pytest backend/mockup-generation/tests -vv -W error` *(fails: ImportError: cannot import name 'list_generated_mockups')*

------
https://chatgpt.com/codex/tasks/task_b_6880f00274cc8331a5831f61821f7dbf