### PR TITLE
Optimize trending factor retrieval with redis pipeline

### DIFF
--- a/backend/scoring-engine/tests/test_trending_factor.py
+++ b/backend/scoring-engine/tests/test_trending_factor.py
@@ -1,0 +1,16 @@
+import importlib
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+
+scoring_module = importlib.import_module("scoring_engine.app")
+
+
+@pytest.mark.asyncio
+async def test_trending_factor_pipeline(monkeypatch: Any) -> None:
+    client = fakeredis.aioredis.FakeRedis()
+    await client.zadd("trending:keywords", {"foo": 10.0, "bar": 20.0})
+    monkeypatch.setattr(scoring_module, "redis_client", client)
+    factor = await scoring_module.trending_factor(["foo", "bar", "baz"])
+    assert factor == pytest.approx(1.2)


### PR DESCRIPTION
## Summary
- optimize trending_factor in scoring engine to use a Redis pipeline
- add regression test verifying trending_factor behaviour

## Testing
- `flake8 backend/scoring-engine/scoring_engine backend/scoring-engine/tests/test_trending_factor.py`
- `black --check backend/scoring-engine/scoring_engine backend/scoring-engine/tests/test_trending_factor.py`
- `docformatter --check backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_trending_factor.py`
- `mypy backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/tests/test_trending_factor.py` *(fails: Library stubs not installed for requests, etc)*
- `pytest backend/scoring-engine/tests/test_trending_factor.py::test_trending_factor_pipeline` *(fails to collect due to ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6880f6661ae48331911eb85e47295ccc