### PR TITLE
Document DB pool metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Base Kubernetes manifests are available under `infrastructure/k8s`.
 
 PgBouncer connection pooling is available via the `pgbouncer` service in
 `docker-compose.dev.yml`. Point `DATABASE_URL` at port `6432` to leverage pooling.
+The default SQLAlchemy pool size can be tuned using the `DB_POOL_SIZE`
+environment variable. Observe the `db_pool_size` and `db_pool_in_use` metrics in
+Prometheus to determine whether the pool is frequently exhausted and adjust the
+setting accordingly.
 Execute `scripts/analyze_query_plans.py` periodically to inspect query plans and
 identify missing indexes.
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -86,6 +86,14 @@ Prometheus metrics are aggregated in memory. Path segments matching numeric or
 UUID-like patterns are replaced with `:id` before counters are updated. This
 keeps label cardinality low even for dynamic endpoints.
 
+## Connection Pool Metrics
+
+Each service exposes the size of its SQLAlchemy connection pool and the number
+of in-use connections via the `db_pool_size` and `db_pool_in_use` gauges. Query
+these metrics from Prometheus to visualize database load over time. When
+`db_pool_in_use` routinely nears `db_pool_size`, increase the `DB_POOL_SIZE`
+environment variable so additional connections can be allocated.
+
 ## PagerDuty Alerts
 
 Set `PAGERDUTY_ROUTING_KEY` and `ENABLE_PAGERDUTY=true` in the environment to enable alerting. The monitoring service triggers alerts when the average publish latency breaches the configured SLA and when listing synchronization detects issues. Rejections during publishing emit a `notify_listing_issue` event with a `nsfw` or `trademarked` state.


### PR DESCRIPTION
## Summary
- document how to monitor database pool gauges via Prometheus
- mention tuning `DB_POOL_SIZE` in the README

## Testing
- `bash scripts/setup_codex.sh` *(fails: build finished with problems)*
- `flake8 backend/shared/db/__init__.py`
- `pytest -k 'nothing' -vv` *(fails: multiple import errors)*

------
https://chatgpt.com/codex/tasks/task_b_6880fa84b310833197cd1073221bb23d