### PR TITLE
Implement async cleanup handlers

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -23,6 +23,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from prometheus_client import Counter, Histogram
 
 from .routes import router, close_http_clients
+from backend.shared.http import close_async_clients
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
@@ -194,3 +195,9 @@ async def ready(request: Request) -> Response:
 
 app.include_router(router)
 app.add_event_handler("shutdown", close_http_clients)
+
+
+@app.on_event("shutdown")
+async def shutdown_async_clients() -> None:
+    """Release shared async HTTP clients."""
+    await close_async_clients()

--- a/backend/feedback-loop/feedback_loop/main.py
+++ b/backend/feedback-loop/feedback_loop/main.py
@@ -15,6 +15,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
+from backend.shared.http import close_async_clients
 from backend.shared.tracing import configure_tracing
 from pydantic import BaseModel
 
@@ -92,6 +93,7 @@ async def shutdown() -> None:
     """Stop the background scheduler."""
     if scheduler:
         scheduler.shutdown()
+    await close_async_clients()
 
 
 app.add_event_handler("startup", startup)

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -29,6 +29,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared.responses import json_cached
 from backend.shared.security import add_security_headers
 from backend.shared.tracing import configure_tracing
+from backend.shared.http import close_async_clients
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Response
 from backend.shared.security import require_status_api_key
@@ -391,6 +392,12 @@ async def ready(request: Request) -> Response:
     """Return service readiness."""
     require_status_api_key(request)
     return json_cached({"status": "ready"})
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    """Release shared async resources."""
+    await close_async_clients()
 
 
 @app.get("/oauth/{marketplace}")

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -50,6 +50,7 @@ from .metrics_store import (
 
 from backend.shared.cache import sync_get, sync_set
 import redis
+from backend.shared.http import close_async_clients
 
 LAST_ALERT_KEY = "sla:last_alert"
 QUEUE_ALERT_KEY = "queue:last_alert"
@@ -325,6 +326,13 @@ async def ready(request: Request) -> Response:
     """Return service readiness."""
     require_status_api_key(request)
     return json_cached({"status": "ready"})
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    """Release async resources on shutdown."""
+    await close_async_clients()
+    metrics_store.close()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -25,6 +25,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from backend.shared.http import close_async_clients
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
@@ -146,10 +147,12 @@ def start_scheduler() -> None:
 
 
 @app.on_event("shutdown")
-def shutdown_scheduler() -> None:
-    """Shutdown the aggregate scheduler."""
+async def shutdown_scheduler() -> None:
+    """Shutdown scheduler and release resources."""
     if scheduler.running:
         scheduler.shutdown()
+    store.close()
+    await close_async_clients()
 
 
 class MetricIn(BaseModel):

--- a/backend/optimization/storage.py
+++ b/backend/optimization/storage.py
@@ -26,6 +26,7 @@ class MetricsStore:
             or f"sqlite:///{os.path.abspath('metrics.db')}"
         )
         parsed = urlparse(self.db_url)
+        self._closed = False
         self._use_sqlite = str(parsed.scheme).startswith("sqlite")
         if self._use_sqlite:
             self.db_path = parsed.path
@@ -244,9 +245,12 @@ class MetricsStore:
             if hasattr(self, "_sqlite_conn"):
                 self._sqlite_conn.commit()
                 self._sqlite_conn.close()
+                self._sqlite_conn = None  # type: ignore[assignment]
         else:
             if hasattr(self, "_pool"):
                 self._pool.closeall()
+                self._pool = None  # type: ignore[assignment]
+        self._closed = True
 
     def __del__(self) -> None:
         """Automatically close connections when destroyed."""

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -32,6 +32,7 @@ from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
+from backend.shared.http import close_async_clients
 
 from backend.shared.config import settings
 from backend.shared.tracing import configure_tracing
@@ -208,6 +209,8 @@ async def stop_consumer() -> None:
         _consumer_thread.join(timeout=5)
     if _consumer is not None:
         _consumer.close()
+    metrics_store.close()
+    await close_async_clients()
 
 
 async def trending_factor(topics: list[str]) -> float:

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -19,6 +19,7 @@ from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
 from backend.shared.currency import start_rate_updater
+from backend.shared.http import close_async_clients
 
 from backend.shared.db import run_migrations_if_needed
 
@@ -102,6 +103,12 @@ async def ready(request: Request) -> Response:
     """Return service readiness."""
     require_status_api_key(request)
     return json_cached({"status": "ready"})
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    """Release async resources."""
+    await close_async_clients()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/shared/http.py
+++ b/backend/shared/http.py
@@ -81,9 +81,17 @@ async def get_async_http_client(
     return client
 
 
+async def close_async_clients() -> None:
+    """Close all cached ``AsyncClient`` instances."""
+    for client in list(_ASYNC_CLIENTS.values()):
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+    _ASYNC_CLIENTS.clear()
+
+
 @atexit.register
 def _close_async_client() -> None:
     """Close all cached ``AsyncClient`` instances."""
-    for client in list(_ASYNC_CLIENTS.values()):
-        asyncio.run(client.aclose())
-    _ASYNC_CLIENTS.clear()
+    asyncio.run(close_async_clients())

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -27,6 +27,7 @@ from backend.shared.profiling import add_profiling
 from backend.shared.metrics import register_metrics
 from backend.shared.security import add_security_headers
 from backend.shared.responses import json_cached
+from backend.shared.http import close_async_clients
 
 from backend.shared import add_error_handlers, configure_sentry
 
@@ -76,6 +77,7 @@ async def startup() -> None:
 async def shutdown() -> None:
     """Stop background tasks."""
     scheduler.shutdown()
+    await close_async_clients()
 
 
 @app.middleware("http")

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,20 @@
+"""Integration tests for application shutdown behavior."""
+
+import asyncio
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+from fastapi.testclient import TestClient
+
+from backend.optimization.api import app, store
+from backend.shared import http as http_module
+
+
+def test_optimization_service_shutdown() -> None:
+    """Start the service and ensure resources are cleaned up on shutdown."""
+    with TestClient(app) as client:
+        asyncio.run(http_module.get_async_http_client())
+        resp = client.get("/health")
+        assert resp.status_code == 200
+    assert store._closed
+    assert http_module._ASYNC_CLIENTS == {}


### PR DESCRIPTION
## Summary
- add `close_async_clients` helper and clean up HTTP clients
- close metrics and optimization stores on shutdown
- hook shutdown handlers into all services
- test that service shutdown clears resources

## Testing
- `flake8 backend/shared/http.py backend/monitoring/src/monitoring/metrics_store.py backend/optimization/storage.py backend/monitoring/src/monitoring/main.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/signal-ingestion/src/signal_ingestion/main.py backend/feedback-loop/feedback_loop/main.py backend/service-template/src/main.py backend/scoring-engine/scoring_engine/app.py backend/optimization/api.py tests/test_shutdown.py`
- `mypy > /tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest tests/test_shutdown.py --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_b_6880fa838d3c8331942387003faf5ce1