### PR TITLE
Implement bulk insert with single commit

### DIFF
--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -28,7 +28,6 @@ def ingest_metrics(
     metrics: Iterable[Mapping[str, float | datetime]],
 ) -> list[dict[str, float | datetime]]:
     """Persist incoming metrics and return them with added timestamps."""
-
     metrics_list = [dict(m) for m in metrics]
     now = datetime.utcnow().replace(tzinfo=UTC)
     for entry in metrics_list:
@@ -78,7 +77,7 @@ def store_marketplace_metrics(metrics: Iterable[Mapping[str, float]]) -> None:
     if not rows:
         return
     with session_scope() as session:
-        session.add_all(rows)
+        session.bulk_save_objects(rows)
         logger.info("stored %s marketplace metrics", len(rows))
 
 


### PR DESCRIPTION
## Summary
- insert batched signals with `bulk_save_objects` and single commit
- bulk insert for marketplace metrics
- adjust performance test for new commit behavior and patch queue metrics

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/tasks.py backend/feedback-loop/feedback_loop/ingestion.py tests/performance/test_adapter_performance.py`
- `pydocstyle backend/signal-ingestion/src/signal_ingestion/tasks.py backend/feedback-loop/feedback_loop/ingestion.py tests/performance/test_adapter_performance.py`
- `docformatter --check tests/performance/test_adapter_performance.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/tasks.py backend/feedback-loop/feedback_loop/ingestion.py tests/performance/test_adapter_performance.py --ignore-missing-imports --follow-imports=skip --disable-error-code=arg-type --disable-error-code=import-untyped`
- `pytest tests/performance/test_adapter_performance.py::test_ingest_large_volume -vv -s -W error` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'exists')*


------
https://chatgpt.com/codex/tasks/task_b_68810abb4e7c8331bc9369c190594c31