### PR TITLE
Cache httpx clients per event loop

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -53,4 +53,5 @@ All services make outbound requests using ``httpx``. The recommended timeout
 for these calls is 10 seconds and is exposed as
 ``backend.shared.http.DEFAULT_TIMEOUT``. Use
 ``backend.shared.http.get_async_http_client()`` to obtain a shared
-``httpx.AsyncClient`` instance configured with this timeout.
+``httpx.AsyncClient`` instance cached for the running event loop and
+configured with this timeout.


### PR DESCRIPTION
## Summary
- cache async http clients per running loop
- close all cached clients on exit
- document per-loop caching in architecture docs
- test that clients are loop-specific and properly closed

## Testing
- `flake8 backend/shared/http.py backend/shared/tests/test_http.py`
- `pydocstyle backend/shared/http.py backend/shared/tests/test_http.py`
- `mypy backend/shared/http.py --ignore-missing-imports --follow-imports=skip`
- `pytest -o addopts='' -p no:unraisableexception backend/shared/tests/test_http.py::test_cached_client_same_loop backend/shared/tests/test_http.py::test_clients_unique_per_loop -vv -s`

------
https://chatgpt.com/codex/tasks/task_b_6880f005c4b48331a987391f6e0f55ec