### PR TITLE
Implement async ComfyUI workflow

### DIFF
--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -114,7 +114,7 @@ class MockupGenerator:
 
             workflow = {"prompt": prompt, "output": str(temp_path)}
             runner = ComfyUIWorkflow(settings.comfyui_url)
-            res = runner.execute(workflow, str(temp_path))
+            res = await runner.execute(workflow, str(temp_path))
             Path(temp_path).replace(output_file)
             return GenerationResult(image_path=str(output_file), duration=res.duration)
 

--- a/backend/mockup-generation/tests/test_generator_comfyui.py
+++ b/backend/mockup-generation/tests/test_generator_comfyui.py
@@ -56,7 +56,7 @@ def test_generate_with_comfyui(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     settings.use_comfyui = True
     called: list[dict[str, str]] = []
 
-    def fake_execute(
+    async def fake_execute(
         self: object, workflow: dict[str, str], output: str
     ) -> SimpleNamespace:
         Path(output).write_text("x")


### PR DESCRIPTION
## Summary
- use `httpx.AsyncClient` in `ComfyUIWorkflow`
- make `ComfyUIWorkflow.execute` asynchronous
- await `ComfyUIWorkflow.execute` in `MockupGenerator`
- update tests for async execution

## Testing
- `mypy backend/mockup-generation/mockup_generation/comfy_workflow.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator_comfyui.py`
- `flake8 backend/mockup-generation/mockup_generation/comfy_workflow.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator_comfyui.py`
- `pydocstyle backend/mockup-generation/mockup_generation/comfy_workflow.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/tests/test_generator_comfyui.py`
- `SKIP_HEAVY_DEPS=1 pytest backend/mockup-generation/tests/test_generator_comfyui.py::test_generate_with_comfyui -q -W error --cov=. --cov-report=term --cov-report=xml --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_b_6880f664a8d08331b1cfc1aa08cc24b7