### PR TITLE
Add optimization hints and monitoring endpoints

### DIFF
--- a/backend/monitoring/tests/test_api_routes.py
+++ b/backend/monitoring/tests/test_api_routes.py
@@ -1,0 +1,44 @@
+"""API endpoint tests for the monitoring service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import sys
+
+import importlib
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import os
+import prometheus_client
+from prometheus_client import CollectorRegistry
+
+os.environ.setdefault("METRICS_DB_URL", "sqlite:///:memory:")
+prometheus_client.REGISTRY = CollectorRegistry()
+import monitoring.main as main_module
+
+
+def _get_client(monkeypatch: Any, **env: str) -> TestClient:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    importlib.reload(main_module)
+    return TestClient(main_module.app)
+
+
+def test_basic_endpoints(monkeypatch: Any, tmp_path: Path) -> None:
+    """Ensure latency and queue endpoints respond."""
+    log_file = tmp_path / "app.log"
+    log_file.write_text("", encoding="utf-8")
+    client = _get_client(
+        monkeypatch,
+        DAILY_SUMMARY_FILE=str(tmp_path / "summary.json"),
+        LOG_FILE=str(log_file),
+        METRICS_DB_URL="sqlite:///:memory:",
+    )
+
+    resp = client.get("/latency")
+    assert resp.status_code == 200
+
+    resp = client.get("/queue_length")
+    assert resp.status_code == 200

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -195,6 +195,13 @@ def get_recommendations() -> List[str]:
     return analyzer.top_recommendations()
 
 
+@app.get("/hints")
+def get_hints() -> List[str]:
+    """Return optimization hints based on recent metrics."""
+    analyzer = MetricsAnalyzer(list(store.get_metrics()))
+    return analyzer.top_recommendations()
+
+
 @app.get("/cost_alerts")
 def get_cost_alerts() -> List[str]:
     """Return alerts when usage or cost thresholds are exceeded."""

--- a/backend/optimization/tests/test_api_routes.py
+++ b/backend/optimization/tests/test_api_routes.py
@@ -40,3 +40,7 @@ def test_recommendation_routes(tmp_path: Path) -> None:
     resp = client.get("/cost_alerts")
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
+
+    resp = client.get("/hints")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,8 @@ services:
       - "8001:8000"
     environment:
       LOKI_URL: http://loki:3100
+      OPTIMIZATION_URL: http://optimization:5007
+      MONITORING_URL: http://monitoring:8000
     depends_on:
       - kafka
       - redis
@@ -282,6 +284,22 @@ services:
       - "prometheus.scrape=true"
       - "prometheus.path=/metrics"
       - "prometheus.port=8000"
+
+  optimization:
+    build: ./backend/optimization
+    mem_limit: 512m
+    cpus: 0.50
+    command: python -m backend.optimization.api
+    ports:
+      - "5007:5007"
+    environment:
+      LOKI_URL: http://loki:3100
+    depends_on:
+      - postgres
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.path=/metrics"
+      - "prometheus.port=5007"
 
   admin-dashboard:
     build: ./frontend/admin-dashboard


### PR DESCRIPTION
## Summary
- fetch optimization hints in orchestrator cleanup
- proxy optimization hints and monitoring metrics via API gateway
- run optimization and monitoring containers
- cover hint API call in optimization tests
- add minimal monitoring API test

## Testing
- `flake8 backend/orchestrator/orchestrator/ops.py backend/api-gateway/src/api_gateway/routes.py backend/optimization/api.py backend/optimization/tests/test_api_routes.py backend/monitoring/tests/test_api_routes.py`
- `mypy --ignore-missing-imports backend/orchestrator/orchestrator/ops.py backend/api-gateway/src/api_gateway/routes.py backend/optimization/api.py` *(failed: Interrupted)*
- `pytest backend/optimization/tests/test_api_routes.py backend/monitoring/tests/test_api_routes.py -q -W error` *(failed: ValueError: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_b_6880f1158b8c83318b03e5f3c6d616cb