### PR TITLE
Add async HTTP cleanup

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -23,6 +23,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from prometheus_client import Counter, Histogram
 
 from .routes import router, close_http_clients
+from backend.shared.http import close_async_clients
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
@@ -193,4 +194,10 @@ async def ready(request: Request) -> Response:
 
 
 app.include_router(router)
-app.add_event_handler("shutdown", close_http_clients)
+
+
+@app.on_event("shutdown")  # type: ignore[misc]
+async def shutdown_event() -> None:
+    """Release HTTP resources on application shutdown."""
+    await close_http_clients()
+    await close_async_clients()

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -29,6 +29,7 @@ from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
+from backend.shared.http import close_async_clients
 from backend.shared.responses import json_cached
 from backend.shared.logging import configure_logging
 from backend.shared import ServiceName, add_error_handlers, configure_sentry
@@ -146,10 +147,11 @@ def start_scheduler() -> None:
 
 
 @app.on_event("shutdown")
-def shutdown_scheduler() -> None:
+async def shutdown_scheduler() -> None:
     """Shutdown the aggregate scheduler."""
     if scheduler.running:
         scheduler.shutdown()
+    await close_async_clients()
 
 
 class MetricIn(BaseModel):

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -19,6 +19,7 @@ from backend.shared.security import require_status_api_key
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from backend.shared.cache import AsyncRedis, get_async_client
+from backend.shared.http import close_async_clients
 from sqlalchemy import select
 import numpy as np
 from prometheus_client import (
@@ -208,6 +209,7 @@ async def stop_consumer() -> None:
         _consumer_thread.join(timeout=5)
     if _consumer is not None:
         _consumer.close()
+    await close_async_clients()
 
 
 async def trending_factor(topics: list[str]) -> float:

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -18,6 +18,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
+from backend.shared.http import close_async_clients
 from backend.shared.currency import start_rate_updater
 
 from backend.shared.db import run_migrations_if_needed
@@ -102,6 +103,12 @@ async def ready(request: Request) -> Response:
     """Return service readiness."""
     require_status_api_key(request)
     return json_cached({"status": "ready"})
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    """Release HTTP clients on application shutdown."""
+    await close_async_clients()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/shared/tests/test_http.py
+++ b/backend/shared/tests/test_http.py
@@ -60,7 +60,7 @@ async def test_cached_client_same_loop() -> None:
     client1 = await get_async_http_client()
     client2 = await get_async_http_client()
     assert client1 is client2
-    await asyncio.to_thread(http_module._close_async_client)
+    await http_module.close_async_clients()
 
 
 def test_clients_unique_per_loop() -> None:
@@ -72,7 +72,7 @@ def test_clients_unique_per_loop() -> None:
     loop2 = asyncio.new_event_loop()
     asyncio.set_event_loop(loop2)
     client2 = loop2.run_until_complete(get_async_http_client())
-    http_module._close_async_client()
+    loop2.run_until_complete(http_module.close_async_clients())
     loop1.run_until_complete(loop1.shutdown_asyncgens())
     loop2.run_until_complete(loop2.shutdown_asyncgens())
     loop1.close()

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -27,6 +27,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
+from backend.shared.http import close_async_clients
 
 from backend.shared import add_error_handlers, configure_sentry
 
@@ -76,6 +77,7 @@ async def startup() -> None:
 async def shutdown() -> None:
     """Stop background tasks."""
     scheduler.shutdown()
+    await close_async_clients()
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- add async close_async_clients helper
- use cleanup hook in various FastAPI apps
- update HTTP helper tests

## Testing
- `mypy --config-file mypy.ini`
- `pydocstyle backend/shared/http.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/main.py backend/shared/tests/test_http.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `flake8 backend/shared/http.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/main.py backend/shared/tests/test_http.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `black backend/shared/http.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/main.py backend/shared/tests/test_http.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `SKIP_HEAVY_DEPS=1 pytest -n auto -W error -vv` *(failed: RuntimeError: There is no current event loop in thread 'MainThread')*

------
https://chatgpt.com/codex/tasks/task_b_6880fa7fa7a08331978fc43c5a6c6969