### PR TITLE
Update contributing guide with profiling info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,3 +117,29 @@ to Codecov.
 To view results locally, open
 `frontend/admin-dashboard/coverage/lcov-report/index.html` in your browser and
 use any coverage tool that supports the XML format to inspect `coverage.xml`.
+
+## Profiling Code
+
+Use `scripts/capture_profile.py` to gather CPU statistics for any module. The
+command executes the given module under `cProfile` and writes the data to a file.
+
+```bash
+python scripts/capture_profile.py backend.app.main --output run.prof
+```
+
+To investigate Dagster jobs or operations, profile the orchestrator package:
+
+```bash
+python scripts/capture_profile.py orchestrator.ops --output orchestrator.prof
+```
+
+You can also profile the scoring API using the benchmark script:
+
+```bash
+python scripts/capture_profile.py scripts.benchmark_score --output scoring.prof
+```
+
+Visualize the resulting profile with tools like `snakeviz` or generate a
+flamegraph via `py-spy`. When your changes noticeably impact performance,
+attach the flamegraph images to the pull request so reviewers can compare
+results.


### PR DESCRIPTION
## Summary
- document how to profile modules with `scripts/capture_profile.py`
- add examples for orchestrator tasks and scoring endpoint profiling
- encourage attaching flamegraphs in PRs

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `npm install --legacy-peer-deps`
- `pytest -n auto -W error -vv` *(failed: AttributeError: 'types.SimpleNamespace' object has no attribute 'empty_cache')*

------
https://chatgpt.com/codex/tasks/task_b_6880fa85cf5c8331addc7e97f27addaa